### PR TITLE
Version control for Maya

### DIFF
--- a/pipeline/pipe/asset/paths.py
+++ b/pipeline/pipe/asset/paths.py
@@ -23,7 +23,7 @@ DCC_HOUDINI = "houdini"
 DCC_SUBSTANCE = "substance_painter"
 
 # Asset root-level filenames
-MODEL_FILENAME = "model.ma"
+MODEL_FILENAME = "model.mb"
 TEXTURES_FILENAME = "textures.spp"
 ASSET_BUILDER_FILENAME = "asset_builder.hipnc"
 MANIFEST_FILENAME = "asset_manifest.json"

--- a/pipeline/pipe/asset/versioning.py
+++ b/pipeline/pipe/asset/versioning.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import datetime
 import getpass
+import hashlib
 import json
 import logging
 import os
 import platform
 import re
 import shutil
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Optional
 
@@ -18,6 +20,23 @@ from .paths import MANIFEST_FILENAME
 log = logging.getLogger(__name__)
 
 _VERSION_RE_TEMPLATE = r"^{stem}\.v(?P<ver>\d+)\.{ext}$"
+_SIGNATURE_KEY = "signature"
+_SIGNATURE_HASH_KEY = "hash"
+_SIGNATURE_HASH_ALGO_KEY = "hash_algo"
+_SIGNATURE_SIZE_KEY = "size"
+_SIGNATURE_MTIME_NS_KEY = "mtime_ns"
+_EXTRA_CHANGED_KEY = "changed"
+_EXTRA_VARIANT_KEY = "variant"
+_EXTRA_PUBLISH_PATH_KEY = "publish_path"
+
+
+@dataclass(frozen=True)
+class BackupResult:
+    changed: bool
+    signature: dict[str, Any]
+    backup_path: Optional[Path]
+    version: Optional[int]
+    manifest: dict[str, Any]
 
 
 def _utc_now_iso() -> str:
@@ -134,6 +153,46 @@ def versioned_filename(stem: str, ext: str, version: int, padding: int = 3) -> s
     return f"{stem}.v{version:0{padding}d}.{ext}"
 
 
+def compute_signature(
+    path: Path,
+    *,
+    use_hash: bool = False,
+    hash_algo: str = "sha256",
+    chunk_size: int = 1024 * 1024,
+) -> dict[str, Any]:
+    """Return a file signature for copy-on-write checks."""
+    stat = path.stat()
+    signature: dict[str, Any] = {
+        _SIGNATURE_SIZE_KEY: stat.st_size,
+        _SIGNATURE_MTIME_NS_KEY: stat.st_mtime_ns,
+    }
+
+    if use_hash:
+        hasher = hashlib.new(hash_algo)
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(chunk_size), b""):
+                hasher.update(chunk)
+        signature[_SIGNATURE_HASH_KEY] = hasher.hexdigest()
+        signature[_SIGNATURE_HASH_ALGO_KEY] = hash_algo
+
+    return signature
+
+
+def _signature_matches(
+    a: Optional[dict[str, Any]], b: Optional[dict[str, Any]]
+) -> bool:
+    if not a or not b:
+        return False
+    for key in (_SIGNATURE_SIZE_KEY, _SIGNATURE_MTIME_NS_KEY):
+        if a.get(key) != b.get(key):
+            return False
+    if _SIGNATURE_HASH_KEY in a or _SIGNATURE_HASH_KEY in b:
+        return a.get(_SIGNATURE_HASH_KEY) == b.get(_SIGNATURE_HASH_KEY) and a.get(
+            _SIGNATURE_HASH_ALGO_KEY
+        ) == b.get(_SIGNATURE_HASH_ALGO_KEY)
+    return True
+
+
 def backup_file(
     source_path: Path,
     backup_dir: Path,
@@ -165,6 +224,98 @@ def backup_file(
     shutil.copy2(source_path, temp_path)
     os.replace(temp_path, target_path)
     return target_path
+
+
+def backup_if_changed(
+    source_path: Path,
+    backup_dir: Path,
+    manifest_path: Path,
+    *,
+    dcc: str,
+    stem: Optional[str] = None,
+    ext: Optional[str] = None,
+    version: Optional[int] = None,
+    padding: int = 3,
+    ensure_exists: bool = True,
+    use_hash: bool = False,
+    note: Optional[str] = None,
+    tool_version: Optional[str] = None,
+    asset_name: Optional[str] = None,
+    asset_path: Optional[str] = None,
+    asset_id: Optional[int] = None,
+    variant: Optional[str] = None,
+    publish_path: Optional[Path] = None,
+    extra: Optional[dict[str, Any]] = None,
+) -> Optional[BackupResult]:
+    """Copy a file into .backup only if the signature changed.
+
+    Records a publish entry in the manifest with signature + metadata.
+    Returns None if the source is missing and ensure_exists is True.
+    """
+    if ensure_exists and not source_path.exists():
+        log.warning("Backup skipped; source missing: %s", source_path)
+        return None
+
+    signature = compute_signature(source_path, use_hash=use_hash)
+    manifest = load_manifest(manifest_path)
+    dcc_block = manifest.get("dcc", {}).get(dcc, {})
+    current = dcc_block.get("current") or {}
+    previous_signature = (current.get("extra") or {}).get(_SIGNATURE_KEY)
+
+    changed = not _signature_matches(previous_signature, signature)
+    backup_path: Optional[Path] = None
+    resolved_version: Optional[int] = current.get("version")
+
+    resolved_stem = stem or source_path.stem
+    resolved_ext = (ext or source_path.suffix.lstrip(".")) or "dat"
+
+    if changed:
+        resolved_version = version or next_version(
+            backup_dir, resolved_stem, resolved_ext
+        )
+        backup_path = backup_file(
+            source_path,
+            backup_dir,
+            stem=resolved_stem,
+            ext=resolved_ext,
+            version=resolved_version,
+            padding=padding,
+            ensure_exists=False,
+        )
+    else:
+        existing_backup = current.get("backup_file")
+        if existing_backup:
+            backup_path = Path(existing_backup)
+
+    extra_payload = dict(extra or {})
+    extra_payload[_SIGNATURE_KEY] = signature
+    extra_payload[_EXTRA_CHANGED_KEY] = changed
+    if variant:
+        extra_payload[_EXTRA_VARIANT_KEY] = variant
+    if publish_path:
+        extra_payload[_EXTRA_PUBLISH_PATH_KEY] = str(publish_path)
+
+    manifest = record_publish(
+        manifest_path,
+        dcc=dcc,
+        source_path=source_path,
+        backup_path=backup_path,
+        version=resolved_version,
+        note=note,
+        tool_version=tool_version,
+        extra=extra_payload,
+        asset_name=asset_name,
+        asset_path=asset_path,
+        asset_id=asset_id,
+    )
+
+    return BackupResult(
+        changed=changed,
+        signature=signature,
+        backup_path=backup_path,
+        version=resolved_version,
+        manifest=manifest,
+    )
 
 
 def record_publish(
@@ -215,6 +366,9 @@ def record_publish(
 
 __all__ = [
     "backup_file",
+    "backup_if_changed",
+    "compute_signature",
+    "BackupResult",
     "build_manifest",
     "get_manifest_path",
     "list_versions",

--- a/pipeline/pipe/asset/versioning.py
+++ b/pipeline/pipe/asset/versioning.py
@@ -28,7 +28,6 @@ _SIGNATURE_MTIME_NS_KEY = "mtime_ns"
 _EXTRA_CHANGED_KEY = "changed"
 _EXTRA_VARIANT_KEY = "variant"
 _EXTRA_PUBLISH_PATH_KEY = "publish_path"
-EXTRA_SUBSTANCE_ONLY_KEY = "substance_only"
 
 
 @dataclass(frozen=True)
@@ -370,7 +369,6 @@ __all__ = [
     "backup_if_changed",
     "compute_signature",
     "BackupResult",
-    "EXTRA_SUBSTANCE_ONLY_KEY",
     "build_manifest",
     "get_manifest_path",
     "list_versions",

--- a/pipeline/pipe/asset/versioning.py
+++ b/pipeline/pipe/asset/versioning.py
@@ -28,6 +28,7 @@ _SIGNATURE_MTIME_NS_KEY = "mtime_ns"
 _EXTRA_CHANGED_KEY = "changed"
 _EXTRA_VARIANT_KEY = "variant"
 _EXTRA_PUBLISH_PATH_KEY = "publish_path"
+EXTRA_SUBSTANCE_ONLY_KEY = "substance_only"
 
 
 @dataclass(frozen=True)
@@ -369,6 +370,7 @@ __all__ = [
     "backup_if_changed",
     "compute_signature",
     "BackupResult",
+    "EXTRA_SUBSTANCE_ONLY_KEY",
     "build_manifest",
     "get_manifest_path",
     "list_versions",

--- a/pipeline/pipe/m/assetfile/__init__.py
+++ b/pipeline/pipe/m/assetfile/__init__.py
@@ -11,6 +11,7 @@ from .assetfile_manager import (
     MAssetFileManager,
     install_asset_menu,
     read_asset_metadata,
+    resolve_asset_from_scene_path,
     write_asset_metadata,
 )
 
@@ -23,6 +24,7 @@ __all__ = [
     "AssetMetadata",
     "write_asset_metadata",
     "read_asset_metadata",
+    "resolve_asset_from_scene_path",
     "AssetOpenDialog",
     "MAssetFileManager",
     "install_asset_menu",

--- a/pipeline/pipe/m/assetfile/__init__.py
+++ b/pipeline/pipe/m/assetfile/__init__.py
@@ -1,0 +1,29 @@
+"""Maya asset file helpers and UI."""
+
+from .assetfile_manager import (
+    FILEINFO_ASSET_DISPLAY_NAME,
+    FILEINFO_ASSET_ID,
+    FILEINFO_ASSET_NAME,
+    FILEINFO_ASSET_PATH,
+    FILEINFO_PREFIX,
+    AssetMetadata,
+    AssetOpenDialog,
+    MAssetFileManager,
+    install_asset_menu,
+    read_asset_metadata,
+    write_asset_metadata,
+)
+
+__all__ = [
+    "FILEINFO_PREFIX",
+    "FILEINFO_ASSET_ID",
+    "FILEINFO_ASSET_NAME",
+    "FILEINFO_ASSET_DISPLAY_NAME",
+    "FILEINFO_ASSET_PATH",
+    "AssetMetadata",
+    "write_asset_metadata",
+    "read_asset_metadata",
+    "AssetOpenDialog",
+    "MAssetFileManager",
+    "install_asset_menu",
+]

--- a/pipeline/pipe/m/assetfile/assetfile_manager.py
+++ b/pipeline/pipe/m/assetfile/assetfile_manager.py
@@ -135,7 +135,7 @@ def _asset_path_from_root(asset_root: Path) -> Optional[str]:
     return rel_path.as_posix()
 
 
-def _resolve_asset_from_scene_path(conn: DB, scene_path: Path) -> Optional[Asset]:
+def resolve_asset_from_scene_path(conn: DB, scene_path: Path) -> Optional[Asset]:
     asset_root = _asset_root_from_scene_path(scene_path)
     if not asset_root:
         return None
@@ -290,7 +290,7 @@ class MAssetFileManager(FileManager):
                 return
             scene_path = Path(raw_path)
 
-        asset = _resolve_asset_from_scene_path(self._conn, scene_path)
+        asset = resolve_asset_from_scene_path(self._conn, scene_path)
         if asset:
             write_asset_metadata(asset)
 
@@ -409,6 +409,7 @@ __all__ = [
     "AssetMetadata",
     "write_asset_metadata",
     "read_asset_metadata",
+    "resolve_asset_from_scene_path",
     "AssetOpenDialog",
     "MAssetFileManager",
     "install_asset_menu",

--- a/pipeline/pipe/m/assetfile/assetfile_manager.py
+++ b/pipeline/pipe/m/assetfile/assetfile_manager.py
@@ -11,8 +11,9 @@ import maya.cmds as mc
 import maya.mel as mel
 from env_sg import DB_Config
 from Qt import QtCore, QtWidgets
+from shared.util import get_production_path
 
-from pipe.asset.paths import DCC_MAYA, AssetPaths, paths_for_asset
+from pipe.asset.paths import BACKUP_DIRNAME, DCC_MAYA, AssetPaths, paths_for_asset
 from pipe.asset.versioning import (
     get_manifest_path,
     list_versions,
@@ -112,6 +113,40 @@ def read_asset_metadata(conn: DB | None = None) -> AssetMetadata:
         path=asset_path,
         asset=resolved,
     )
+
+
+def _asset_root_from_scene_path(scene_path: Path) -> Optional[Path]:
+    if not scene_path:
+        return None
+    parent = scene_path.parent
+    if parent.name == BACKUP_DIRNAME:
+        return parent.parent
+    return parent
+
+
+def _asset_path_from_root(asset_root: Path) -> Optional[str]:
+    if not asset_root:
+        return None
+    prod_root = get_production_path()
+    try:
+        rel_path = asset_root.relative_to(prod_root)
+    except ValueError:
+        rel_path = asset_root
+    return rel_path.as_posix()
+
+
+def _resolve_asset_from_scene_path(conn: DB, scene_path: Path) -> Optional[Asset]:
+    asset_root = _asset_root_from_scene_path(scene_path)
+    if not asset_root:
+        return None
+    asset_path = _asset_path_from_root(asset_root)
+    if not asset_path:
+        return None
+    try:
+        return conn.get_asset_by_attr("path", asset_path)
+    except Exception as exc:
+        log.debug("No asset found for scene path %s: %s", scene_path, exc)
+        return None
 
 
 class AssetOpenDialog(FilteredListDialog):
@@ -233,6 +268,31 @@ class MAssetFileManager(FileManager):
         mc.file(new=True, force=True)
         mc.file(rename=str(path))
         mc.file(save=True, type="mayaBinary")
+        asset = entity if isinstance(entity, Asset) else None
+        if asset:
+            write_asset_metadata(asset)
+
+    def _ensure_scene_asset_metadata(self, scene_path: Optional[Path] = None) -> None:
+        meta = read_asset_metadata(self._conn)
+        if meta.asset:
+            if (
+                meta.id is None
+                or not meta.name
+                or not meta.display_name
+                or not meta.path
+            ):
+                write_asset_metadata(meta.asset)
+            return
+
+        if scene_path is None:
+            raw_path = mc.file(query=True, sn=True) or ""
+            if not raw_path:
+                return
+            scene_path = Path(raw_path)
+
+        asset = _resolve_asset_from_scene_path(self._conn, scene_path)
+        if asset:
+            write_asset_metadata(asset)
 
     def _prompt_backup_version(self, paths: AssetPaths) -> Optional[Path]:
         versions = list_versions(paths.backup_dir, "model", "mb")
@@ -293,6 +353,7 @@ class MAssetFileManager(FileManager):
             backup_path = self._prompt_backup_version(paths)
             if backup_path:
                 self._open_file(backup_path)
+                self._ensure_scene_asset_metadata(backup_path)
             return
 
         if not self._prompt_create_if_not_exist(paths.root):
@@ -301,6 +362,7 @@ class MAssetFileManager(FileManager):
         model_path = paths.model_path
         if model_path.is_file():
             self._open_file(model_path)
+            self._ensure_scene_asset_metadata(model_path)
         else:
             self._setup_file(model_path, asset)
 

--- a/pipeline/pipe/m/assetfile/assetfile_manager.py
+++ b/pipeline/pipe/m/assetfile/assetfile_manager.py
@@ -227,11 +227,8 @@ class AssetOpenDialog(FilteredListDialog):
 
         manifest_state = "present" if manifest_path.exists() else "missing"
         info_lines = [
-            f"Root: {paths.root}",
-            f"Model: {paths.model_path}",
-            f"Manifest: {manifest_path} ({manifest_state})",
-            f"Last publish (manifest): {publish_summary}",
-            f"Available backups: {backup_label}",
+            f"Path: {paths.root}",
+            f"Last publish: {publish_summary}",
         ]
         self._info_label.setText("\n".join(info_lines))
 

--- a/pipeline/pipe/m/assetfile/assetfile_manager.py
+++ b/pipeline/pipe/m/assetfile/assetfile_manager.py
@@ -103,9 +103,7 @@ def read_asset_metadata(conn: DB | None = None) -> AssetMetadata:
             try:
                 resolved = conn.get_asset_by_attr("path", asset_path)
             except Exception as exc:
-                log.warning(
-                    "Failed to resolve asset by path %s: %s", asset_path, exc
-                )
+                log.warning("Failed to resolve asset by path %s: %s", asset_path, exc)
 
     return AssetMetadata(
         id=asset_id,
@@ -186,7 +184,7 @@ class AssetOpenDialog(FilteredListDialog):
                 parts.append(f"at {timestamp}")
             publish_summary = " ".join(parts)
 
-        backup_versions = list_versions(paths.backup_dir, "model", "ma")
+        backup_versions = list_versions(paths.backup_dir, "model", "mb")
         if backup_versions:
             backup_label = ", ".join(f"v{v:03d}" for v in backup_versions)
         else:
@@ -226,7 +224,7 @@ class MAssetFileManager(FileManager):
         return True
 
     def _generate_filename_ext(self, entity: SGEntity) -> tuple[str, str]:
-        return "model", "ma"
+        return "model", "mb"
 
     def _open_file(self, path: Path) -> None:
         mc.file(str(path), open=True, force=True)
@@ -234,10 +232,10 @@ class MAssetFileManager(FileManager):
     def _setup_file(self, path: Path, entity: SGEntity) -> None:
         mc.file(new=True, force=True)
         mc.file(rename=str(path))
-        mc.file(save=True, type="mayaAscii")
+        mc.file(save=True, type="mayaBinary")
 
     def _prompt_backup_version(self, paths: AssetPaths) -> Optional[Path]:
-        versions = list_versions(paths.backup_dir, "model", "ma")
+        versions = list_versions(paths.backup_dir, "model", "mb")
         if not versions:
             MessageDialog(
                 self._main_window,
@@ -247,7 +245,7 @@ class MAssetFileManager(FileManager):
             return None
 
         version_files = [
-            versioned_filename("model", "ma", version)
+            versioned_filename("model", "mb", version)
             for version in sorted(versions, reverse=True)
         ]
         dialog = FilteredListDialog(

--- a/pipeline/pipe/m/assetfile/assetfile_manager.py
+++ b/pipeline/pipe/m/assetfile/assetfile_manager.py
@@ -281,18 +281,23 @@ class MAssetFileManager(FileManager):
                 or not meta.display_name
                 or not meta.path
             ):
+                log.info("Backfilling incomplete asset metadata in fileInfo.")
                 write_asset_metadata(meta.asset)
             return
 
         if scene_path is None:
             raw_path = mc.file(query=True, sn=True) or ""
             if not raw_path:
+                log.debug("Scene has no file path; cannot infer asset metadata.")
                 return
             scene_path = Path(raw_path)
 
         asset = resolve_asset_from_scene_path(self._conn, scene_path)
         if asset:
+            log.info("Inferred asset metadata from scene path: %s", asset.path)
             write_asset_metadata(asset)
+        else:
+            log.debug("Unable to infer asset metadata from scene path: %s", scene_path)
 
     def _prompt_backup_version(self, paths: AssetPaths) -> Optional[Path]:
         versions = list_versions(paths.backup_dir, "model", "mb")

--- a/pipeline/pipe/m/assetfile/assetfile_manager.py
+++ b/pipeline/pipe/m/assetfile/assetfile_manager.py
@@ -1,8 +1,9 @@
-"""Maya asset file manager and UI for opening model files with version info."""
+"""Maya asset file manager and scene asset metadata helpers."""
 
 from __future__ import annotations
 
 import logging
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 
@@ -25,6 +26,94 @@ from pipe.struct.db import Asset, SGEntity
 from pipe.util import FileManager
 
 log = logging.getLogger(__name__)
+
+FILEINFO_PREFIX = "pipe_asset"
+FILEINFO_ASSET_ID = f"{FILEINFO_PREFIX}_id"
+FILEINFO_ASSET_NAME = f"{FILEINFO_PREFIX}_name"
+FILEINFO_ASSET_DISPLAY_NAME = f"{FILEINFO_PREFIX}_display_name"
+FILEINFO_ASSET_PATH = f"{FILEINFO_PREFIX}_path"
+
+
+@dataclass(frozen=True)
+class AssetMetadata:
+    id: Optional[int]
+    name: Optional[str]
+    display_name: Optional[str]
+    path: Optional[str]
+    asset: Optional[Asset]
+
+
+def _normalize_value(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    value = str(value).strip()
+    return value or None
+
+
+def _get_file_info_value(key: str) -> Optional[str]:
+    try:
+        value = mc.fileInfo(key, query=True)
+    except Exception:
+        return None
+    if isinstance(value, (list, tuple)):
+        value = value[0] if value else None
+    return _normalize_value(value)
+
+
+def _set_file_info_value(key: str, value: Optional[str]) -> None:
+    mc.fileInfo(key, value or "")
+
+
+def write_asset_metadata(asset: Asset) -> None:
+    """Write asset metadata to the current Maya scene fileInfo."""
+    _set_file_info_value(FILEINFO_ASSET_ID, str(asset.id) if asset.id else "")
+    _set_file_info_value(FILEINFO_ASSET_NAME, _normalize_value(asset.name))
+    _set_file_info_value(
+        FILEINFO_ASSET_DISPLAY_NAME, _normalize_value(asset.display_name)
+    )
+    _set_file_info_value(FILEINFO_ASSET_PATH, _normalize_value(asset.path))
+
+
+def read_asset_metadata(conn: DB | None = None) -> AssetMetadata:
+    """Read asset metadata from fileInfo and resolve to an Asset when possible."""
+    asset_id_raw = _get_file_info_value(FILEINFO_ASSET_ID)
+    asset_name = _get_file_info_value(FILEINFO_ASSET_NAME)
+    asset_display_name = _get_file_info_value(FILEINFO_ASSET_DISPLAY_NAME)
+    asset_path = _get_file_info_value(FILEINFO_ASSET_PATH)
+
+    asset_id: Optional[int]
+    if asset_id_raw:
+        try:
+            asset_id = int(asset_id_raw)
+        except Exception:
+            log.warning("Invalid asset id in fileInfo: %s", asset_id_raw)
+            asset_id = None
+    else:
+        asset_id = None
+
+    resolved: Asset | None = None
+    conn = conn or DB.Get(DB_Config)
+    if conn:
+        if asset_id is not None:
+            try:
+                resolved = conn.get_asset_by_id(asset_id)
+            except Exception as exc:
+                log.warning("Failed to resolve asset by id %s: %s", asset_id, exc)
+        if resolved is None and asset_path:
+            try:
+                resolved = conn.get_asset_by_attr("path", asset_path)
+            except Exception as exc:
+                log.warning(
+                    "Failed to resolve asset by path %s: %s", asset_path, exc
+                )
+
+    return AssetMetadata(
+        id=asset_id,
+        name=asset_name,
+        display_name=asset_display_name,
+        path=asset_path,
+        asset=resolved,
+    )
 
 
 class AssetOpenDialog(FilteredListDialog):
@@ -251,4 +340,16 @@ def install_asset_menu(
     )
 
 
-__all__ = ["MAssetFileManager", "install_asset_menu"]
+__all__ = [
+    "FILEINFO_PREFIX",
+    "FILEINFO_ASSET_ID",
+    "FILEINFO_ASSET_NAME",
+    "FILEINFO_ASSET_DISPLAY_NAME",
+    "FILEINFO_ASSET_PATH",
+    "AssetMetadata",
+    "write_asset_metadata",
+    "read_asset_metadata",
+    "AssetOpenDialog",
+    "MAssetFileManager",
+    "install_asset_menu",
+]

--- a/pipeline/pipe/m/assetfile/assetfile_manager.py
+++ b/pipeline/pipe/m/assetfile/assetfile_manager.py
@@ -65,6 +65,20 @@ def _set_file_info_value(key: str, value: Optional[str]) -> None:
     mc.fileInfo(key, value or "")
 
 
+def _set_dialog_button_tooltips(
+    dialog: QtWidgets.QDialog, *, ok_text: str, cancel_text: str
+) -> None:
+    buttons = getattr(dialog, "buttons", None)
+    if not buttons:
+        return
+    ok_btn = buttons.button(QtWidgets.QDialogButtonBox.Ok)
+    if ok_btn:
+        ok_btn.setToolTip(ok_text)
+    cancel_btn = buttons.button(QtWidgets.QDialogButtonBox.Cancel)
+    if cancel_btn:
+        cancel_btn.setToolTip(cancel_text)
+
+
 def write_asset_metadata(asset: Asset) -> None:
     """Write asset metadata to the current Maya scene fileInfo."""
     _set_file_info_value(FILEINFO_ASSET_ID, str(asset.id) if asset.id else "")
@@ -174,14 +188,28 @@ class AssetOpenDialog(FilteredListDialog):
         info_layout.setSpacing(6)
 
         self._open_backup_cb = QtWidgets.QCheckBox("Open backup version")
+        self._open_backup_cb.setToolTip(
+            "Open a versioned backup instead of the live asset model file."
+        )
         info_layout.addWidget(self._open_backup_cb)
 
         self._info_label = QtWidgets.QLabel("Select an asset to see details.")
         self._info_label.setWordWrap(True)
         self._info_label.setTextFormat(QtCore.Qt.PlainText)
+        self._info_label.setToolTip(
+            "Shows recent publish info and available backups for the selected asset."
+        )
         info_layout.addWidget(self._info_label)
 
         self._layout.insertWidget(1, info_widget)
+        if hasattr(self, "_filter_field"):
+            self._filter_field.setToolTip("Type to filter the asset list.")
+        self._list_widget.setToolTip("Select the asset model you want to open.")
+        _set_dialog_button_tooltips(
+            self,
+            ok_text="Open the selected asset model file.",
+            cancel_text="Close without opening a file.",
+        )
 
     @property
     def open_backup(self) -> bool:
@@ -316,6 +344,14 @@ class MAssetFileManager(FileManager):
             "Open Backup Version",
             "Select the backup version to open.",
             accept_button_name="Open",
+        )
+        if hasattr(dialog, "_filter_field"):
+            dialog._filter_field.setToolTip("Type to filter backup versions.")
+        dialog._list_widget.setToolTip("Select a backup version to open.")
+        _set_dialog_button_tooltips(
+            dialog,
+            ok_text="Open the selected backup version.",
+            cancel_text="Close without opening a backup.",
         )
         if not dialog.exec_():
             return None

--- a/pipeline/pipe/m/publish/asset.py
+++ b/pipeline/pipe/m/publish/asset.py
@@ -13,16 +13,12 @@ import maya.cmds as mc
 from env import Executables
 from Qt.QtCore import QRegExp
 from Qt.QtGui import QRegExpValidator, QTextCursor
-from Qt.QtWidgets import QCheckBox, QComboBox, QHBoxLayout, QLabel, QWidget
+from Qt.QtWidgets import QComboBox, QHBoxLayout, QLabel, QWidget
 from shared.util import get_pipe_path
 from software.houdini.dcc import HoudiniDCC
 
 from pipe.asset.paths import DCC_MAYA, paths_for_asset
-from pipe.asset.versioning import (
-    EXTRA_SUBSTANCE_ONLY_KEY,
-    BackupResult,
-    backup_if_changed,
-)
+from pipe.asset.versioning import BackupResult, backup_if_changed
 from pipe.db import DB
 from pipe.glui.dialogs import (
     FilteredListDialog,
@@ -61,19 +57,10 @@ class HoudiniBuildError(RuntimeError):
 
 
 class _PublishAssetVariantControls:
-    _substance_only: QCheckBox
     _geo_var_dropdown: QComboBox
     _conn: Optional[DB]
 
     def _init_variant_controls(self) -> None:
-        self._substance_only = QCheckBox(
-            "Export Substance-only file? ONLY USE IF INSTRUCTED BY A LEAD"
-        )
-        self._substance_only.setToolTip(
-            "Exports a Substance-only USD; use only when instructed by a lead."
-        )
-        self._layout.insertWidget(1, self._substance_only)  # type: ignore[attr-defined]
-
         geo_var_widget = QWidget(self)  # type: ignore[misc]
         geo_var_layout = QHBoxLayout(geo_var_widget)
         geo_var_layout.setContentsMargins(0, 0, 0, 0)
@@ -98,10 +85,6 @@ class _PublishAssetVariantControls:
 
     def get_selected_variant(self) -> str:
         return self._geo_var_dropdown.currentText()
-
-    @property
-    def is_substance_only(self) -> bool:
-        return self._substance_only.isChecked()
 
     def _populate_geo_var(self, asset: Asset | None) -> None:
         if asset and hasattr(asset, "geometry_variants"):
@@ -130,6 +113,8 @@ class PublishAssetOptionsDialog(FilteredListDialog, _PublishAssetVariantControls
         self._conn = conn
         self._selected_asset_name = items[0] if items else None
 
+        self.resize(460, 240)
+
         if hasattr(self, "_filter_field"):
             self._filter_field.setVisible(False)
         self._list_widget.setVisible(False)
@@ -145,6 +130,7 @@ class PublishAssetOptionsDialog(FilteredListDialog, _PublishAssetVariantControls
 
         self._init_variant_controls()
 
+        self._layout.addStretch(1)
         asset = None
         if self._conn and self._selected_asset_name:
             asset = self._conn.get_asset_by_display_name(self._selected_asset_name)
@@ -171,8 +157,10 @@ class PublishAssetPickerDialog(FilteredListDialog, _PublishAssetVariantControls)
             accept_button_name="Publish",
         )
         self._conn = conn
+        self.resize(520, 520)
         self._init_variant_controls()
         self._populate_geo_var(None)
+        self._layout.addStretch(1)
 
     def _on_item_selected(self) -> None:
         selected = self.get_selected_item()
@@ -186,7 +174,6 @@ class PublishAssetPickerDialog(FilteredListDialog, _PublishAssetVariantControls)
 class AssetPublisher(Publisher):
     _override: bool
     _geo_variant: str
-    _is_substance_only: bool
     _component_export_dir: Path | None
     _component_hip_path: Path | None
     _component_basename: str | None
@@ -196,7 +183,6 @@ class AssetPublisher(Publisher):
     def __init__(self) -> None:
         super().__init__(PublishAssetOptionsDialog)
         self._geo_variant = "main"
-        self._is_substance_only = False
         self._component_export_dir = None
         self._component_hip_path = None
         self._component_basename = None
@@ -281,7 +267,6 @@ class AssetPublisher(Publisher):
             dcc=DCC_MAYA,
             variant=self._geo_variant,
             publish_path=self._publish_path,
-            extra={EXTRA_SUBSTANCE_ONLY_KEY: self._is_substance_only},
             asset_name=asset.name,
             asset_path=asset.path,
             asset_id=asset.id,
@@ -320,9 +305,7 @@ class AssetPublisher(Publisher):
         log.warning("Asset metadata missing; falling back to asset picker dialog.")
 
     @staticmethod
-    def _compute_component_basename(
-        asset: Asset, variant: str, is_substance: bool
-    ) -> tuple[str, str]:
+    def _compute_component_basename(asset: Asset, variant: str) -> tuple[str, str]:
         name = (asset.name or "").strip()
         if not name or name == "none":
             name = ""
@@ -334,9 +317,6 @@ class AssetPublisher(Publisher):
         base_name = name
         if variant and variant != "main":
             base_name = f"{base_name}_{variant}"
-        if is_substance:
-            base_name = f"{base_name}_SUBSTANCE"
-
         return name, base_name
 
     def _prepublish(self) -> bool:
@@ -415,18 +395,13 @@ class AssetPublisher(Publisher):
         write_asset_metadata(asset)
 
         self._geo_variant = variant_name
-        self._is_substance_only = cast(
-            PublishAssetOptionsDialog, self._dialog
-        ).is_substance_only
 
         if variant_name not in asset.geometry_variants:
             asset.geometry_variants.add(variant_name)
             log.info(f"Updating new geo variant: {variant_name}")
             self._conn.update_asset(asset)
 
-        name, basename = self._compute_component_basename(
-            asset, variant_name, self._is_substance_only
-        )
+        name, basename = self._compute_component_basename(asset, variant_name)
         asset_paths = paths_for_asset(asset)
         self._asset_name = name
         self._component_basename = basename
@@ -438,11 +413,6 @@ class AssetPublisher(Publisher):
         details: list[str] = []
         if self._backup_status:
             details.append(self._backup_status)
-
-        if self._is_substance_only:
-            if details:
-                return f"{message}\n\n" + "\n".join(details)
-            return message
 
         if self._houdini_result is None:
             details.append("Houdini component publish failed or was skipped.")
@@ -591,10 +561,6 @@ class AssetPublisher(Publisher):
                 "warnings": [],
                 "errors": [],
             }
-            return
-
-        if self._is_substance_only:
-            log.info("Skipping Houdini component publish for substance-only export")
             return
 
         asset = cast(Asset, self._entity)

--- a/pipeline/pipe/m/publish/asset.py
+++ b/pipeline/pipe/m/publish/asset.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import json
 import logging
+import os
+import shutil
 import subprocess
+import traceback
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Sequence, cast
 
@@ -14,7 +17,8 @@ from Qt.QtWidgets import QCheckBox, QComboBox, QHBoxLayout, QLabel, QWidget
 from shared.util import get_pipe_path
 from software.houdini.dcc import HoudiniDCC
 
-from pipe.asset.paths import paths_for_asset
+from pipe.asset.paths import DCC_MAYA, paths_for_asset
+from pipe.asset.versioning import BackupResult, backup_if_changed
 from pipe.db import DB
 from pipe.glui.dialogs import (
     FilteredListDialog,
@@ -26,6 +30,7 @@ from pipe.m.assetfile import (
     resolve_asset_from_scene_path,
     write_asset_metadata,
 )
+from pipe.m.util import maintain_selection
 from pipe.struct.db import Asset, SGEntity
 
 if TYPE_CHECKING:
@@ -60,6 +65,9 @@ class _PublishAssetVariantControls:
         self._substance_only = QCheckBox(
             "Export Substance-only file? ONLY USE IF INSTRUCTED BY A LEAD"
         )
+        self._substance_only.setToolTip(
+            "Exports a Substance-only USD; use only when instructed by a lead."
+        )
         self._layout.insertWidget(1, self._substance_only)  # type: ignore[attr-defined]
 
         geo_var_widget = QWidget(self)  # type: ignore[misc]
@@ -74,6 +82,9 @@ class _PublishAssetVariantControls:
         self._geo_var_dropdown = QComboBox()
         self._geo_var_dropdown.setEditable(True)
         self._geo_var_dropdown.setCurrentText("default")
+        self._geo_var_dropdown.setToolTip(
+            "Enter or select the geometry variant to publish."
+        )
         pattern = QRegExp("[a-z][a-z_\d]*")
         geo_var_validator = QRegExpValidator(pattern)
         self._geo_var_dropdown.setValidator(geo_var_validator)
@@ -125,6 +136,7 @@ class PublishAssetOptionsDialog(FilteredListDialog, _PublishAssetVariantControls
             f"Asset: {self._selected_asset_name or 'Unknown'}",
             parent=self,
         )
+        asset_label.setToolTip("Asset resolved from the current scene metadata.")
         self._layout.insertWidget(0, asset_label)
 
         self._init_variant_controls()
@@ -187,6 +199,8 @@ class AssetPublisher(Publisher):
         self._asset_name = None
         self._houdini_result = None
         self._scene_asset: Asset | None = None
+        self._backup_result: BackupResult | None = None
+        self._backup_status: str | None = None
 
     def _resolve_scene_asset(self) -> Asset | None:
         metadata = read_asset_metadata(self._conn)
@@ -201,6 +215,78 @@ class AssetPublisher(Publisher):
         if asset:
             write_asset_metadata(asset)
         return asset
+
+    def _ensure_scene_saved(self) -> bool:
+        scene_path = mc.file(query=True, sn=True) or ""
+        if not scene_path:
+            MessageDialog(
+                self._window,
+                "Scene must be saved before publishing. Please save the asset file and try again.",
+                "Save Required",
+            ).exec_()
+            return False
+
+        if not mc.file(query=True, modified=True):
+            return True
+
+        response = mc.confirmDialog(
+            title="Save Changes",
+            message="This scene has unsaved changes. Save before publishing?",
+            button=["Save", "Cancel"],
+            defaultButton="Save",
+            cancelButton="Cancel",
+            dismissString="Cancel",
+        )
+        if response != "Save":
+            return False
+
+        try:
+            mc.file(save=True, force=True)
+        except Exception:
+            MessageDialog(
+                self._window,
+                "Failed to save the current scene. Please resolve any file issues and try again.",
+                "Save Failed",
+            ).exec_()
+            return False
+
+        return True
+
+    def _run_backup(self, asset: Asset) -> None:
+        self._backup_result = None
+        self._backup_status = None
+
+        scene_path = mc.file(query=True, sn=True) or ""
+        if not scene_path:
+            self._backup_status = "Backup skipped: scene has no file path."
+            return
+
+        asset_paths = paths_for_asset(asset)
+        result = backup_if_changed(
+            source_path=Path(scene_path),
+            backup_dir=asset_paths.backup_dir,
+            manifest_path=asset_paths.manifest_path,
+            dcc=DCC_MAYA,
+            variant=self._geo_variant,
+            publish_path=self._publish_path,
+            extra={"substance_only": self._is_substance_only},
+            asset_name=asset.name,
+            asset_path=asset.path,
+            asset_id=asset.id,
+        )
+
+        if result is None:
+            self._backup_status = "Backup skipped: source file missing."
+            return
+
+        self._backup_result = result
+        if result.changed:
+            if result.backup_path:
+                self._backup_status = f"Backup created: {result.backup_path.name}"
+            else:
+                self._backup_status = "Backup created."
+        else:
+            self._backup_status = "Backup skipped: no changes detected."
 
     def _configure_dialog_for_scene(self) -> None:
         self._scene_asset = self._resolve_scene_asset()
@@ -309,6 +395,8 @@ class AssetPublisher(Publisher):
             ).exec_()
             return None
 
+        write_asset_metadata(asset)
+
         self._geo_variant = variant_name
         self._is_substance_only = cast(
             PublishAssetOptionsDialog, self._dialog
@@ -329,33 +417,143 @@ class AssetPublisher(Publisher):
 
     def _get_confirm_message(self) -> str:
         message = super()._get_confirm_message()
+
+        details: list[str] = []
+        if self._backup_status:
+            details.append(self._backup_status)
+
         if self._is_substance_only:
+            if details:
+                return f"{message}\n\n" + "\n".join(details)
             return message
 
         if self._houdini_result is None:
-            return f"{message}\n\nHoudini component publish failed or was skipped."
+            details.append("Houdini component publish failed or was skipped.")
+        else:
+            result = self._houdini_result
+            status = result.get("status", "unknown").capitalize()
+            mode = result.get("mode", "unknown")
 
-        result = self._houdini_result
-        status = result.get("status", "unknown").capitalize()
-        mode = result.get("mode", "unknown")
+            details.append(f"Houdini build status: {status} ({mode} mode)")
+            if result.get("changed_usd_reference"):
+                details.append("- Updated USD reference.")
+            if result.get("export_performed"):
+                details.append(f"- Exported to: {result.get('export_dir')}")
 
-        details = [f"Houdini build status: {status} ({mode} mode)"]
-        if result.get("changed_usd_reference"):
-            details.append("- Updated USD reference.")
-        if result.get("export_performed"):
-            details.append(f"- Exported to: {result.get('export_dir')}")
+            warnings = result.get("warnings")
+            if warnings:
+                details.append("")
+                details.append("Warnings:")
+                details.extend(f"- {w}" for w in warnings)
 
-        warnings = result.get("warnings")
-        if warnings:
-            details.append("\nWarnings:")
-            details.extend(f"- {w}" for w in warnings)
+            errors = result.get("errors")
+            if errors:
+                details.append("")
+                details.append("Errors:")
+                details.extend(f"- {e.get('code')}: {e.get('message')}" for e in errors)
 
-        errors = result.get("errors")
-        if errors:
-            details.append("\nErrors:")
-            details.extend(f"- {e.get('code')}: {e.get('message')}" for e in errors)
+        if details:
+            return f"{message}\n\n" + "\n".join(details)
+        return message
 
-        return f"{message}\n\n" + "\n".join(details)
+    def publish(self):
+        with maintain_selection():
+            self._backup_result = None
+            self._backup_status = None
+            if not self._ensure_scene_saved():
+                return
+
+            if not self._prepublish():
+                return
+
+            if entity_list := self._get_entity_list():
+                if self._dialog_T in (
+                    PublishAssetOptionsDialog,
+                    PublishAssetPickerDialog,
+                ):
+                    self._dialog = self._dialog_T(self._window, entity_list, self._conn)
+                else:
+                    self._dialog = self._dialog_T(self._window, entity_list)
+
+                if not self._dialog.exec_():
+                    return
+
+                self._selected_item = self._dialog.get_selected_item()
+                if self._selected_item is None:
+                    MessageDialog(
+                        self._window,
+                        "Error: Nothing selected. Nothing exported",
+                        "Error",
+                    ).exec_()
+                    return
+
+                if self._use_sg_entity:
+                    try:
+                        self._entity = self._get_entity_from_name(self._selected_item)
+                    except AssertionError:
+                        entity_label = Asset.__name__
+                        MessageDialog(
+                            self._window,
+                            "Error: The selected item did not correspond to a valid "
+                            f"{entity_label} in ShotGrid. Please "
+                            "report this error. Nothing exported",
+                            "Error",
+                        ).exec_()
+                        return
+
+            self._publish_path = self._get_save_path()
+            if not self._publish_path:
+                mc.error("No save path found!")
+                return
+
+            if not self._presave():
+                return
+
+            self._publish_path.parent.mkdir(parents=True, exist_ok=True)
+            temp_publish_path = (
+                os.getenv("TEMP", "") + os.pathsep + self._publish_path.name
+            )
+
+            kwargs = {
+                "file": str(
+                    temp_publish_path if self._IS_WINDOWS else self._publish_path
+                ),
+                "selection": True,
+                "stripNamespaces": True,
+                **self._get_mayausd_kwargs(),
+            }
+
+            try:
+                mc.mayaUSDExport(**kwargs)  # type: ignore[attr-defined]
+            except Exception:
+                print(traceback.format_exc())
+                MessageDialog(
+                    self._window,
+                    "WARNING: Publish failed! Please check the console for more information",
+                    "Export Failed",
+                ).exec_()
+                return
+
+            if self._IS_WINDOWS:
+                shutil.move(temp_publish_path, self._publish_path)
+
+            self._postpublish()
+
+            asset = None
+            if getattr(self, "_entity", None):
+                asset = cast(Asset, self._entity)
+            if asset is None:
+                asset = self._scene_asset or self._resolve_scene_asset()
+            if asset:
+                self._run_backup(asset)
+            else:
+                self._backup_status = "Backup skipped: asset could not be resolved."
+
+            MessageDialog(
+                self._window,
+                self._get_confirm_message(),
+                "Export Complete",
+            ).exec_()
 
     def _presave(self) -> bool:
         return True

--- a/pipeline/pipe/m/publish/asset.py
+++ b/pipeline/pipe/m/publish/asset.py
@@ -6,6 +6,7 @@ import subprocess
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Optional, Sequence, cast
 
+import maya.cmds as mc
 from env import Executables
 from Qt.QtCore import QRegExp
 from Qt.QtGui import QRegExpValidator, QTextCursor
@@ -19,6 +20,11 @@ from pipe.glui.dialogs import (
     FilteredListDialog,
     MessageDialog,
     MessageDialogCustomButtons,
+)
+from pipe.m.assetfile import (
+    read_asset_metadata,
+    resolve_asset_from_scene_path,
+    write_asset_metadata,
 )
 from pipe.struct.db import Asset, SGEntity
 
@@ -45,9 +51,98 @@ class HoudiniBuildError(RuntimeError):
     pass
 
 
-class PublishAssetDialog(FilteredListDialog):
+class _PublishAssetVariantControls:
     _substance_only: QCheckBox
-    _geo_var_widget: QWidget
+    _geo_var_dropdown: QComboBox
+    _conn: Optional[DB]
+
+    def _init_variant_controls(self) -> None:
+        self._substance_only = QCheckBox(
+            "Export Substance-only file? ONLY USE IF INSTRUCTED BY A LEAD"
+        )
+        self._layout.insertWidget(1, self._substance_only)  # type: ignore[attr-defined]
+
+        geo_var_widget = QWidget(self)  # type: ignore[misc]
+        geo_var_layout = QHBoxLayout(geo_var_widget)
+        geo_var_layout.setContentsMargins(0, 0, 0, 0)
+        geo_var_layout.setSpacing(0)
+        geo_var_settings_widget = QWidget()
+        geo_var_settings_layout = QHBoxLayout(geo_var_settings_widget)
+        geo_var_label = QLabel("Geometry Variant:")
+        geo_var_settings_layout.addWidget(geo_var_label, 30)
+
+        self._geo_var_dropdown = QComboBox()
+        self._geo_var_dropdown.setEditable(True)
+        self._geo_var_dropdown.setCurrentText("default")
+        pattern = QRegExp("[a-z][a-z_\d]*")
+        geo_var_validator = QRegExpValidator(pattern)
+        self._geo_var_dropdown.setValidator(geo_var_validator)
+        geo_var_settings_layout.addWidget(self._geo_var_dropdown, 70)
+        geo_var_layout.addWidget(geo_var_settings_widget, 90)
+        self._layout.addWidget(geo_var_widget)  # type: ignore[attr-defined]
+
+    def get_selected_variant(self) -> str:
+        return self._geo_var_dropdown.currentText()
+
+    @property
+    def is_substance_only(self) -> bool:
+        return self._substance_only.isChecked()
+
+    def _populate_geo_var(self, asset: Asset | None) -> None:
+        if asset and hasattr(asset, "geometry_variants"):
+            variants = sorted(set(asset.geometry_variants) | {"main"})
+        else:
+            variants = []
+        self._geo_var_dropdown.clear()
+        self._geo_var_dropdown.addItems(variants)
+
+
+class PublishAssetOptionsDialog(FilteredListDialog, _PublishAssetVariantControls):
+    """Publish dialog for the current scene asset (read-only asset name)."""
+
+    _selected_asset_name: Optional[str]
+
+    def __init__(
+        self, parent: QWidget | None, items: Sequence[str], conn: Optional[DB]
+    ) -> None:
+        super().__init__(
+            parent,
+            items,
+            "Publish Asset",
+            "Asset to publish",
+            accept_button_name="Publish",
+        )
+        self._conn = conn
+        self._selected_asset_name = items[0] if items else None
+
+        if hasattr(self, "_filter_field"):
+            self._filter_field.setVisible(False)
+        self._list_widget.setVisible(False)
+        if hasattr(self, "_list_label"):
+            self._list_label.setVisible(False)
+
+        asset_label = QLabel(
+            f"Asset: {self._selected_asset_name or 'Unknown'}",
+            parent=self,
+        )
+        self._layout.insertWidget(0, asset_label)
+
+        self._init_variant_controls()
+
+        asset = None
+        if self._conn and self._selected_asset_name:
+            asset = self._conn.get_asset_by_display_name(self._selected_asset_name)
+        self._populate_geo_var(asset)
+
+    def get_selected_item(self) -> str | None:
+        return self._selected_asset_name
+
+    def _on_item_selected(self) -> None:
+        return
+
+
+class PublishAssetPickerDialog(FilteredListDialog, _PublishAssetVariantControls):
+    """Fallback dialog that lets users choose the asset to publish."""
 
     def __init__(
         self, parent: QWidget | None, items: Sequence[str], conn: Optional[DB]
@@ -59,49 +154,9 @@ class PublishAssetDialog(FilteredListDialog):
             "Select asset to publish",
             accept_button_name="Publish",
         )
-
-        self._substance_only = QCheckBox(
-            "Export Substance-only file? ONLY USE IF INSTRUCTED BY A LEAD"
-        )
-        self._layout.insertWidget(1, self._substance_only)
-
         self._conn = conn
-
-        geo_var_widget = QWidget(self)
-        geo_var_layout = QHBoxLayout(geo_var_widget)
-        geo_var_layout.setContentsMargins(0, 0, 0, 0)
-        geo_var_layout.setSpacing(0)
-        geo_var_settings_widget = QWidget()
-        geo_var_settings_layout = QHBoxLayout(geo_var_settings_widget)
-        geo_var_label = QLabel("Geometry Variant:")
-        geo_var_settings_layout.addWidget(geo_var_label, 30)
-
-        # Editable combo box for geo variant
-        self._geo_var_dropdown = QComboBox()
-        self._geo_var_dropdown.setEditable(True)
-        self._geo_var_dropdown.setCurrentText("default")
-        pattern = QRegExp("[a-z][a-z_\d]*")
-        geo_var_validator = QRegExpValidator(pattern)
-        self._geo_var_dropdown.setValidator(geo_var_validator)
-        geo_var_settings_layout.addWidget(self._geo_var_dropdown, 70)
-        geo_var_layout.addWidget(geo_var_settings_widget, 90)
-        self._layout.addWidget(geo_var_widget)
-
+        self._init_variant_controls()
         self._populate_geo_var(None)
-
-    def get_selected_variant(self) -> str:
-        return self._geo_var_dropdown.currentText()
-
-    @property
-    def is_substance_only(self) -> bool:
-        """Return whether the substance-only option is checked."""
-        return self._substance_only.isChecked()
-
-    def get_selected_item(self) -> str | None:
-        selected_items = self._list_widget.selectedItems()
-        if selected_items:
-            return selected_items[0].text()
-        return None
 
     def _on_item_selected(self) -> None:
         selected = self.get_selected_item()
@@ -110,18 +165,6 @@ class PublishAssetDialog(FilteredListDialog):
         else:
             return
         self._populate_geo_var(asset)
-
-    def _populate_geo_var(self, asset: Asset | None) -> None:
-        """Populate the variant selector with variants from the selected asset."""
-        if asset and hasattr(asset, "geometry_variants"):
-            var_set = set(asset.geometry_variants)
-            var_set.add("main")
-            variants = list(var_set)
-        else:
-            variants = []
-
-        self._geo_var_dropdown.clear()
-        self._geo_var_dropdown.addItems(variants)
 
 
 class AssetPublisher(Publisher):
@@ -135,7 +178,7 @@ class AssetPublisher(Publisher):
     _houdini_result: dict[str, Any] | None
 
     def __init__(self) -> None:
-        super().__init__(PublishAssetDialog)
+        super().__init__(PublishAssetOptionsDialog)
         self._geo_variant = "main"
         self._is_substance_only = False
         self._component_export_dir = None
@@ -143,6 +186,35 @@ class AssetPublisher(Publisher):
         self._component_basename = None
         self._asset_name = None
         self._houdini_result = None
+        self._scene_asset: Asset | None = None
+
+    def _resolve_scene_asset(self) -> Asset | None:
+        metadata = read_asset_metadata(self._conn)
+        if metadata.asset:
+            return metadata.asset
+
+        scene_path = mc.file(query=True, sn=True) or ""
+        if not scene_path:
+            return None
+
+        asset = resolve_asset_from_scene_path(self._conn, Path(scene_path))
+        if asset:
+            write_asset_metadata(asset)
+        return asset
+
+    def _configure_dialog_for_scene(self) -> None:
+        self._scene_asset = self._resolve_scene_asset()
+        if self._scene_asset:
+            self._dialog_T = PublishAssetOptionsDialog
+            return
+
+        self._dialog_T = PublishAssetPickerDialog
+        MessageDialog(
+            self._window,
+            "Asset metadata is missing from this scene. "
+            "Please select the asset to publish.",
+            "Asset Selection Required",
+        ).exec_()
 
     @staticmethod
     def _compute_component_basename(
@@ -186,9 +258,12 @@ class AssetPublisher(Publisher):
                     "<h1>Asset not exported. Please resolve model checks.</h1>"
                 )
                 return False
+        self._configure_dialog_for_scene()
         return True
 
     def _get_entity_list(self) -> list[str]:
+        if self._scene_asset:
+            return [self._scene_asset.display_name]
         return self._conn.get_asset_display_name_list(sorted=True)
 
     def _get_entity_from_name(self, display_name: str) -> SGEntity | None:
@@ -196,7 +271,7 @@ class AssetPublisher(Publisher):
 
     def _get_asset(self) -> Asset | None:
         """Get the asset from the database."""
-        dialog = cast(PublishAssetDialog, self._dialog)
+        dialog = cast(PublishAssetOptionsDialog, self._dialog)
         asset_display_name = dialog.get_selected_item()
         if not asset_display_name:
             return None
@@ -204,7 +279,7 @@ class AssetPublisher(Publisher):
 
     def _get_variant_name(self) -> str | None:
         """Get the variant name from the dialog."""
-        dialog = cast(PublishAssetDialog, self._dialog)
+        dialog = cast(PublishAssetOptionsDialog, self._dialog)
         return dialog.get_selected_variant()
 
     def _get_save_path(self) -> Path | None:
@@ -236,7 +311,7 @@ class AssetPublisher(Publisher):
 
         self._geo_variant = variant_name
         self._is_substance_only = cast(
-            PublishAssetDialog, self._dialog
+            PublishAssetOptionsDialog, self._dialog
         ).is_substance_only
 
         if variant_name not in asset.geometry_variants:

--- a/pipeline/pipe/m/publish/asset.py
+++ b/pipeline/pipe/m/publish/asset.py
@@ -18,7 +18,11 @@ from shared.util import get_pipe_path
 from software.houdini.dcc import HoudiniDCC
 
 from pipe.asset.paths import DCC_MAYA, paths_for_asset
-from pipe.asset.versioning import BackupResult, backup_if_changed
+from pipe.asset.versioning import (
+    EXTRA_SUBSTANCE_ONLY_KEY,
+    BackupResult,
+    backup_if_changed,
+)
 from pipe.db import DB
 from pipe.glui.dialogs import (
     FilteredListDialog,
@@ -209,11 +213,15 @@ class AssetPublisher(Publisher):
 
         scene_path = mc.file(query=True, sn=True) or ""
         if not scene_path:
+            log.warning("No scene path; cannot resolve asset metadata.")
             return None
 
         asset = resolve_asset_from_scene_path(self._conn, Path(scene_path))
         if asset:
+            log.info("Resolved asset from scene path; writing file metadata.")
             write_asset_metadata(asset)
+        else:
+            log.warning("Failed to resolve asset from scene path: %s", scene_path)
         return asset
 
     def _ensure_scene_saved(self) -> bool:
@@ -224,6 +232,7 @@ class AssetPublisher(Publisher):
                 "Scene must be saved before publishing. Please save the asset file and try again.",
                 "Save Required",
             ).exec_()
+            log.warning("Publish canceled: scene has no file path.")
             return False
 
         if not mc.file(query=True, modified=True):
@@ -238,6 +247,7 @@ class AssetPublisher(Publisher):
             dismissString="Cancel",
         )
         if response != "Save":
+            log.info("Publish canceled: user declined to save scene.")
             return False
 
         try:
@@ -248,6 +258,7 @@ class AssetPublisher(Publisher):
                 "Failed to save the current scene. Please resolve any file issues and try again.",
                 "Save Failed",
             ).exec_()
+            log.exception("Failed to save scene before publish.")
             return False
 
         return True
@@ -259,6 +270,7 @@ class AssetPublisher(Publisher):
         scene_path = mc.file(query=True, sn=True) or ""
         if not scene_path:
             self._backup_status = "Backup skipped: scene has no file path."
+            log.warning("Backup skipped: scene has no file path.")
             return
 
         asset_paths = paths_for_asset(asset)
@@ -269,7 +281,7 @@ class AssetPublisher(Publisher):
             dcc=DCC_MAYA,
             variant=self._geo_variant,
             publish_path=self._publish_path,
-            extra={"substance_only": self._is_substance_only},
+            extra={EXTRA_SUBSTANCE_ONLY_KEY: self._is_substance_only},
             asset_name=asset.name,
             asset_path=asset.path,
             asset_id=asset.id,
@@ -277,16 +289,20 @@ class AssetPublisher(Publisher):
 
         if result is None:
             self._backup_status = "Backup skipped: source file missing."
+            log.warning("Backup skipped: source file missing.")
             return
 
         self._backup_result = result
         if result.changed:
             if result.backup_path:
                 self._backup_status = f"Backup created: {result.backup_path.name}"
+                log.info("Backup created at %s", result.backup_path)
             else:
                 self._backup_status = "Backup created."
+                log.info("Backup created for %s", scene_path)
         else:
             self._backup_status = "Backup skipped: no changes detected."
+            log.info("Backup skipped: no changes detected.")
 
     def _configure_dialog_for_scene(self) -> None:
         self._scene_asset = self._resolve_scene_asset()
@@ -301,6 +317,7 @@ class AssetPublisher(Publisher):
             "Please select the asset to publish.",
             "Asset Selection Required",
         ).exec_()
+        log.warning("Asset metadata missing; falling back to asset picker dialog.")
 
     @staticmethod
     def _compute_component_basename(
@@ -548,6 +565,7 @@ class AssetPublisher(Publisher):
                 self._run_backup(asset)
             else:
                 self._backup_status = "Backup skipped: asset could not be resolved."
+                log.warning("Backup skipped: asset could not be resolved.")
 
             MessageDialog(
                 self._window,

--- a/pipeline/pipe/m/publish/asset.py
+++ b/pipeline/pipe/m/publish/asset.py
@@ -81,7 +81,8 @@ class _PublishAssetVariantControls:
         self._geo_var_dropdown.setValidator(geo_var_validator)
         geo_var_settings_layout.addWidget(self._geo_var_dropdown, 70)
         geo_var_layout.addWidget(geo_var_settings_widget, 90)
-        self._layout.addWidget(geo_var_widget)  # type: ignore[attr-defined]
+        insert_at = max(self._layout.count() - 1, 0)  # type: ignore[attr-defined]
+        self._layout.insertWidget(insert_at, geo_var_widget)  # type: ignore[attr-defined]
 
     def get_selected_variant(self) -> str:
         return self._geo_var_dropdown.currentText()
@@ -130,7 +131,8 @@ class PublishAssetOptionsDialog(FilteredListDialog, _PublishAssetVariantControls
 
         self._init_variant_controls()
 
-        self._layout.addStretch(1)
+        insert_at = max(self._layout.count() - 1, 0)
+        self._layout.insertStretch(insert_at, 1)
         asset = None
         if self._conn and self._selected_asset_name:
             asset = self._conn.get_asset_by_display_name(self._selected_asset_name)
@@ -160,7 +162,8 @@ class PublishAssetPickerDialog(FilteredListDialog, _PublishAssetVariantControls)
         self.resize(520, 520)
         self._init_variant_controls()
         self._populate_geo_var(None)
-        self._layout.addStretch(1)
+        insert_at = max(self._layout.count() - 1, 0)
+        self._layout.insertStretch(insert_at, 1)
 
     def _on_item_selected(self) -> None:
         selected = self.get_selected_item()

--- a/pipeline/pipe/m/publish/asset.py
+++ b/pipeline/pipe/m/publish/asset.py
@@ -13,7 +13,7 @@ import maya.cmds as mc
 from env import Executables
 from Qt.QtCore import QRegExp
 from Qt.QtGui import QRegExpValidator, QTextCursor
-from Qt.QtWidgets import QComboBox, QHBoxLayout, QLabel, QWidget
+from Qt.QtWidgets import QComboBox, QDialogButtonBox, QHBoxLayout, QLabel, QWidget
 from shared.util import get_pipe_path
 from software.houdini.dcc import HoudiniDCC
 
@@ -68,6 +68,7 @@ class _PublishAssetVariantControls:
         geo_var_settings_widget = QWidget()
         geo_var_settings_layout = QHBoxLayout(geo_var_settings_widget)
         geo_var_label = QLabel("Geometry Variant:")
+        geo_var_label.setToolTip("Choose the geometry variant to publish.")
         geo_var_settings_layout.addWidget(geo_var_label, 30)
 
         self._geo_var_dropdown = QComboBox()
@@ -138,6 +139,13 @@ class PublishAssetOptionsDialog(FilteredListDialog, _PublishAssetVariantControls
             asset = self._conn.get_asset_by_display_name(self._selected_asset_name)
         self._populate_geo_var(asset)
 
+        ok_btn = self.buttons.button(QDialogButtonBox.Ok)
+        if ok_btn:
+            ok_btn.setToolTip("Publish the selected geometry variant.")
+        cancel_btn = self.buttons.button(QDialogButtonBox.Cancel)
+        if cancel_btn:
+            cancel_btn.setToolTip("Cancel publishing and close this window.")
+
     def get_selected_item(self) -> str | None:
         return self._selected_asset_name
 
@@ -160,10 +168,20 @@ class PublishAssetPickerDialog(FilteredListDialog, _PublishAssetVariantControls)
         )
         self._conn = conn
         self.resize(520, 520)
+        if hasattr(self, "_filter_field"):
+            self._filter_field.setToolTip("Type to filter the asset list.")
+        self._list_widget.setToolTip("Select the asset to publish.")
         self._init_variant_controls()
         self._populate_geo_var(None)
         insert_at = max(self._layout.count() - 1, 0)
         self._layout.insertStretch(insert_at, 1)
+
+        ok_btn = self.buttons.button(QDialogButtonBox.Ok)
+        if ok_btn:
+            ok_btn.setToolTip("Publish the selected asset and variant.")
+        cancel_btn = self.buttons.button(QDialogButtonBox.Cancel)
+        if cancel_btn:
+            cancel_btn.setToolTip("Cancel publishing and close this window.")
 
     def _on_item_selected(self) -> None:
         selected = self.get_selected_item()

--- a/pipeline/pipe/m/publish/previs_asset.py
+++ b/pipeline/pipe/m/publish/previs_asset.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Optional, cast
 import maya.api.OpenMaya as om
 import maya.cmds as cmds
 from pxr import Gf, Sdf, Usd, UsdGeom, Vt
-from Qt.QtWidgets import QCheckBox, QWidget
+from Qt.QtWidgets import QWidget
 
 from pipe.db import DB
 
@@ -25,9 +25,6 @@ log = logging.getLogger(__name__)
 
 
 class PublishPrevisAssetDialog(FilteredListDialog):
-    _substance_only: QCheckBox
-    _geo_var_widget: QWidget
-
     def __init__(
         self, parent: QWidget | None, items: Sequence[str], conn: Optional[DB]
     ) -> None:

--- a/pipeline/pipe/m/publish/publisher.py
+++ b/pipeline/pipe/m/publish/publisher.py
@@ -120,14 +120,18 @@ class Publisher:
                 return
 
             if entity_list := self._get_entity_list():
-                from pipe.m.publish.asset import PublishAssetDialog
+                from pipe.m.publish.asset import (
+                    PublishAssetOptionsDialog,
+                    PublishAssetPickerDialog,
+                )
                 from pipe.m.publish.previs_asset import PublishPrevisAssetDialog
 
-                if (
-                    self._dialog_T == PublishAssetDialog
-                    or self._dialog_T == PublishPrevisAssetDialog
+                if self._dialog_T in (
+                    PublishAssetOptionsDialog,
+                    PublishAssetPickerDialog,
+                    PublishPrevisAssetDialog,
                 ):
-                    # Pass extra parameter (conn) if it's PublishAssetDialog
+                    # Pass extra parameter (conn) if dialog needs DB access
                     self._dialog = self._dialog_T(self._window, entity_list, self._conn)
                 else:
                     # Otherwise, use the dialog normally

--- a/pipeline/software/maya/shelves/shelf_Bobo_Assets.mel
+++ b/pipeline/software/maya/shelves/shelf_Bobo_Assets.mel
@@ -99,8 +99,8 @@ global proc shelf_Bobo_Assets () {
         -imageOverlayLabel "Publish Asset"
         -overlayLabelColor 2.624876 0.801436 0.012446
         -overlayLabelBackColor 0.227129 0.227129 0.227129 0.5
-        -image "createContainer.png"
-        -image1 "createContainer.png"
+        -image "envelope.png"
+        -image1 "envelope.png"
         -style "iconOnly"
         -marginWidth 0
         -marginHeight 1


### PR DESCRIPTION
Oh yea. Its all coming together.

Publishing a model now creates a backup. This means any publish can be reverted to. USD files are artifacts of the maya modeling files, so we dont need to version the USD files. I kinda went ham on adding robust file signature metadata. This did involve embedding information in the asset files similar to shotfiles.

This pull request also tightens up the UX. Publish no longer asks what asset you want to publish. Because maya files are pipe owned, it now works more like the anim publish.

I did remove the "substance only" export. I need to iron out the details on what to replace it with. But I dont think the maya publish tool was the correct space for it. Will work with team leads to refine that in the future.

Oh also maya files are binary by default. Not sure why I made them binary. Maybe for future git support? But I dont plan on using git so uh

Anyways will still be working in this branch for a bit, still gotta add this support to the other DCCs.

Might add other ways to version without publishing but uh that'll be based on what the artists say