### PR TITLE
The pipe name massacre

### DIFF
--- a/pipeline/pipe/db/interface.py
+++ b/pipeline/pipe/db/interface.py
@@ -11,15 +11,15 @@ if TYPE_CHECKING:
 from pipe.struct.db import (
     Asset,
     AssetStub,
-    User,
     Environment,
     EnvironmentStub,
-    SGEntity,
-    SGEntityStub,
     Sequence,
     SequenceStub,
+    SGEntity,
+    SGEntityStub,
     Shot,
     ShotStub,
+    User,
 )
 
 
@@ -119,8 +119,13 @@ class DBInterface(metaclass=ABCMeta):
         raise NotImplementedError
 
     @abstractmethod
-    def get_asset_by_name(self, attr_val: str | int) -> Asset:
-        """Get an asset by its name"""
+    def get_asset_by_name(self, name: str) -> Asset:
+        """Get an asset by its normalized name (asset.name)"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_asset_by_display_name(self, display_name: str) -> Asset:
+        """Get an asset by its ShotGrid display name (asset.display_name / code)"""
         raise NotImplementedError
 
     @abstractmethod
@@ -153,17 +158,36 @@ class DBInterface(metaclass=ABCMeta):
     def get_asset_name_list(
         self, child_mode: DBInterface.ChildQueryMode, sorted: bool
     ) -> list[str]:
-        """Get a list of asset names"""
+        """Get a list of normalized asset names (asset.name)"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_asset_display_name_list(
+        self, child_mode: DBInterface.ChildQueryMode, sorted: bool
+    ) -> list[str]:
+        """Get a list of asset display names (asset.display_name / code)"""
         raise NotImplementedError
 
     @abstractmethod
     def get_assets_by_name(self, names: typing.Iterable[str]) -> list[Asset]:
-        """Get a list of assets from a list of names"""
+        """Get a list of assets from a list of normalized names (asset.name)"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_assets_by_display_name(self, names: typing.Iterable[str]) -> list[Asset]:
+        """Get a list of assets from a list of display names (asset.display_name / code)"""
         raise NotImplementedError
 
     @abstractmethod
     def get_asset_name_list_by_type(self, types: list[str], sorted: bool) -> list[str]:
-        """Get a list of asset names given asset types"""
+        """Get a list of normalized asset names given asset types (asset.name)"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_asset_display_name_list_by_type(
+        self, types: list[str], sorted: bool
+    ) -> list[str]:
+        """Get a list of asset display names (asset.display_name / code) given asset types"""
         raise NotImplementedError
 
     @abstractmethod

--- a/pipeline/pipe/db/sgaadb.py
+++ b/pipeline/pipe/db/sgaadb.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import logging
-import threading
 import os
-
+import threading
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from functools import partialmethod as pm
@@ -17,22 +16,23 @@ from pipe.struct.db import (
     SGEntityStub,
     Shot,
     ShotStub,
-    Version,
-    User,
     Task,
+    User,
+    Version,
+    normalize_display_name,
 )
 
 if TYPE_CHECKING:
     import typing
     from typing import Any, Callable, Iterable, Optional
-    from typing_extensions import Unpack
-    from .typing import AttrMappingKwargs, Filter
-    from .typing import *  # noqa: F403
 
-from .interface import DBInterface
+    from typing_extensions import Unpack
+
+    from .typing import *  # noqa: F403
+    from .typing import AttrMappingKwargs, Filter
 
 from . import shotgun_api3
-
+from .interface import DBInterface
 
 log = logging.getLogger(__name__)
 
@@ -250,13 +250,51 @@ class SGaaDB(DBInterface):
 
     get_asset_attr_list: T_GetAssetAttrList = pm(get_entity_attr_list, Asset)  # type: ignore[assignment] # noqa: F405
     get_asset_by_attr: T_GetAssetByAttr = pm(get_entity_by_attr, Asset)  # type: ignore[assignment] # noqa: F405
-    get_asset_by_name: T_GetAssetByName = pm(get_asset_by_attr, "code")  # type: ignore[assignment] # noqa: F405
+    get_asset_by_display_name: T_GetAssetByDisplayName = pm(get_asset_by_attr, "code")  # type: ignore[assignment] # noqa: F405
     get_asset_by_id: T_GetAssetById = pm(get_asset_by_attr, "id")  # type: ignore[assignment] # noqa: F405
     get_asset_by_stub: T_GetAssetByStub = pm(get_entity_by_stub, Asset)  # type: ignore[assignment] # noqa: F405
-    get_asset_name_list: T_GetCodeList = pm(get_asset_attr_list, "code")  # type: ignore[assignment] # noqa: F405
+    get_asset_display_name_list: T_GetAssetDisplayNameList = pm(
+        get_asset_attr_list, "code"
+    )  # type: ignore[assignment] # noqa: F405
     get_assets_by_stub: T_GetAssetsByStub = pm(get_entities_by_stub, Asset)  # type: ignore[assignment] # noqa: F405
 
+    def get_asset_by_name(self, name: str) -> Asset:
+        target = normalize_display_name(name)
+        return Asset.from_sg(
+            next(
+                asset
+                for asset in self._sg_entity_lists[Asset.__name__]
+                if normalize_display_name(asset.get("code")) == target
+            )
+        )
+
+    def get_asset_name_list(
+        self,
+        child_mode: DBInterface.ChildQueryMode = DBInterface.ChildQueryMode.LEAVES,
+        sorted: bool = False,
+    ) -> list[str]:
+        display_names = self.get_asset_display_name_list(
+            child_mode=child_mode, sorted=False
+        )
+        names = [normalize_display_name(display_name) for display_name in display_names]
+        if sorted:
+            names.sort()
+        return names
+
     def get_assets_by_name(self, names: Iterable[str]) -> list[Asset]:
+        targets = {normalize_display_name(name) for name in names}
+        return [
+            Asset.from_sg(i)
+            for i in set(
+                [
+                    a
+                    for a in self._sg_entity_lists[Asset.__name__]
+                    if normalize_display_name(a.get("code")) in targets
+                ]
+            )
+        ]
+
+    def get_assets_by_display_name(self, names: Iterable[str]) -> list[Asset]:
         return [
             Asset.from_sg(i)
             for i in set(
@@ -342,7 +380,7 @@ class SGaaDB(DBInterface):
         print(raw_tasks)
         return [Task.from_sg(task) for task in raw_tasks]
 
-    def get_asset_name_list_by_type(
+    def get_asset_display_name_list_by_type(
         self, types: list[str], sorted: bool = False
     ) -> list[str]:
         mapper = self._entity_attr_custom_mappers.get(
@@ -359,6 +397,15 @@ class SGaaDB(DBInterface):
         if sorted:
             arr.sort()
         return arr
+
+    def get_asset_name_list_by_type(
+        self, types: list[str], sorted: bool = False
+    ) -> list[str]:
+        display_names = self.get_asset_display_name_list_by_type(types, sorted=False)
+        names = [normalize_display_name(display_name) for display_name in display_names]
+        if sorted:
+            names.sort()
+        return names
 
     get_user_attr_list: T_GetAttrList = pm(get_entity_attr_list, User)  # type: ignore[assignment] # noqa: F405
     get_user_by_attr: T_GetUserByAttr = pm(get_entity_by_attr, User)  # type: ignore[assignment] # noqa: F405
@@ -470,7 +517,6 @@ class _AssetListQuery(_Query):
     def _base_fields(self) -> list[str]:
         return [
             "code",  # display name
-            "sg_pipe_name",  # internal name
             "sg_path",  # asset path
             "id",  # asset id
             "parents",  # parent assets
@@ -538,7 +584,6 @@ class _EnvironmentListQuery(_Query):
     def _base_fields(self) -> list[str]:
         return [
             "code",  # display name
-            "sg_pipe_name",  # internal name
             "sg_path",  # environment path
             "id",  # asset id
             "shots",  # shots environment present in

--- a/pipeline/pipe/db/sgaadb.py
+++ b/pipeline/pipe/db/sgaadb.py
@@ -4,6 +4,7 @@ import logging
 import os
 import threading
 from abc import ABC, abstractmethod
+from collections import defaultdict
 from dataclasses import dataclass
 from functools import partialmethod as pm
 from typing import TYPE_CHECKING, Optional
@@ -107,7 +108,34 @@ class SGaaDB(DBInterface):
         """Load the list of assets from SG to local cache"""
         with self._cache_lock:
             query = _AssetListQuery(self._id)
-            self._sg_entity_lists[Asset.__name__] = query.exec(self._sg)
+            asset_list = query.exec(self._sg)
+            self._sg_entity_lists[Asset.__name__] = asset_list
+            self._log_asset_name_collisions(asset_list)
+
+    @staticmethod
+    def _log_asset_name_collisions(asset_list: list[dict]) -> None:
+        """Log collisions where display names normalize to the same asset.name."""
+        normalized_names: dict[str, list[tuple[Optional[int], Optional[str]]]] = (
+            defaultdict(list)
+        )
+        for asset in asset_list:
+            code = asset.get("code")
+            normalized = normalize_display_name(code)
+            if not normalized:
+                continue
+            normalized_names[normalized].append((asset.get("id"), code))
+
+        for normalized, entries in normalized_names.items():
+            if len(entries) < 2:
+                continue
+            details = ", ".join(
+                f"id={asset_id} code={code!r}" for asset_id, code in entries
+            )
+            log.error(
+                "Asset name collision after normalization: name=%r assets=[%s]",
+                normalized,
+                details,
+            )
 
     def _load_sg_user_list(self) -> None:
         """Load the list of assets from SG to local cache"""

--- a/pipeline/pipe/db/typing.py
+++ b/pipeline/pipe/db/typing.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any, Iterable, Literal, Optional, Protocol, TypedDict, Union
+
 from typing_extensions import NotRequired, Unpack
 
 from pipe.struct.db import (
@@ -76,7 +77,11 @@ class T_GetAssetById(Protocol):
 
 
 class T_GetAssetByName(Protocol):
-    def __call__(self, name: str) -> Asset: ...
+    def __call__(self, normalized_name: str) -> Asset: ...
+
+
+class T_GetAssetByDisplayName(Protocol):
+    def __call__(self, display_name: str) -> Asset: ...
 
 
 class T_GetAssetByStub(Protocol):
@@ -84,6 +89,14 @@ class T_GetAssetByStub(Protocol):
 
 
 class T_GetAssetNameList(Protocol):
+    def __call__(
+        self,
+        child_mode: DBInterface.ChildQueryMode = DBInterface.ChildQueryMode.LEAVES,
+        sorted: bool = False,
+    ) -> list[str]: ...
+
+
+class T_GetAssetDisplayNameList(Protocol):
     def __call__(
         self,
         child_mode: DBInterface.ChildQueryMode = DBInterface.ChildQueryMode.LEAVES,

--- a/pipeline/pipe/h/shading.py
+++ b/pipeline/pipe/h/shading.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 import hou
-import os
+from env_sg import DB_Config
 
 from pipe.db import DB
 from pipe.struct.db import Asset
-
-from env_sg import DB_Config
 
 _MATLIB_NAME = "Material_Library"
 _MATNAME = "matname"
@@ -34,8 +33,7 @@ class MatlibManager:
     def _asset(self) -> Asset:
         """Get asset based off of the path of the current hipfile"""
         asset_name = str(hou.contextOption("ASSET"))
-        a = self._conn.get_asset_by_attr("name", asset_name)
-        return a
+        return self._conn.get_asset_by_name(asset_name)
 
     @property
     def _hip(self) -> Path:

--- a/pipeline/pipe/m/layout/maker.py
+++ b/pipeline/pipe/m/layout/maker.py
@@ -1,18 +1,20 @@
-import maya.cmds as mc
-import mayaUsd.lib as mayaUsdLib  # type: ignore[import-not-found]
-from pxr import UsdGeom, Usd, Kind
-from PySide6 import QtWidgets  # type: ignore[import-not-found]
-import maya.OpenMayaUI as omui
-from shiboken6 import wrapInstance  # type: ignore[import-not-found]
-from env_sg import DB_Config
-from pipe.glui.dialogs import FilteredListDialog
-from pipe.db import DB
-from shared.util import get_production_path
-from pipe.struct.db import Environment
-from .file_manager import HOUDINI_TO_MAYA_SCALE
+import os
 import shutil
 
-import os
+import maya.cmds as mc
+import maya.OpenMayaUI as omui
+import mayaUsd.lib as mayaUsdLib  # type: ignore[import-not-found]
+from env_sg import DB_Config
+from pxr import Kind, Usd, UsdGeom
+from PySide6 import QtWidgets  # type: ignore[import-not-found]
+from shared.util import get_production_path
+from shiboken6 import wrapInstance  # type: ignore[import-not-found]
+
+from pipe.db import DB
+from pipe.glui.dialogs import FilteredListDialog
+from pipe.struct.db import Environment
+
+from .file_manager import HOUDINI_TO_MAYA_SCALE
 
 
 class SelectFromGroup(FilteredListDialog):
@@ -159,20 +161,20 @@ class LayoutMaker:
         selected_layout = layout_dialog.get_selected_item()
 
         conn = DB.Get(DB_Config)
-        asset_list = conn.get_asset_name_list(sorted=True)
+        asset_display_names = conn.get_asset_display_name_list(sorted=True)
 
         asset_dialog = SelectFromGroup(
-            asset_list, "Reference Asset", "Select your asset"
+            asset_display_names, "Reference Asset", "Select your asset"
         )
         if not asset_dialog.exec_():
             return  # User cancelled
 
-        selected_asset_name = asset_dialog.get_selected_item()
-        if not selected_asset_name:
+        selected_asset_display_name = asset_dialog.get_selected_item()
+        if not selected_asset_display_name:
             mc.warning("No asset selected.")
             return
 
-        selected_asset = conn.get_asset_by_name(selected_asset_name)
+        selected_asset = conn.get_asset_by_display_name(selected_asset_display_name)
 
         # Define the reference prim under the selected layout group
         base_path = f"/{env_prim.GetName()}/{set_prim.GetName()}/{selected_layout}"

--- a/pipeline/pipe/m/publish/asset.py
+++ b/pipeline/pipe/m/publish/asset.py
@@ -106,7 +106,7 @@ class PublishAssetDialog(FilteredListDialog):
     def _on_item_selected(self) -> None:
         selected = self.get_selected_item()
         if self._conn and selected:
-            asset = self._conn.get_asset_by_name(selected)
+            asset = self._conn.get_asset_by_display_name(selected)
         else:
             return
         self._populate_geo_var(asset)
@@ -131,7 +131,7 @@ class AssetPublisher(Publisher):
     _component_export_dir: Path | None
     _component_hip_path: Path | None
     _component_basename: str | None
-    _asset_pipe_name: str | None
+    _asset_name: str | None
     _houdini_result: dict[str, Any] | None
 
     def __init__(self) -> None:
@@ -141,28 +141,28 @@ class AssetPublisher(Publisher):
         self._component_export_dir = None
         self._component_hip_path = None
         self._component_basename = None
-        self._asset_pipe_name = None
+        self._asset_name = None
         self._houdini_result = None
 
     @staticmethod
     def _compute_component_basename(
         asset: Asset, variant: str, is_substance: bool
     ) -> tuple[str, str]:
-        pipe_name = (asset.name or "").strip()
-        if not pipe_name or pipe_name.lower() == "none":
-            pipe_name = (asset.disp_name or "").strip()
-        if not pipe_name and asset.path:
-            pipe_name = Path(asset.path).name
-        if not pipe_name:
-            pipe_name = "asset"
+        name = (asset.name or "").strip()
+        if not name or name == "none":
+            name = ""
+        if not name and asset.path:
+            name = Path(asset.path).name
+        if not name:
+            name = "asset"
 
-        base_name = pipe_name
+        base_name = name
         if variant and variant != "main":
             base_name = f"{base_name}_{variant}"
         if is_substance:
             base_name = f"{base_name}_SUBSTANCE"
 
-        return pipe_name, base_name
+        return name, base_name
 
     def _prepublish(self) -> bool:
         checker = ModelChecker.get()
@@ -189,18 +189,18 @@ class AssetPublisher(Publisher):
         return True
 
     def _get_entity_list(self) -> list[str]:
-        return self._conn.get_asset_name_list(sorted=True)
+        return self._conn.get_asset_display_name_list(sorted=True)
 
-    def _get_entity_from_name(self, name: str) -> SGEntity | None:
-        return self._conn.get_asset_by_name(name)
+    def _get_entity_from_name(self, display_name: str) -> SGEntity | None:
+        return self._conn.get_asset_by_display_name(display_name)
 
     def _get_asset(self) -> Asset | None:
         """Get the asset from the database."""
         dialog = cast(PublishAssetDialog, self._dialog)
-        asset_name = dialog.get_selected_item()
-        if not asset_name:
+        asset_display_name = dialog.get_selected_item()
+        if not asset_display_name:
             return None
-        return self._conn.get_asset_by_name(asset_name)
+        return self._conn.get_asset_by_display_name(asset_display_name)
 
     def _get_variant_name(self) -> str | None:
         """Get the variant name from the dialog."""
@@ -244,11 +244,11 @@ class AssetPublisher(Publisher):
             log.info(f"Updating new geo variant: {variant_name}")
             self._conn.update_asset(asset)
 
-        pipe_name, basename = self._compute_component_basename(
+        name, basename = self._compute_component_basename(
             asset, variant_name, self._is_substance_only
         )
         publish_dir = get_production_path() / asset.path
-        self._asset_pipe_name = pipe_name
+        self._asset_name = name
         self._component_basename = basename
         return publish_dir / f"{basename}.usd"
 
@@ -288,7 +288,7 @@ class AssetPublisher(Publisher):
             asset = cast(Asset, self._entity)
             override_info = {
                 "user": os.getlogin(),
-                "asset": asset.disp_name,
+                "asset": asset.display_name,
                 "path": str(self._publish_path),
             }
             data = bytes(json.dumps(override_info), encoding="utf-8")
@@ -346,15 +346,11 @@ class AssetPublisher(Publisher):
                 f"Houdini executable not found at {Executables.hython}"
             )
 
-        asset_pipe_name = (
-            self._asset_pipe_name
-            or (asset.name or "").strip()
-            or (asset.disp_name or "").strip()
-        )
-        if not asset_pipe_name and asset.path:
-            asset_pipe_name = Path(asset.path).name
-        if not asset_pipe_name:
-            asset_pipe_name = component_name
+        asset_name = self._asset_name or (asset.name or "").strip()
+        if not asset_name and asset.path:
+            asset_name = Path(asset.path).name
+        if not asset_name:
+            asset_name = component_name
 
         command = [
             str(Executables.hython),
@@ -369,13 +365,13 @@ class AssetPublisher(Publisher):
             "--component-name",
             component_name,
             "--asset-name",
-            asset_pipe_name,
+            asset_name,
             "--variant",
             self._geo_variant,
         ]
 
-        if asset_pipe_name and asset_pipe_name != component_name:
-            command.extend(["--root-prim", asset_pipe_name])
+        if asset_name and asset_name != component_name:
+            command.extend(["--root-prim", asset_name])
 
         dcc = HoudiniDCC(is_python_shell=True)
         env = dcc._get_env_vars()

--- a/pipeline/pipe/m/publish/camera.py
+++ b/pipeline/pipe/m/publish/camera.py
@@ -2,23 +2,23 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import TYPE_CHECKING, cast
+
 from Qt.QtCore import QRegExp
 from Qt.QtGui import QRegExpValidator
 from Qt.QtWidgets import QComboBox, QHBoxLayout, QLabel, QWidget
-from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
     from typing import Any, Sequence
 
 import maya.cmds as mc
+from shared.util import get_production_path
 
 from pipe.glui.dialogs import FilteredListDialog, MessageDialog
 from pipe.struct.db import SGEntity, Shot
-from shared.util import get_production_path
 
 from .publisher import Publisher
-from .usdchaser import ExportChaser, ChaserMode
-
+from .usdchaser import ChaserMode, ExportChaser
 
 log = logging.getLogger(__name__)
 
@@ -60,8 +60,8 @@ class CameraPublisher(Publisher):
     def _get_entity_list(self) -> list[str]:
         return self._conn.get_shot_code_list(sorted=True)
 
-    def _get_entity_from_name(self, name: str) -> SGEntity | None:
-        return self._conn.get_shot_by_code(name)
+    def _get_entity_from_name(self, display_name: str) -> SGEntity | None:
+        return self._conn.get_shot_by_code(display_name)
 
     def _get_save_path(self) -> Path | None:
         try:

--- a/pipeline/pipe/m/publish/previs_asset.py
+++ b/pipeline/pipe/m/publish/previs_asset.py
@@ -3,25 +3,23 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import TYPE_CHECKING, cast
-from Qt.QtWidgets import QCheckBox, QWidget
-from pipe.db import DB
-from typing import Optional
-from pxr import Usd, Sdf, UsdGeom
+from typing import TYPE_CHECKING, Optional, cast
 
-import maya.cmds as cmds
 import maya.api.OpenMaya as om
-from pxr import Gf, Vt
+import maya.cmds as cmds
+from pxr import Gf, Sdf, Usd, UsdGeom, Vt
+from Qt.QtWidgets import QCheckBox, QWidget
 
+from pipe.db import DB
 
 if TYPE_CHECKING:
     from typing import Any, Sequence
-from pipe.glui.dialogs import FilteredListDialog, MessageDialog
-from pipe.struct.db import Asset, SGEntity
 from shared.util import get_production_path
 
-from .publisher import Publisher
+from pipe.glui.dialogs import FilteredListDialog, MessageDialog
+from pipe.struct.db import Asset, SGEntity
 
+from .publisher import Publisher
 
 log = logging.getLogger(__name__)
 
@@ -57,10 +55,10 @@ class PrevisAssetPublisher(Publisher):
         super().__init__(PublishPrevisAssetDialog)
 
     def _get_entity_list(self) -> list[str]:
-        return self._conn.get_asset_name_list(sorted=True)
+        return self._conn.get_asset_display_name_list(sorted=True)
 
-    def _get_entity_from_name(self, name: str) -> SGEntity | None:
-        return self._conn.get_asset_by_name(name)
+    def _get_entity_from_name(self, display_name: str) -> SGEntity | None:
+        return self._conn.get_asset_by_display_name(display_name)
 
     def _get_save_path(self) -> Path | None:
         cast(PublishPrevisAssetDialog, self._dialog)

--- a/pipeline/pipe/m/publish/publisher.py
+++ b/pipeline/pipe/m/publish/publisher.py
@@ -7,20 +7,20 @@ import shutil
 import traceback
 from functools import wraps
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import maya.cmds as mc
+from env_sg import DB_Config
 
 import pipe
 from pipe.db import DB
 from pipe.glui.dialogs import FilteredListDialog, MessageDialog
 from pipe.m.util import maintain_selection
 from pipe.struct.db import SGEntity
-from env_sg import DB_Config
-
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Any
+
     from Qt.QtWidgets import QWidget
 
 log = logging.getLogger(__name__)
@@ -79,8 +79,8 @@ class Publisher:
         return []
 
     @_assert_not_none
-    def _get_entity_from_name(self, name: str) -> SGEntity | None:
-        """Turn the string chosen in the dialog into a SG entity"""
+    def _get_entity_from_name(self, display_name: str) -> SGEntity | None:
+        """Turn the chosen display name into a SG entity"""
         return None
 
     @_assert_not_none
@@ -110,7 +110,7 @@ class Publisher:
         following functions:
           - `prepublish(self)`
           - `get_entity_list(self) -> list[str]`
-          - `get_entity_from_name(self, disp_name: str) -> SGEntity`
+          - `get_entity_from_name(self, display_name: str) -> SGEntity`
           - `get_save_path(self) -> Path`
           - `presave(self)`
           - `get_mayausd_kwargs(self) -> dict[str, Any]`

--- a/pipeline/pipe/m/publish/rig.py
+++ b/pipeline/pipe/m/publish/rig.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
 import logging
-import shutil
 import re
-
-from typing import TYPE_CHECKING
-from shared.util import get_production_path
+import shutil
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+from shared.util import get_production_path
+
 from pipe.glui.dialogs import MessageDialog
 
 if TYPE_CHECKING:
@@ -29,7 +30,9 @@ class RigPublisher(Publisher):
         super().__init__(use_sg_entity=False)
 
     def _get_entity_list(self) -> list[str]:
-        return self._conn.get_asset_name_list_by_type(["Character", "Rigged Prop"])
+        return self._conn.get_asset_display_name_list_by_type(
+            ["Character", "Rigged Prop"]
+        )
 
     def _get_mayausd_kwargs(self) -> dict[str, Any]:
         kwargs = {
@@ -49,7 +52,7 @@ class RigPublisher(Publisher):
         return True
 
     def _get_save_path(self) -> Path | None:
-        asset = self._conn.get_asset_by_name(self._selected_item)
+        asset = self._conn.get_asset_by_display_name(self._selected_item)
 
         try:
             assert asset.path is not None

--- a/pipeline/pipe/m/publish/usdchaser.py
+++ b/pipeline/pipe/m/publish/usdchaser.py
@@ -523,7 +523,7 @@ class ExportChaser(mayaUsdLib.ExportChaser):
                 asset = None
                 relative_path_str = None
                 try:
-                    asset = conn.get_asset_by_attr("name", base_name)
+                    asset = conn.get_asset_by_name(base_name)
 
                     assert asset.path is not None
                     rig_path = str(asset.path).replace("\\", "/") + "/usd/main.usd"

--- a/pipeline/pipe/m/shotfile/anim.py
+++ b/pipeline/pipe/m/shotfile/anim.py
@@ -104,7 +104,7 @@ class MAnimShotFileManager(MShotFileManager):
                 if (get_production_path() / ".." / rig_path).exists():
                     mc.file(rig_path, reference=True, namespace=asset.name)
                 else:
-                    print(f'Unable to find rig for asset "{asset.disp_name}"')
+                    print(f'Unable to find rig for asset "{asset.display_name}"')
 
         self._import_env()
 

--- a/pipeline/pipe/sp/ui.py
+++ b/pipeline/pipe/sp/ui.py
@@ -3,28 +3,30 @@ from __future__ import annotations
 import logging
 import os
 from math import log2
-from Qt import QtCore, QtWidgets
-from Qt.QtGui import QIcon, QPixmap, QRegExpValidator
-from Qt.QtCore import QRegExp
+from re import findall
+from typing import TYPE_CHECKING
+
 from PySide6.QtCore import QEventLoop  # type: ignore[import-not-found]
+from Qt import QtCore, QtWidgets
+from Qt.QtCore import QRegExp
+from Qt.QtGui import QIcon, QPixmap, QRegExpValidator
 from Qt.QtWidgets import (
     QComboBox,
     QLabel,
     QLayout,
-    QMainWindow,
-    QWidget,
-    QVBoxLayout,
-    QScrollArea,
-    QPushButton,
     QLineEdit,
+    QMainWindow,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
 )
-from re import findall
-from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     import typing
 
 import substance_painter as sp
+from env_sg import DB_Config
 
 from pipe.db import DB
 from pipe.glui.dialogs import ButtonPair, MessageDialog
@@ -33,8 +35,6 @@ from pipe.sp.local import get_main_qt_window
 from pipe.struct.db import Asset
 from pipe.struct.material import DisplacementSource, NormalSource, NormalType
 from pipe.util import checkbox_callback_helper, dict_index
-
-from env_sg import DB_Config
 
 log = logging.getLogger(__name__)
 
@@ -88,7 +88,7 @@ class SubstanceExportWindow(QMainWindow, ButtonPair):
         texture_set_layout = QVBoxLayout()
 
         # Get asset names (assumed sorted)
-        asset_names = self._conn.get_asset_name_list(sorted=True)
+        asset_display_names = self._conn.get_asset_display_name_list(sorted=True)
 
         # Add widgets for each texture set
         for ts in sp.textureset.all_texture_sets():
@@ -106,7 +106,7 @@ class SubstanceExportWindow(QMainWindow, ButtonPair):
 
             # Dropdown to select asset
             asset_dropdown = QComboBox()
-            asset_dropdown.addItems(asset_names)
+            asset_dropdown.addItems(asset_display_names)
 
             # Store dropdown in a dictionary
             self._tex_set_dropdowns[ts] = asset_dropdown
@@ -142,7 +142,7 @@ class SubstanceExportWindow(QMainWindow, ButtonPair):
             # Filter the items based on the text
             filtered_assets = [
                 asset
-                for asset in self._conn.get_asset_name_list()
+                for asset in self._conn.get_asset_display_name_list()
                 if text.lower() in asset.lower()
             ]
             asset_dropdown.clear()  # Clear existing items
@@ -152,12 +152,12 @@ class SubstanceExportWindow(QMainWindow, ButtonPair):
         self._tex_set_asset_dict = {}
 
         for ts, dropdown in self._tex_set_dropdowns.items():
-            selected_asset = dropdown.currentText()
+            selected_asset_display_name = dropdown.currentText()
 
-            if selected_asset not in self._tex_set_asset_dict.keys():
-                self._tex_set_asset_dict[selected_asset] = []
+            if selected_asset_display_name not in self._tex_set_asset_dict.keys():
+                self._tex_set_asset_dict[selected_asset_display_name] = []
 
-            self._tex_set_asset_dict[selected_asset].append(ts)
+            self._tex_set_asset_dict[selected_asset_display_name].append(ts)
 
         self.clear_layout()
         self._setup_asset_ui()
@@ -188,10 +188,10 @@ class SubstanceExportWindow(QMainWindow, ButtonPair):
 
     def _setup_asset_ui(self):
         # loops though every asset that was selected in the first prompt, and lets them set export options per texture set
-        for i, curr_asset_name in enumerate(self._tex_set_asset_dict.keys()):
+        for i, curr_asset_display_name in enumerate(self._tex_set_asset_dict.keys()):
             self.clear_layout()
 
-            self.setWindowTitle(f"{curr_asset_name} Publish Textures")
+            self.setWindowTitle(f"{curr_asset_display_name} Publish Textures")
 
             # Make sure window always stays on top
             self.setWindowFlags(self.windowFlags() | QtCore.Qt.WindowStaysOnTopHint)
@@ -214,11 +214,13 @@ class SubstanceExportWindow(QMainWindow, ButtonPair):
             lock_warning.setWordWrap(True)
             self._main_layout.addWidget(lock_warning)
 
-            self._curr_asset = self._conn.get_asset_by_name(curr_asset_name)
+            self._curr_asset = self._conn.get_asset_by_display_name(
+                curr_asset_display_name
+            )
 
             # Texture set widgets
             texture_set_layout = QtWidgets.QVBoxLayout()
-            for ts in self._tex_set_asset_dict[curr_asset_name]:
+            for ts in self._tex_set_asset_dict[curr_asset_display_name]:
                 widget = TexSetWidget(self, ts)
                 self._tex_set_dict[ts] = widget
                 texture_set_layout.addWidget(widget)

--- a/pipeline/pipe/struct/db.py
+++ b/pipeline/pipe/struct/db.py
@@ -1,14 +1,12 @@
 from __future__ import annotations
 
-import attrs
-import cattrs
-
-
-from attrs import field
-
 # We need to always import typing for defining the structs
 # attrs doesn't support `|` syntax in 3.9
 from typing import Any, Optional, Type, TypeVar
+
+import attrs
+import cattrs
+from attrs import field
 
 from pipe.struct.util import Diffable
 
@@ -113,7 +111,6 @@ class AssetStub(SGEntityStub):
 
 @attrs.define
 class Asset(SGEntity):
-    name: str = field(metadata={_SG_NAME: "sg_pipe_name"})
     type: str = field(metadata={_SG_NAME: "sg_asset_type"})
     material_variants: set[str] = field(
         metadata={
@@ -155,24 +152,12 @@ class Asset(SGEntity):
         return self.code or ""
 
     @property
-    def is_variant(self) -> bool:
-        return "_" in self.name
-
-    @property
     def tex_path(self) -> Optional[str]:
         return f"{self.path}/tex/"
-
-    @property
-    def variant_name(self) -> Optional[str]:
-        if not self.is_variant:
-            return None
-        return self.name.split("_")[1]
 
 
 @attrs.define
 class Environment(SGEntity):
-    name: str = field(metadata={_SG_NAME: "sg_pipe_name"})
-
     @property
     def disp_name(self) -> str:
         """Alias for code"""

--- a/pipeline/pipe/struct/db.py
+++ b/pipeline/pipe/struct/db.py
@@ -34,6 +34,18 @@ _con.register_structure_hook_factory(
 )
 
 
+def _normalize_pipe_name(name: Optional[str]) -> str:
+    """Normalize a ShotGrid display name into a pipe-safe name.
+
+    Current rules:
+    - lower-case the string
+    - replace spaces with underscores
+    """
+    if not name:
+        return ""
+    return name.strip().lower().replace(" ", "_")
+
+
 @attrs.define
 class SGDiffable(Diffable):
     @classmethod
@@ -147,9 +159,14 @@ class Asset(SGEntity):
     version = None
 
     @property
-    def disp_name(self) -> str:
-        """Alias for code"""
+    def display_name(self) -> str:
+        """ShotGrid display name (code)."""
         return self.code or ""
+
+    @property
+    def name(self) -> str:
+        """Pipe-safe name derived from the ShotGrid display name."""
+        return _normalize_pipe_name(self.display_name)
 
     @property
     def tex_path(self) -> Optional[str]:
@@ -159,9 +176,14 @@ class Asset(SGEntity):
 @attrs.define
 class Environment(SGEntity):
     @property
-    def disp_name(self) -> str:
-        """Alias for code"""
+    def display_name(self) -> str:
+        """ShotGrid display name (code)."""
         return self.code or ""
+
+    @property
+    def name(self) -> str:
+        """Pipe-safe name derived from the ShotGrid display name."""
+        return _normalize_pipe_name(self.display_name)
 
 
 @attrs.define

--- a/pipeline/pipe/struct/db.py
+++ b/pipeline/pipe/struct/db.py
@@ -34,8 +34,8 @@ _con.register_structure_hook_factory(
 )
 
 
-def _normalize_pipe_name(name: Optional[str]) -> str:
-    """Normalize a ShotGrid display name into a pipe-safe name.
+def normalize_display_name(name: Optional[str]) -> str:
+    """Normalize a ShotGrid display name into a pipeline-safe name.
 
     Current rules:
     - lower-case the string
@@ -115,10 +115,11 @@ class SGEntityStub(SGDiffable):
 @attrs.frozen
 class AssetStub(SGEntityStub):
     """Represent "stubs" that come from ShotGrid
-    Stubs are JSON objects with 3 fields: id, name, and type (which is always Asset in this case)
+    Stubs are JSON objects with 3 fields: id, name (display name), and type
+    (which is always Asset in this case)
     """
 
-    disp_name: str = field(metadata={_SG_NAME: "name"})
+    display_name: str = field(metadata={_SG_NAME: "name"})
 
 
 @attrs.define
@@ -165,8 +166,8 @@ class Asset(SGEntity):
 
     @property
     def name(self) -> str:
-        """Pipe-safe name derived from the ShotGrid display name."""
-        return _normalize_pipe_name(self.display_name)
+        """Normalized name derived from the ShotGrid display name."""
+        return normalize_display_name(self.display_name)
 
     @property
     def tex_path(self) -> Optional[str]:
@@ -182,8 +183,8 @@ class Environment(SGEntity):
 
     @property
     def name(self) -> str:
-        """Pipe-safe name derived from the ShotGrid display name."""
-        return _normalize_pipe_name(self.display_name)
+        """Normalized name derived from the ShotGrid display name."""
+        return normalize_display_name(self.display_name)
 
 
 @attrs.define


### PR DESCRIPTION
Here lies the pipe_name attribute in shot grid. Gone are the days of artists forgetting to set the pipe name, or setting the pipe name differently from the asset name. Now we just treat the single name ass the source of truth.

We do normalize the names for use internally. Spaces are a scary thing.