### PR TITLE
Shot paths

### DIFF
--- a/pipeline/pipe/db/sgaadb.py
+++ b/pipeline/pipe/db/sgaadb.py
@@ -21,6 +21,7 @@ from pipe.struct.db import (
     User,
     Version,
     build_asset_path,
+    build_shot_path,
     normalize_display_name,
 )
 
@@ -168,6 +169,25 @@ class SGaaDB(DBInterface):
             return self._normalize_relative_path(legacy_path) == target_path
         return False
 
+    @staticmethod
+    def _canonical_shot_path_from_sg(shot: dict) -> str:
+        return build_shot_path(shot.get("code"))
+
+    def _shot_matches_path(self, shot: dict, target_path: str) -> bool:
+        try:
+            canonical = self._normalize_relative_path(
+                self._canonical_shot_path_from_sg(shot)
+            )
+        except ValueError as exc:
+            log.error(
+                "Invalid shot code in ShotGrid (id=%s code=%r): %s",
+                shot.get("id"),
+                shot.get("code"),
+                exc,
+            )
+            return False
+        return canonical == target_path
+
     def _load_sg_user_list(self) -> None:
         """Load the list of assets from SG to local cache"""
         with self._cache_lock:
@@ -206,6 +226,15 @@ class SGaaDB(DBInterface):
                     e
                     for e in self._sg_entity_lists[Asset.__name__]
                     if self._asset_matches_path(e, target)
+                )
+            )
+        if entity_type is Shot and attr == "path":
+            target = self._normalize_relative_path(str(attr_val))
+            return Shot.from_sg(
+                next(
+                    e
+                    for e in self._sg_entity_lists[Shot.__name__]
+                    if self._shot_matches_path(e, target)
                 )
             )
 
@@ -291,6 +320,23 @@ class SGaaDB(DBInterface):
             arr = [
                 self._canonical_asset_path_from_sg(asset) for asset in filtered_assets
             ]
+            if sorted:
+                arr.sort()
+            return arr
+        if entity_type is Shot and attr == "path":
+            arr: list[str] = []
+            for shot in self._sg_entity_lists[Shot.__name__]:
+                if not shot.get("code"):
+                    continue
+                try:
+                    arr.append(self._canonical_shot_path_from_sg(shot))
+                except ValueError as exc:
+                    log.error(
+                        "Invalid shot code in ShotGrid (id=%s code=%r): %s",
+                        shot.get("id"),
+                        shot.get("code"),
+                        exc,
+                    )
             if sorted:
                 arr.sort()
             return arr

--- a/pipeline/pipe/db/sgaadb.py
+++ b/pipeline/pipe/db/sgaadb.py
@@ -703,7 +703,6 @@ class _ShotListQuery(_Query):
             "sg_cut_in",
             "sg_cut_out",
             "sg_cut_duration",
-            "sg_path",
             "sg_sequence",
             "sg_set",
             "sg_sets",

--- a/pipeline/pipe/h/animpostprocess.py
+++ b/pipeline/pipe/h/animpostprocess.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-import hou
-
 from typing import TYPE_CHECKING
 
-from pipe.db import DB
+import hou
 from env_sg import DB_Config
+
+from pipe.db import DB
 
 if TYPE_CHECKING:
     pass
@@ -20,6 +20,7 @@ class AnimPostProcessor:
     def run(self, shot_code: str) -> None:
         # Set up
         shot = self._conn.get_shot_by_code(shot_code)
+        shot_path = shot.shot_path
         hou.playbar.setFrameRange(shot.cut_in - 5, shot.cut_out + 5)
         hou.playbar.setPlaybackRange(shot.cut_in - 5, shot.cut_out + 5)
 
@@ -33,7 +34,7 @@ class AnimPostProcessor:
                 load_layer = stage_ctx.createNode(
                     "dbclark::main::Bobo_Load_Layers::1.0"
                 )
-                load_layer.parm("shot").set(f"$JOB/{shot.path}")  # type: ignore[union-attr]
+                load_layer.parm("shot").set(f"$JOB/{shot_path}")  # type: ignore[union-attr]
                 for dep in ["cfx", "fx", "envfx", "flo", "lighting", "render"]:
                     load_layer.parm(f"{dep}_enable").set(0)  # type: ignore[union-attr]
                 if layout and layout.path:
@@ -44,7 +45,7 @@ class AnimPostProcessor:
             env_stub = shot.set or self._conn.get_sequence_by_stub(shot.sequence).set  # type: ignore[assignment, arg-type]
             layout = self._conn.get_env_by_stub(env_stub)
             load_layer = stage_ctx.createNode("dbclark::main::Bobo_Load_Layers::1.0")
-            load_layer.parm("shot").set(f"$JOB/{shot.path}")  # type: ignore[union-attr]
+            load_layer.parm("shot").set(f"$JOB/{shot_path}")  # type: ignore[union-attr]
             for dep in ["cfx", "fx", "envfx", "flo" "lighting", "render"]:
                 load_layer.parm(f"{dep}_enable").set(0)  # type: ignore[union-attr]
             if layout and layout.path:
@@ -68,7 +69,7 @@ class AnimPostProcessor:
 
         publish = stage_ctx.createNode("usd_rop")
         publish.parm("trange").set("normal")  # type: ignore[union-attr]
-        publish.parm("lopoutput").set(f"$JOB/{shot.path}/anim/usd/post-process.usd")  # type: ignore[union-attr]
+        publish.parm("lopoutput").set(f"$JOB/{shot_path}/anim/usd/post-process.usd")  # type: ignore[union-attr]
         publish.parm("savestyle").set("flattenalllayers")  # type: ignore[union-attr]
         publish.setInput(0, postprocess)
 

--- a/pipeline/pipe/h/hipfile/shot.py
+++ b/pipeline/pipe/h/hipfile/shot.py
@@ -304,8 +304,7 @@ class HShotFileManager(HFileManager):
         return stage
 
     def _set_shot_context(self, shot: Shot) -> None:
-        if shot.path:
-            hou.setContextOption("SHOT", shot.path)
+        hou.setContextOption("SHOT", shot.shot_path)
 
     def _set_playbar_ranges(self, shot: Shot) -> None:
         start = shot.cut_in - 5

--- a/pipeline/pipe/m/publish/anim.py
+++ b/pipeline/pipe/m/publish/anim.py
@@ -70,9 +70,7 @@ class AnimPublisher(Publisher):
         return True
 
     def _get_save_path(self) -> Path | None:
-        if not self._shot.path:
-            return None
-        return get_production_path() / self._shot.path / "anim/usd/main.usd"
+        return get_production_path() / self._shot.shot_path / "anim/usd/main.usd"
 
     def _presave(self) -> bool:
         return True

--- a/pipeline/pipe/m/publish/camera.py
+++ b/pipeline/pipe/m/publish/camera.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 import maya.cmds as mc
 from shared.util import get_production_path
 
-from pipe.glui.dialogs import FilteredListDialog, MessageDialog
+from pipe.glui.dialogs import FilteredListDialog
 from pipe.struct.db import SGEntity, Shot
 
 from .publisher import Publisher
@@ -64,18 +64,8 @@ class CameraPublisher(Publisher):
         return self._conn.get_shot_by_code(display_name)
 
     def _get_save_path(self) -> Path | None:
-        try:
-            assert self._entity.path is not None
-        except AssertionError:
-            error = MessageDialog(
-                self._window,
-                "Error: No path for this Shot set in ShotGrid. Nothing exported",
-                "Error",
-            )
-            error.exec_()
-            return None
-
-        return get_production_path() / self._entity.path / "cam" / "cam.usd"
+        shot = cast(Shot, self._entity)
+        return get_production_path() / shot.shot_path / "cam" / "cam.usd"
 
     def _presave(self) -> bool:
         mc.select(self._camera, replace=True)

--- a/pipeline/pipe/m/publish/customanim.py
+++ b/pipeline/pipe/m/publish/customanim.py
@@ -80,9 +80,9 @@ class AnimPublisher(Publisher):
 
     def _get_save_path(self) -> Path | None:
         rig_name = self._rig_root.split("|")[-1]  # get the short name
-        if not self._shot.path:
-            return None
-        save_path = get_production_path() / self._shot.path / f"rigs/usd/{rig_name}.usd"
+        save_path = (
+            get_production_path() / self._shot.shot_path / f"rigs/usd/{rig_name}.usd"
+        )
         return save_path
 
     def _presave(self) -> bool:

--- a/pipeline/pipe/m/shotfile/shotfile_manager.py
+++ b/pipeline/pipe/m/shotfile/shotfile_manager.py
@@ -344,13 +344,13 @@ class MShotFileManager(FileManager):
         self.run_on_open()
 
     def _import_camera(self) -> None:
-        assert self.shot.path is not None
+        shot_path = self.shot.shot_path
         root_layer = self.get_stage().GetRootLayer()
 
         # mc.mayaUsdLayerEditor(cam_layer.identifier, edit=True, lockLayer=(2, 0, stageShape))
 
         cam_file_layer = Sdf.Layer.FindOrOpenRelativeToLayer(
-            root_layer, "/".join((self.shot.path, "cam", "cam.usd"))
+            root_layer, "/".join((shot_path, "cam", "cam.usd"))
         )
         if not cam_file_layer:
             mc.warning("No exported camera found")
@@ -360,7 +360,7 @@ class MShotFileManager(FileManager):
             root_layer.subLayerPaths.append(cam_file_layer.identifier)
 
     def _import_env(self) -> None:
-        assert self.shot.path is not None
+        shot_path = self.shot.shot_path
         stage = self.get_stage()
         root_layer = stage.GetRootLayer()
         # locked_layers: list[str] = []
@@ -376,11 +376,11 @@ class MShotFileManager(FileManager):
         # Set up shot-level overrides
         env_override_layer = Sdf.Layer.FindOrOpenRelativeToLayer(
             root_layer,
-            "/".join((self.shot.path, "set", MShotFileManager.MAYA_OVERRIDE)),
+            "/".join((shot_path, "set", MShotFileManager.MAYA_OVERRIDE)),
         ) or Sdf.Layer.CreateNew(
             str(
                 get_production_path()
-                / self.shot.path
+                / shot_path
                 / "set"
                 / MShotFileManager.MAYA_OVERRIDE
             )
@@ -451,7 +451,7 @@ class MShotFileManager(FileManager):
         mc.file(rename=str(path))
 
         self.shot = cast(Shot, entity)
-        assert self.shot.path is not None
+        shot_path = self.shot.shot_path
 
         # Create USD Stage
         transform = mc.createNode("transform", name="stage_transform")
@@ -460,7 +460,7 @@ class MShotFileManager(FileManager):
         mc.connectAttr("time1.outTime", f"{stage_shape}.time")
 
         ROOT_LAYER = "maya_root.usd"
-        root_layer_path = str(get_production_path() / self.shot.path / ROOT_LAYER)
+        root_layer_path = str(get_production_path() / shot_path / ROOT_LAYER)
         root_layer = Sdf.Layer.FindOrOpen(root_layer_path) or Sdf.Layer.CreateNew(
             root_layer_path
         )

--- a/pipeline/pipe/m/shotfile/shotfile_manager.py
+++ b/pipeline/pipe/m/shotfile/shotfile_manager.py
@@ -15,7 +15,7 @@ from timeline_marker.ui import TimelineMarker  # type: ignore[import-not-found]
 
 from pipe.db import DB
 from pipe.m.local import get_main_qt_window
-from pipe.struct.db import SGEntity, Shot
+from pipe.struct.db import SGEntity, Shot, build_shot_path, validate_shot_code_token
 from pipe.util import FileManager, log_errors
 
 from .timeline import shot_timeline_generator
@@ -52,17 +52,35 @@ class MShotFileManager(FileManager):
 
     @classmethod
     def _shot_code_from_scene_path(cls, scene_path: Optional[str]) -> Optional[str]:
+        """Resolve shot code from a scene path using canonical shot folder semantics.
+
+        Preferred source is the directory token immediately after `shot/`.
+        Falls back to the scene filename stem for legacy/non-canonical paths.
+        """
         if not scene_path:
             return None
         path = Path(scene_path)
         try:
             shot_index = path.parts.index("shot")
             if shot_index + 1 < len(path.parts):
-                return path.parts[shot_index + 1]
+                try:
+                    return validate_shot_code_token(path.parts[shot_index + 1])
+                except ValueError:
+                    log.warning("Invalid shot token in scene path: %s", scene_path)
         except ValueError:
             pass
         stem = path.stem
-        return stem.split(".")[0] if stem else None
+        if not stem:
+            return None
+        try:
+            return validate_shot_code_token(stem.split(".")[0])
+        except ValueError:
+            return None
+
+    @classmethod
+    def _edit_target_path_for_shot(cls, shot_code: str) -> str:
+        """Return canonical edit target path for a shot override layer."""
+        return "/".join((build_shot_path(shot_code), "set", cls.MAYA_OVERRIDE))
 
     @classmethod
     def _path_has_layout_name(cls, path: str, layout_name: str) -> bool:
@@ -282,7 +300,7 @@ class MShotFileManager(FileManager):
             mc.mayaUsdEditTarget(  # type: ignore[attr-defined]
                 cls.get_stage_shape(),
                 edit=True,
-                editTarget="/".join(["shot", shot_code, "set", cls.MAYA_OVERRIDE]),
+                editTarget=cls._edit_target_path_for_shot(shot_code),
             )
 
             conn = DB.Get(DB_Config)

--- a/pipeline/pipe/struct/db.py
+++ b/pipeline/pipe/struct/db.py
@@ -365,6 +365,11 @@ class Shot(SGEntity):
         },
     )
 
+    @property
+    def shot_path(self) -> str:
+        """Canonical relative path for this shot: shot/<shot_code>."""
+        return build_shot_path(self.code)
+
 
 @attrs.frozen
 class UserStub(SGEntityStub):

--- a/pipeline/pipe/struct/db.py
+++ b/pipeline/pipe/struct/db.py
@@ -369,6 +369,17 @@ class Shot(SGEntity):
         self.path = build_shot_path(self.code)
         super().__attrs_post_init__()
 
+    def sg_diff(self) -> dict[str, Any]:
+        """Return only ShotGrid fields that should be updated for Shot.
+
+        Shot path is derived from shot code and should never write to sg_path.
+        """
+        self.path = build_shot_path(self.code)
+        diff = super().sg_diff()
+        diff.pop("path", None)
+        diff.pop("sg_path", None)
+        return diff
+
 
 @attrs.frozen
 class UserStub(SGEntityStub):

--- a/pipeline/pipe/struct/db.py
+++ b/pipeline/pipe/struct/db.py
@@ -80,6 +80,35 @@ def build_asset_path(display_name: Optional[str], subdirectory: Optional[str]) -
     return "/".join(path_parts)
 
 
+def validate_shot_code_token(shot_code: Optional[str]) -> str:
+    """Validate a shot code for safe use as a single path token.
+
+    Rules:
+    - required (must be non-empty after trimming whitespace)
+    - must not be "." or ".."
+    - must not contain path separators ("/" or "\\")
+    """
+    if shot_code is None:
+        raise ValueError("Shot code is required")
+
+    token = str(shot_code).strip()
+    if not token:
+        raise ValueError("Shot code cannot be empty")
+    if token in {".", ".."}:
+        raise ValueError("Shot code cannot be '.' or '..'")
+    if "/" in token or "\\" in token:
+        raise ValueError(
+            "Shot code must be a single folder name without path separators"
+        )
+
+    return token
+
+
+def build_shot_path(shot_code: Optional[str]) -> str:
+    """Build the canonical relative shot path: shot/<shot_code>."""
+    return "/".join(("shot", validate_shot_code_token(shot_code)))
+
+
 def _split_csv_set(value: Optional[str]) -> set[str]:
     """Parse a comma-separated ShotGrid string into normalized variant tokens."""
     if not value:

--- a/pipeline/pipe/struct/db.py
+++ b/pipeline/pipe/struct/db.py
@@ -365,10 +365,9 @@ class Shot(SGEntity):
         },
     )
 
-    @property
-    def shot_path(self) -> str:
-        """Canonical relative path for this shot: shot/<shot_code>."""
-        return build_shot_path(self.code)
+    def __attrs_post_init__(self) -> None:
+        self.path = build_shot_path(self.code)
+        super().__attrs_post_init__()
 
 
 @attrs.frozen

--- a/pipeline/pipe/struct/db.py
+++ b/pipeline/pipe/struct/db.py
@@ -365,8 +365,13 @@ class Shot(SGEntity):
         },
     )
 
+    @property
+    def shot_path(self) -> str:
+        """Canonical relative path for this shot: shot/<shot_code>."""
+        return build_shot_path(self.code)
+
     def __attrs_post_init__(self) -> None:
-        self.path = build_shot_path(self.code)
+        self.path = self.shot_path
         super().__attrs_post_init__()
 
     def sg_diff(self) -> dict[str, Any]:
@@ -374,7 +379,7 @@ class Shot(SGEntity):
 
         Shot path is derived from shot code and should never write to sg_path.
         """
-        self.path = build_shot_path(self.code)
+        self.path = self.shot_path
         diff = super().sg_diff()
         diff.pop("path", None)
         diff.pop("sg_path", None)


### PR DESCRIPTION
Bobo has had a whole lotta renaming issues with typos and other pain points. I am removing the reliance on shotgrid for paths in favor of canonicalizing `<production_path>/shot/<shot_code>`. Yes, this means you cant have per sequence folders, or `test` folders for things like character turnarounds or whatnot. But sorting by names and prefixing tests with Z (which they decided to do without my feedback) is sufficient and more robust against user error