### PR TITLE
Playblast 2 electric boogaloo

### DIFF
--- a/pipeline/pipe/db/interface.py
+++ b/pipeline/pipe/db/interface.py
@@ -19,6 +19,7 @@ from pipe.struct.db import (
     SGEntityStub,
     Shot,
     ShotStub,
+    Task,
     User,
 )
 
@@ -215,6 +216,21 @@ class DBInterface(metaclass=ABCMeta):
     @abstractmethod
     def update_asset(self, asset: Asset) -> bool:
         """Update an asset in the DB"""
+        raise NotImplementedError
+
+    @abstractmethod
+    def create_version_for_shot(
+        self,
+        shot: Shot | ShotStub | dict[str, typing.Any] | int,
+        code: str,
+        user: User | dict[str, typing.Any] | int | None = None,
+        task: Task | dict[str, typing.Any] | int | None = None,
+        video_path: str | None = None,
+        description: str | None = None,
+        playlist_id: int | None = None,
+        extra_fields: dict[str, typing.Any] | None = None,
+    ) -> dict[str, typing.Any]:
+        """Create a ShotGrid Version for a shot with optional links."""
         raise NotImplementedError
 
     @abstractmethod

--- a/pipeline/pipe/db/sgaadb.py
+++ b/pipeline/pipe/db/sgaadb.py
@@ -19,7 +19,6 @@ from pipe.struct.db import (
     ShotStub,
     Task,
     User,
-    Version,
     build_asset_path,
     build_shot_path,
     normalize_display_name,
@@ -450,33 +449,111 @@ class SGaaDB(DBInterface):
 
     def create_version_for_shot(
         self,
-        shot: ShotStub,
+        shot: ShotStub | dict[str, Any] | int,
         code: str,
-        user: User,
-        task: Task,
+        user: User | dict[str, Any] | int | None = None,
+        task: Task | dict[str, Any] | int | None = None,
         video_path: Optional[str] = None,
         description: Optional[str] = None,
         playlist_id: Optional[int] = None,
+        extra_fields: Optional[dict[str, Any]] = None,
     ) -> dict[Any, Any]:
-        # Create Version instance
-        version = Version(
-            id=-1,
-            code=code,
-            shot=shot,
-            video_path=video_path,
-            user=user,
-            description=description,
-            task=task,
-        )
+        """Create a ShotGrid Version linked to a shot.
 
-        # Push to ShotGrid
-        sg_dict = version.to_sg(exclude=["id"])
-        sg_dict["project"] = {"type": "Project", "id": self._id}
-        sg_dict["playlists"] = [{"type": "Playlist", "id": playlist_id}]
-        new_version = self._sg.create("Version", sg_dict)
+        `code` and `shot` are required. `user`, `task`, and `playlist_id`
+        are optional and only included when valid ids are provided.
+        `extra_fields` can provide additional ShotGrid Version fields.
+        """
 
-        # Return structured object
-        return new_version
+        version_code = str(code).strip()
+        if not version_code:
+            raise ValueError("Version code is required.")
+
+        shot_ref = self._entity_ref("Shot", shot)
+        if shot_ref is None:
+            raise ValueError("A valid shot (with id) is required.")
+
+        version_payload: dict[str, Any] = {
+            "code": version_code,
+            "entity": shot_ref,
+            "project": {"type": "Project", "id": self._id},
+        }
+
+        normalized_video_path = str(video_path).strip() if video_path else ""
+        if normalized_video_path:
+            version_payload["sg_path_to_frames"] = normalized_video_path
+
+        normalized_description = str(description).strip() if description else ""
+        if normalized_description:
+            version_payload["description"] = normalized_description
+
+        user_ref = self._entity_ref("HumanUser", user)
+        if user_ref is not None:
+            version_payload["user"] = user_ref
+
+        task_ref = self._entity_ref("Task", task)
+        if task_ref is not None:
+            version_payload["sg_task"] = task_ref
+
+        playlist_ref = self._entity_ref("Playlist", playlist_id)
+        if playlist_ref is not None:
+            version_payload["playlists"] = [playlist_ref]
+
+        self._apply_extra_version_fields(version_payload, extra_fields)
+        return self._sg.create("Version", version_payload)
+
+    @staticmethod
+    def _entity_ref(entity_type: str, entity: Any) -> dict[str, int] | None:
+        entity_id = SGaaDB._extract_entity_id(entity)
+        if entity_id is None:
+            return None
+        return {"type": entity_type, "id": entity_id}
+
+    @staticmethod
+    def _extract_entity_id(entity: Any) -> int | None:
+        if entity is None:
+            return None
+
+        if isinstance(entity, int):
+            return entity if entity > 0 else None
+
+        if isinstance(entity, str):
+            token = entity.strip()
+            if not token:
+                return None
+            try:
+                parsed = int(token)
+            except ValueError:
+                return None
+            return parsed if parsed > 0 else None
+
+        if isinstance(entity, dict):
+            raw_id = entity.get("id")
+            return raw_id if isinstance(raw_id, int) and raw_id > 0 else None
+
+        raw_id = getattr(entity, "id", None)
+        return raw_id if isinstance(raw_id, int) and raw_id > 0 else None
+
+    def _apply_extra_version_fields(
+        self,
+        version_payload: dict[str, Any],
+        extra_fields: Optional[dict[str, Any]],
+    ) -> None:
+        if not extra_fields:
+            return
+
+        reserved_fields = {"code", "entity", "project"}
+        for raw_field_name, value in extra_fields.items():
+            field_name = str(raw_field_name).strip()
+            if not field_name or value is None:
+                continue
+            if field_name in reserved_fields:
+                log.warning(
+                    "Ignoring extra Version field '%s' because it is reserved.",
+                    field_name,
+                )
+                continue
+            version_payload[field_name] = value
 
     def upload_version_movie(self, version_id, path_to_file, field="sg_uploaded_movie"):
         display_name = os.path.basename(path_to_file)

--- a/pipeline/pipe/db/sgaadb.py
+++ b/pipeline/pipe/db/sgaadb.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import threading
+import urllib.request
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from dataclasses import dataclass
@@ -70,8 +71,15 @@ class SGaaDB(DBInterface):
             return cls._conn_instances[config]
 
     def __init__(self, config: SG_Config) -> None:
+        self._apply_houdini_shotgrid_upload_runtime_patch()
+        ca_certs_path = self._resolve_shotgrid_ca_bundle_for_current_dcc()
+        if ca_certs_path:
+            log.info("ShotGrid CA bundle selected: %s", ca_certs_path)
         self._sg = shotgun_api3.Shotgun(
-            config.sg_server, config.sg_script, config.sg_key
+            config.sg_server,
+            config.sg_script,
+            config.sg_key,
+            ca_certs=ca_certs_path,
         )
         self._id = config.project_id
 
@@ -89,6 +97,108 @@ class SGaaDB(DBInterface):
             target=self._threaded_updater, daemon=True
         )
         self._update_thread.start()
+
+    @staticmethod
+    def _is_houdini_runtime() -> bool:
+        return os.environ.get("DCC", "").strip().lower() == "houdini"
+
+    @classmethod
+    def _apply_houdini_shotgrid_upload_runtime_patch(cls) -> None:
+        """Apply a Houdini-only runtime fix for ShotGrid API upload HTTPS classes.
+
+        We intentionally keep the vendored `shotgun_api3` source unmodified and
+        patch the legacy upload HTTPS classes at runtime from our DB wrapper.
+        """
+        if not cls._is_houdini_runtime():
+            return
+
+        from .shotgun_api3 import shotgun as shotgun_module
+
+        existing_handler_class = shotgun_module.CACertsHTTPSHandler
+        existing_connection_class = shotgun_module.CACertsHTTPSConnection
+
+        handler_already_fixed = issubclass(
+            existing_handler_class,
+            urllib.request.HTTPSHandler,
+        )
+        connection_init_fixed = (
+            existing_connection_class.__init__.__qualname__
+            == "_PipelineCACertsHTTPSConnection.__init__"
+        )
+
+        if handler_already_fixed and connection_init_fixed:
+            return
+
+        import http.client
+        import ssl
+
+        class _PipelineCACertsHTTPSConnection(http.client.HTTPConnection):
+            """Drop-in replacement with Python 3.11-compatible super() usage."""
+
+            default_port = http.client.HTTPS_PORT
+
+            def __init__(self, *args, **kwargs):
+                self.__ca_certs = kwargs.pop("ca_certs")
+                super().__init__(*args, **kwargs)
+
+            def connect(self):
+                super().connect()
+                if shotgun_module.six.PY38:
+                    context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+                    context.verify_mode = ssl.CERT_REQUIRED
+                    context.check_hostname = False
+                    if self.__ca_certs:
+                        context.load_verify_locations(self.__ca_certs)
+                    self.sock = context.wrap_socket(self.sock)
+                else:
+                    self.sock = ssl.wrap_socket(
+                        self.sock,
+                        ca_certs=self.__ca_certs,
+                        cert_reqs=ssl.CERT_REQUIRED,
+                    )
+
+        class _PipelineCACertsHTTPSHandler(urllib.request.HTTPSHandler):
+            """HTTPS opener that routes upload requests through custom CA certs."""
+
+            def __init__(self, ca_certs):
+                super().__init__()
+                self.__ca_certs = ca_certs
+
+            def https_open(self, req):
+                return self.do_open(self.create_https_connection, req)
+
+            def create_https_connection(self, *args, **kwargs):
+                return _PipelineCACertsHTTPSConnection(
+                    *args,
+                    ca_certs=self.__ca_certs,
+                    **kwargs,
+                )
+
+        shotgun_module.CACertsHTTPSConnection = _PipelineCACertsHTTPSConnection
+        shotgun_module.CACertsHTTPSHandler = _PipelineCACertsHTTPSHandler
+        log.info("Applied Houdini ShotGrid upload HTTPS runtime compatibility patch.")
+
+    @staticmethod
+    def _resolve_shotgrid_ca_bundle_for_current_dcc() -> str | None:
+        """Resolve CA bundle path for DCCs that need explicit TLS trust config."""
+        if not SGaaDB._is_houdini_runtime():
+            return None
+
+        explicit_path = os.environ.get("SHOTGUN_API_CACERTS", "").strip()
+        if explicit_path:
+            return explicit_path if os.path.isfile(explicit_path) else None
+
+        system_ca_bundle_candidates = (
+            "/etc/ssl/certs/ca-certificates.crt",
+            "/etc/pki/tls/certs/ca-bundle.crt",
+            "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem",
+            "/etc/ssl/cert.pem",
+            "/etc/ssl/certs/ca-bundle.crt",
+        )
+        for candidate_path in system_ca_bundle_candidates:
+            if os.path.isfile(candidate_path):
+                return candidate_path
+        return None
 
     def _threaded_updater(self) -> None:
         while True:

--- a/pipeline/pipe/db/sgaadb.py
+++ b/pipeline/pipe/db/sgaadb.py
@@ -114,19 +114,7 @@ class SGaaDB(DBInterface):
 
         from .shotgun_api3 import shotgun as shotgun_module
 
-        existing_handler_class = shotgun_module.CACertsHTTPSHandler
-        existing_connection_class = shotgun_module.CACertsHTTPSConnection
-
-        handler_already_fixed = issubclass(
-            existing_handler_class,
-            urllib.request.HTTPSHandler,
-        )
-        connection_init_fixed = (
-            existing_connection_class.__init__.__qualname__
-            == "_PipelineCACertsHTTPSConnection.__init__"
-        )
-
-        if handler_already_fixed and connection_init_fixed:
+        if getattr(shotgun_module, "_PIPELINE_HOUDINI_UPLOAD_PATCHED", False):
             return
 
         import http.client
@@ -176,6 +164,7 @@ class SGaaDB(DBInterface):
 
         shotgun_module.CACertsHTTPSConnection = _PipelineCACertsHTTPSConnection
         shotgun_module.CACertsHTTPSHandler = _PipelineCACertsHTTPSHandler
+        shotgun_module._PIPELINE_HOUDINI_UPLOAD_PATCHED = True
         log.info("Applied Houdini ShotGrid upload HTTPS runtime compatibility patch.")
 
     @staticmethod
@@ -186,7 +175,12 @@ class SGaaDB(DBInterface):
 
         explicit_path = os.environ.get("SHOTGUN_API_CACERTS", "").strip()
         if explicit_path:
-            return explicit_path if os.path.isfile(explicit_path) else None
+            if os.path.isfile(explicit_path):
+                return explicit_path
+            log.warning(
+                "SHOTGUN_API_CACERTS is set but file does not exist: %s",
+                explicit_path,
+            )
 
         system_ca_bundle_candidates = (
             "/etc/ssl/certs/ca-certificates.crt",
@@ -198,6 +192,10 @@ class SGaaDB(DBInterface):
         for candidate_path in system_ca_bundle_candidates:
             if os.path.isfile(candidate_path):
                 return candidate_path
+
+        log.warning(
+            "No system CA bundle candidate was found for Houdini ShotGrid uploads."
+        )
         return None
 
     def _threaded_updater(self) -> None:
@@ -695,7 +693,6 @@ class SGaaDB(DBInterface):
         ]
 
         raw_tasks = self._sg.find("Task", filters, fields)
-        print(raw_tasks)
         return [Task.from_sg(task) for task in raw_tasks]
 
     def get_asset_display_name_list_by_type(

--- a/pipeline/pipe/h/playblast/paths.py
+++ b/pipeline/pipe/h/playblast/paths.py
@@ -5,10 +5,43 @@ from pathlib import Path
 
 from shared.util import get_edit_path
 
+from pipe.playblast_naming import (
+    playblast_date_folder,
+    resolve_versioned_playblast_basename,
+)
 
-def _build_base_name(shot_code: str, timestamp: datetime) -> str:
-    timestamp_str = timestamp.strftime("%m-%d-%Y_%H-%M")
-    return f"{shot_code}_{timestamp_str}"
+
+def build_edit_output_directory(
+    department: str, timestamp: datetime | None = None
+) -> Path:
+    return get_edit_path() / department / playblast_date_folder(timestamp)
+
+
+def build_output_base_paths(
+    department: str,
+    shot_code: str,
+    custom_dir: Path | None = None,
+    timestamp: datetime | None = None,
+) -> tuple[Path, Path | None]:
+    if timestamp is None:
+        timestamp = datetime.now()
+
+    edit_output_dir = build_edit_output_directory(department, timestamp)
+    destination_dirs = [edit_output_dir]
+    if custom_dir is not None:
+        destination_dirs.append(custom_dir)
+
+    output_basename = resolve_versioned_playblast_basename(
+        shot_code,
+        destination_dirs,
+        now=timestamp,
+    )
+
+    edit_output_base = edit_output_dir / output_basename
+    custom_output_base = (
+        custom_dir / output_basename if custom_dir is not None else None
+    )
+    return edit_output_base, custom_output_base
 
 
 def build_output_base_path(
@@ -16,16 +49,13 @@ def build_output_base_path(
     shot_code: str,
     timestamp: datetime | None = None,
 ) -> Path:
-    if timestamp is None:
-        timestamp = datetime.now()
-
-    date_folder = timestamp.strftime("%m-%d-%Y")
-    return (
-        get_edit_path()
-        / department
-        / date_folder
-        / _build_base_name(shot_code, timestamp)
+    edit_output_base, _ = build_output_base_paths(
+        department,
+        shot_code,
+        custom_dir=None,
+        timestamp=timestamp,
     )
+    return edit_output_base
 
 
 def build_custom_output_base_path(
@@ -33,6 +63,9 @@ def build_custom_output_base_path(
     shot_code: str,
     timestamp: datetime | None = None,
 ) -> Path:
-    if timestamp is None:
-        timestamp = datetime.now()
-    return custom_dir / _build_base_name(shot_code, timestamp)
+    output_basename = resolve_versioned_playblast_basename(
+        shot_code,
+        [custom_dir],
+        now=timestamp,
+    )
+    return custom_dir / output_basename

--- a/pipeline/pipe/h/playblast/paths.py
+++ b/pipeline/pipe/h/playblast/paths.py
@@ -5,67 +5,10 @@ from pathlib import Path
 
 from shared.util import get_edit_path
 
-from pipe.playblast_naming import (
-    playblast_date_folder,
-    resolve_versioned_playblast_basename,
-)
+from pipe.playblast_naming import playblast_date_folder
 
 
 def build_edit_output_directory(
     department: str, timestamp: datetime | None = None
 ) -> Path:
     return get_edit_path() / department / playblast_date_folder(timestamp)
-
-
-def build_output_base_paths(
-    department: str,
-    shot_code: str,
-    custom_dir: Path | None = None,
-    timestamp: datetime | None = None,
-) -> tuple[Path, Path | None]:
-    if timestamp is None:
-        timestamp = datetime.now()
-
-    edit_output_dir = build_edit_output_directory(department, timestamp)
-    destination_dirs = [edit_output_dir]
-    if custom_dir is not None:
-        destination_dirs.append(custom_dir)
-
-    output_basename = resolve_versioned_playblast_basename(
-        shot_code,
-        destination_dirs,
-        now=timestamp,
-    )
-
-    edit_output_base = edit_output_dir / output_basename
-    custom_output_base = (
-        custom_dir / output_basename if custom_dir is not None else None
-    )
-    return edit_output_base, custom_output_base
-
-
-def build_output_base_path(
-    department: str,
-    shot_code: str,
-    timestamp: datetime | None = None,
-) -> Path:
-    edit_output_base, _ = build_output_base_paths(
-        department,
-        shot_code,
-        custom_dir=None,
-        timestamp=timestamp,
-    )
-    return edit_output_base
-
-
-def build_custom_output_base_path(
-    custom_dir: Path,
-    shot_code: str,
-    timestamp: datetime | None = None,
-) -> Path:
-    output_basename = resolve_versioned_playblast_basename(
-        shot_code,
-        [custom_dir],
-        now=timestamp,
-    )
-    return custom_dir / output_basename

--- a/pipeline/pipe/h/playblast/playblaster.py
+++ b/pipeline/pipe/h/playblast/playblaster.py
@@ -45,11 +45,13 @@ _GUIDES_TO_DISABLE = (
 
 
 class HPlayblaster(Playblaster):
+    _camera_path: str | None
     _out_paths: dict[Playblaster.PRESET, list[Path | str]]
     _tails: tuple[int, int]
 
     def __init__(self) -> None:
         super().__init__()
+        self._camera_path = None
         self._out_paths = {}
         self._tails = (0, 0)
         try:
@@ -62,10 +64,12 @@ class HPlayblaster(Playblaster):
         shot: Shot,
         out_paths: dict[Playblaster.PRESET, list[Path | str]],
         tails: tuple[int, int] = (0, 0),
+        camera_path: str | None = None,
     ) -> "HPlayblaster":
         self._shot = shot
         self._out_paths = out_paths
         self._tails = tails
+        self._camera_path = str(camera_path).strip() or None
         return self
 
     def _run_postprocess(self, video_path: Path) -> None:
@@ -79,7 +83,10 @@ class HPlayblaster(Playblaster):
         flip = scene_viewer.flipbookSettings().stash()
         _configure_flipbook(flip, path, start_frame, end_frame)
 
-        with _clean_viewport(scene_viewer, viewport):
+        with (
+            _applied_viewport_camera(viewport, self._camera_path),
+            _clean_viewport(scene_viewer, viewport),
+        ):
             _run_flipbook(scene_viewer, viewport, flip)
 
     def playblast(self) -> None:
@@ -135,6 +142,55 @@ def _configure_flipbook(
 
     if USE_BEAUTY_ONLY:
         settings.beautyPassOnly(True)
+
+
+@contextmanager
+def _applied_viewport_camera(
+    viewport: hou.GeometryViewport,
+    camera_path: str | None,
+) -> Iterator[None]:
+    if not camera_path:
+        yield
+        return
+
+    try:
+        camera_node = hou.node(camera_path)
+    except Exception:
+        camera_node = None
+
+    if camera_node is None:
+        log.warning(
+            "Could not find camera '%s'; using current viewport camera.", camera_path
+        )
+        yield
+        return
+
+    try:
+        original_camera = viewport.camera()
+    except Exception:
+        original_camera = None
+
+    try:
+        viewport.setCamera(camera_node)
+    except Exception:
+        log.warning(
+            "Could not set viewport camera to '%s'; using current viewport camera.",
+            camera_path,
+            exc_info=True,
+        )
+        yield
+        return
+
+    try:
+        yield
+    finally:
+        try:
+            if original_camera is None:
+                viewport.setDefaultCamera()
+            else:
+                viewport.setCamera(original_camera)
+        except Exception:
+            pass
 
 
 @contextmanager

--- a/pipeline/pipe/h/playblast/tool.py
+++ b/pipeline/pipe/h/playblast/tool.py
@@ -61,12 +61,11 @@ def launch_playblast() -> None:
         ).exec_()
         return
 
-    output_base = dialog.output_base_path
+    output_base, custom_base = dialog.resolve_output_base_paths()
     if output_base is None:
         MessageDialog(parent, "Unable to build export path.", "Playblast").exec_()
         return
 
-    custom_base = dialog.custom_output_base_path
     out_paths: dict[Playblaster.PRESET, list[Path | str]] = {
         Playblaster.PRESET.EDIT_SQ: [output_base]
     }

--- a/pipeline/pipe/h/playblast/tool.py
+++ b/pipeline/pipe/h/playblast/tool.py
@@ -13,7 +13,12 @@ from pipe.db import DB
 from pipe.glui.dialogs import MessageDialog
 from pipe.h import local
 from pipe.playblast_artist import resolve_artist_display_name
-from pipe.playblast_shotgrid import resolve_preferred_upload_movie_path
+from pipe.playblast_shotgrid import (
+    PlayblastVersionUploadRequest,
+    default_version_name_from_movie_path,
+    resolve_preferred_upload_movie_path,
+    upload_playblast_version,
+)
 from pipe.struct.db import Shot
 from pipe.util import Playblaster
 
@@ -78,6 +83,7 @@ class HoudiniPlayblastLaunchContext:
     custom_frame_range: tuple[int, int] | None
     custom_shot_code: str
     output_destinations: tuple["ResolvedOutputDestination", ...]
+    shotgrid_description: str
     upload_to_shotgrid: bool
 
 
@@ -217,6 +223,7 @@ def _build_launch_context(
         custom_frame_range=custom_frame_range,
         custom_shot_code=dialog.custom_shot_code,
         output_destinations=output_destinations,
+        shotgrid_description=dialog.shotgrid_description,
         upload_to_shotgrid=dialog.upload_to_shotgrid,
     )
 
@@ -353,7 +360,55 @@ def _run_post_export_actions(config: HoudiniPlayblastExportConfig) -> list[str]:
         )
         return ["ShotGrid Upload: Skipped - no valid playblast movie file was found."]
 
-    return [_upload_stub(upload_movie)]
+    return _upload_shot_playblast_to_shotgrid(context, upload_movie)
+
+
+def _upload_shot_playblast_to_shotgrid(
+    context: HoudiniPlayblastLaunchContext,
+    movie_path: Path,
+) -> list[str]:
+    shot_code = str(context.shot_code or "").strip()
+    if not shot_code:
+        return ["ShotGrid Upload: Skipped - shot code is missing."]
+
+    version_name = default_version_name_from_movie_path(movie_path)
+    if not version_name:
+        version_name = f"{shot_code}_playblast"
+
+    artist_name = resolve_artist_display_name().strip() or None
+    upload_request = PlayblastVersionUploadRequest(
+        shot_code=shot_code,
+        movie_path=movie_path,
+        version_name=version_name,
+        description=context.shotgrid_description or None,
+        path_to_frames=str(movie_path),
+        artist_display_name=artist_name,
+    )
+
+    try:
+        upload_result = upload_playblast_version(upload_request)
+    except Exception as exc:
+        log.exception("ShotGrid upload failed for shot '%s'", shot_code)
+        return [f"ShotGrid Upload: Failed - {exc}"]
+
+    message_lines: list[str] = []
+    if upload_result.ok:
+        success_message = (
+            f"ShotGrid Upload: Success - {upload_result.version_name}"
+            f" (shot {upload_result.shot_code})."
+        )
+        if upload_result.version_id is not None:
+            success_message = (
+                f"{success_message} Version ID: {upload_result.version_id}."
+            )
+        message_lines.append(success_message)
+    else:
+        message_lines.append(f"ShotGrid Upload: Failed - {upload_result.message}")
+
+    for warning in upload_result.warnings:
+        message_lines.append(f"ShotGrid Warning: {warning}")
+
+    return message_lines
 
 
 def _build_success_message(
@@ -395,18 +450,3 @@ def _resolve_shot_code() -> str | None:
             return part
 
     return None
-
-
-def _upload_stub(movie_path: Path) -> str:
-    artist_display_name = resolve_artist_display_name().strip()
-    if artist_display_name:
-        log.info(
-            "ShotGrid upload requested for %s by %s (not implemented yet).",
-            movie_path,
-            artist_display_name,
-        )
-    else:
-        log.info("ShotGrid upload requested for %s (not implemented yet).", movie_path)
-    return (
-        f"ShotGrid Upload: Skipped - not implemented yet (requested for {movie_path})."
-    )

--- a/pipeline/pipe/h/playblast/tool.py
+++ b/pipeline/pipe/h/playblast/tool.py
@@ -89,6 +89,16 @@ class ResolvedOutputDestination:
     output_base: Path
 
 
+@dataclass(frozen=True)
+class HoudiniPlayblastExportConfig:
+    """Fully resolved export configuration used by launch orchestration."""
+
+    context: HoudiniPlayblastLaunchContext
+    shot: Shot
+    out_paths: dict[Playblaster.PRESET, list[Path | str]]
+    final_movies: tuple[Path, ...]
+
+
 def launch_playblast() -> None:
     if local.is_headless():
         MessageDialog(None, "Playblast requires the Houdini UI.", "Playblast").exec_()
@@ -105,34 +115,32 @@ def launch_playblast() -> None:
     if not dialog.exec_():
         return
 
-    context = _build_launch_context_or_report(dialog, parent)
-    if context is None:
+    export_config = _generate_export_config_or_report(dialog, conn, parent)
+    if export_config is None:
         return
 
-    shot = _resolve_source_shot_or_report(conn, context, parent)
-    if shot is None:
+    validation_error = _validate_export_config(export_config)
+    if validation_error:
+        MessageDialog(parent, validation_error, "Playblast").exec_()
         return
 
-    out_paths = _build_output_paths(context)
-    playblaster = HPlayblaster().configure(
-        shot,
-        out_paths,
-        camera_path=context.custom_camera_path,
+    if not _run_local_playblast_or_report(export_config, parent):
+        return
+
+    try:
+        post_export_messages = _run_post_export_actions(export_config)
+    except Exception as exc:
+        log.exception("Post-playblast actions failed")
+        post_export_messages = [
+            "Post-export actions failed. Local playblast files were still written.",
+            f"Reason: {exc}",
+        ]
+
+    success_message = _build_success_message(
+        output_paths=list(export_config.final_movies),
+        post_export_messages=post_export_messages,
     )
-    if not _run_local_playblast_or_report(playblaster, parent):
-        return
-
-    final_movies = _ordered_final_movie_paths_for_upload(context)
-    if context.source_mode == "shot" and context.upload_to_shotgrid:
-        upload_movie = _resolve_shotgrid_upload_movie_path(context)
-        if upload_movie is None:
-            log.warning(
-                "ShotGrid upload requested but no valid movie output was found in selected destinations."
-            )
-        else:
-            _upload_stub(parent, upload_movie)
-
-    _show_success_dialog(parent, final_movies)
+    MessageDialog(parent, success_message, "Playblast").exec_()
 
 
 def _resolve_connection_or_report(parent: QtWidgets.QWidget | None) -> Any | None:
@@ -144,14 +152,45 @@ def _resolve_connection_or_report(parent: QtWidgets.QWidget | None) -> Any | Non
         return None
 
 
-def _build_launch_context_or_report(
+def _generate_export_config_or_report(
     dialog: HPlayblastDialog,
+    conn: Any,
     parent: QtWidgets.QWidget | None,
-) -> HoudiniPlayblastLaunchContext | None:
+) -> HoudiniPlayblastExportConfig | None:
+    try:
+        return _generate_export_config(dialog, conn)
+    except Exception as exc:
+        log.exception("Playblast config generation failed")
+        MessageDialog(
+            parent,
+            f"Could not generate playblast settings.\n\n{exc}",
+            "Playblast Error",
+        ).exec_()
+        return None
+
+
+def _generate_export_config(
+    dialog: HPlayblastDialog,
+    conn: Any,
+) -> HoudiniPlayblastExportConfig:
+    context = _build_launch_context(dialog)
+    shot = _resolve_source_shot(conn, context)
+    out_paths = _build_output_paths(context)
+    final_movies = tuple(_ordered_final_movie_paths_for_upload(context))
+    return HoudiniPlayblastExportConfig(
+        context=context,
+        shot=shot,
+        out_paths=out_paths,
+        final_movies=final_movies,
+    )
+
+
+def _build_launch_context(
+    dialog: HPlayblastDialog,
+) -> HoudiniPlayblastLaunchContext:
     output_bases_by_destination = dialog.resolve_output_bases_by_destination()
     if not output_bases_by_destination:
-        MessageDialog(parent, "Unable to build export path.", "Playblast").exec_()
-        return None
+        raise ValueError("Unable to build export path.")
 
     output_destinations = tuple(
         ResolvedOutputDestination(
@@ -162,16 +201,12 @@ def _build_launch_context_or_report(
         if destination_name in output_bases_by_destination
     )
     if not output_destinations:
-        MessageDialog(parent, "Unable to build export path.", "Playblast").exec_()
-        return None
+        raise ValueError("Unable to build export path.")
 
     source_mode = dialog.selected_source_mode
     shot_code = dialog.shot_code if source_mode == "shot" else None
     if source_mode == "shot" and not shot_code:
-        MessageDialog(
-            parent, "No shot code was found for Shot Playblast.", "Playblast"
-        ).exec_()
-        return None
+        raise ValueError("No shot code was found for Shot Playblast.")
 
     custom_frame_range = dialog.custom_frame_range if source_mode == "custom" else None
 
@@ -186,23 +221,22 @@ def _build_launch_context_or_report(
     )
 
 
-def _resolve_source_shot_or_report(
+def _resolve_source_shot(
     conn: Any,
     context: HoudiniPlayblastLaunchContext,
-    parent: QtWidgets.QWidget | None,
-) -> Shot | None:
+) -> Shot:
     if context.source_mode == "custom":
-        return _build_custom_mode_shot(context)
+        custom_mode_shot = _build_custom_mode_shot(context)
+        if custom_mode_shot is None:
+            raise ValueError("Could not build custom shot context.")
+        return custom_mode_shot
 
     shot_code = context.shot_code or ""
     try:
         return conn.get_shot_by_code(shot_code)
     except Exception as exc:
         log.error("Shot lookup failed for %s: %s", shot_code, exc, exc_info=True)
-        MessageDialog(
-            parent, f"Shot '{shot_code}' not found in ShotGrid.", "Playblast"
-        ).exec_()
-        return None
+        raise ValueError(f"Shot '{shot_code}' not found in ShotGrid.") from exc
 
 
 def _build_custom_mode_shot(context: HoudiniPlayblastLaunchContext) -> Shot | None:
@@ -236,16 +270,37 @@ def _build_output_paths(
     }
 
 
+def _validate_export_config(config: HoudiniPlayblastExportConfig) -> str | None:
+    if not config.out_paths:
+        return "No playblast outputs are configured."
+
+    output_count = sum(len(paths) for paths in config.out_paths.values())
+    if output_count < 1:
+        return "No playblast outputs are configured."
+
+    if not config.final_movies:
+        return "No output movie paths were resolved for this export."
+
+    return None
+
+
 def _run_local_playblast_or_report(
-    playblaster: HPlayblaster,
+    config: HoudiniPlayblastExportConfig,
     parent: QtWidgets.QWidget | None,
 ) -> bool:
+    playblaster = HPlayblaster().configure(
+        config.shot,
+        config.out_paths,
+        camera_path=config.context.custom_camera_path,
+    )
     try:
         playblaster.playblast()
     except Exception as exc:
-        log.error("Playblast failed: %s", exc, exc_info=True)
+        log.exception("Playblast export failed")
         MessageDialog(
-            parent, "Playblast failed. Check the console for details.", "Playblast"
+            parent,
+            f"Playblast failed.\n\n{exc}",
+            "Playblast Error",
         ).exec_()
         return False
     return True
@@ -286,18 +341,35 @@ def _resolve_shotgrid_upload_movie_path(
     )
 
 
-def _show_success_dialog(
-    parent: QtWidgets.QWidget | None, final_movies: list[Path]
-) -> None:
-    if not final_movies:
-        message = "Playblast export completed, but no output files were resolved."
-        MessageDialog(parent, message, "Playblast").exec_()
-        return
+def _run_post_export_actions(config: HoudiniPlayblastExportConfig) -> list[str]:
+    context = config.context
+    if context.source_mode != "shot" or not context.upload_to_shotgrid:
+        return []
 
-    message_lines = ["Playblast saved to:"]
-    message_lines.extend(str(path) for path in final_movies)
-    message = "\n".join(message_lines)
-    MessageDialog(parent, message, "Playblast").exec_()
+    upload_movie = _resolve_shotgrid_upload_movie_path(context)
+    if upload_movie is None:
+        log.warning(
+            "ShotGrid upload requested but no valid movie output was found in selected destinations."
+        )
+        return ["ShotGrid Upload: Skipped - no valid playblast movie file was found."]
+
+    return [_upload_stub(upload_movie)]
+
+
+def _build_success_message(
+    output_paths: list[Path],
+    post_export_messages: list[str],
+) -> str:
+    message_lines = ["Local playblast export successful."]
+    if output_paths:
+        message_lines.append("")
+        message_lines.append("Outputs:")
+        message_lines.extend(str(path) for path in output_paths)
+    if post_export_messages:
+        message_lines.append("")
+        message_lines.append("Post-export:")
+        message_lines.extend(post_export_messages)
+    return "\n".join(message_lines)
 
 
 def _resolve_shot_code() -> str | None:
@@ -325,7 +397,7 @@ def _resolve_shot_code() -> str | None:
     return None
 
 
-def _upload_stub(parent: QtWidgets.QWidget | None, movie_path: Path) -> None:
+def _upload_stub(movie_path: Path) -> str:
     artist_display_name = resolve_artist_display_name().strip()
     if artist_display_name:
         log.info(
@@ -335,6 +407,6 @@ def _upload_stub(parent: QtWidgets.QWidget | None, movie_path: Path) -> None:
         )
     else:
         log.info("ShotGrid upload requested for %s (not implemented yet).", movie_path)
-    MessageDialog(
-        parent, "ShotGrid upload is not implemented yet.", "Playblast"
-    ).exec_()
+    return (
+        f"ShotGrid Upload: Skipped - not implemented yet (requested for {movie_path})."
+    )

--- a/pipeline/pipe/h/playblast/tool.py
+++ b/pipeline/pipe/h/playblast/tool.py
@@ -30,47 +30,7 @@ log = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from Qt import QtWidgets
 
-
-@dataclass(frozen=True)
-class MayaPlayblastParityTarget:
-    """Maya behavior that Houdini should mirror during feature unification."""
-
-    name: str
-    maya_reference: str
-    expected_houdini_behavior: str
-
-
-MAYA_PARITY_TARGETS: tuple[MayaPlayblastParityTarget, ...] = (
-    MayaPlayblastParityTarget(
-        name="export_orchestration",
-        maya_reference="pipe.m.playblast.ui.PlayblastDialog.do_export",
-        expected_houdini_behavior=(
-            "Use the same staged flow: generate config, validate, run local export, "
-            "run post-export actions, then show a single final summary dialog."
-        ),
-    ),
-    MayaPlayblastParityTarget(
-        name="post_export_hook",
-        maya_reference="pipe.m.playblast.ui.PlayblastDialog._after_local_playblast",
-        expected_houdini_behavior=(
-            "Keep local exports successful even when optional post-export actions fail."
-        ),
-    ),
-    MayaPlayblastParityTarget(
-        name="shot_mode_upload_wiring",
-        maya_reference="pipe.m.playblast.previs.PrevisPlayblastDialog._upload_shot_playblast_to_shotgrid",
-        expected_houdini_behavior=(
-            "Wire ShotGrid uploads as an optional step after successful local output."
-        ),
-    ),
-    MayaPlayblastParityTarget(
-        name="deterministic_upload_source_selection",
-        maya_reference="pipe.m.playblast.previs.PrevisPlayblastDialog._resolve_shotgrid_upload_movie_path",
-        expected_houdini_behavior=(
-            "Resolve upload movie path deterministically with explicit destination preference."
-        ),
-    ),
-)
+SHOT_CODE_FALLBACK_PATTERN = re.compile(r"[A-Za-z]+_\d{3}(?:_[A-Za-z0-9]+)*")
 
 
 @dataclass(frozen=True)
@@ -214,12 +174,13 @@ def _build_launch_context(
     if source_mode == "shot" and not shot_code:
         raise ValueError("No shot code was found for Shot Playblast.")
 
+    custom_camera_path = dialog.custom_camera_path if source_mode == "custom" else None
     custom_frame_range = dialog.custom_frame_range if source_mode == "custom" else None
 
     return HoudiniPlayblastLaunchContext(
         source_mode=source_mode,
         shot_code=shot_code,
-        custom_camera_path=dialog.custom_camera_path,
+        custom_camera_path=custom_camera_path,
         custom_frame_range=custom_frame_range,
         custom_shot_code=dialog.custom_shot_code,
         output_destinations=output_destinations,
@@ -433,20 +394,52 @@ def _resolve_shot_code() -> str | None:
     except Exception:
         shot_path = None
 
-    if isinstance(shot_path, (str, Path)) and str(shot_path):
-        try:
-            return Path(shot_path).name
-        except Exception:
-            pass
+    shot_code_from_context = _shot_code_from_context_option(shot_path)
+    if shot_code_from_context:
+        return shot_code_from_context
 
     try:
         hip_path = Path(hou.hipFile.path())
     except Exception:
         return None
 
-    pattern = re.compile(r"[A-Za-z]+_\d+")
-    for part in hip_path.parts:
-        if pattern.fullmatch(part):
-            return part
+    shot_code_from_path = _shot_code_from_hip_path(hip_path)
+    if shot_code_from_path:
+        return shot_code_from_path
+
+    return None
+
+
+def _shot_code_from_context_option(shot_path: Any) -> str | None:
+    if not isinstance(shot_path, (str, Path)):
+        return None
+
+    context_token = str(shot_path).strip()
+    if not context_token:
+        return None
+
+    try:
+        candidate = Path(context_token).name.strip()
+    except Exception:
+        return None
+
+    if candidate and SHOT_CODE_FALLBACK_PATTERN.fullmatch(candidate):
+        return candidate
+    return None
+
+
+def _shot_code_from_hip_path(hip_path: Path) -> str | None:
+    path_parts = list(hip_path.parts)
+    for index, part in enumerate(path_parts[:-1]):
+        if part.lower() != "shot":
+            continue
+        candidate = str(path_parts[index + 1]).strip()
+        if SHOT_CODE_FALLBACK_PATTERN.fullmatch(candidate):
+            return candidate
+
+    for part in path_parts:
+        candidate = str(part).strip()
+        if SHOT_CODE_FALLBACK_PATTERN.fullmatch(candidate):
+            return candidate
 
     return None

--- a/pipeline/pipe/h/playblast/tool.py
+++ b/pipeline/pipe/h/playblast/tool.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import logging
 import re
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import hou
 from env_sg import DB_Config
@@ -11,6 +12,7 @@ from env_sg import DB_Config
 from pipe.db import DB
 from pipe.glui.dialogs import MessageDialog
 from pipe.h import local
+from pipe.playblast_artist import resolve_artist_display_name
 from pipe.util import Playblaster
 
 from .playblaster import HPlayblaster
@@ -22,18 +24,68 @@ if TYPE_CHECKING:
     from Qt import QtWidgets
 
 
+@dataclass(frozen=True)
+class MayaPlayblastParityTarget:
+    """Maya behavior that Houdini should mirror during feature unification."""
+
+    name: str
+    maya_reference: str
+    expected_houdini_behavior: str
+
+
+MAYA_PARITY_TARGETS: tuple[MayaPlayblastParityTarget, ...] = (
+    MayaPlayblastParityTarget(
+        name="export_orchestration",
+        maya_reference="pipe.m.playblast.ui.PlayblastDialog.do_export",
+        expected_houdini_behavior=(
+            "Use the same staged flow: generate config, validate, run local export, "
+            "run post-export actions, then show a single final summary dialog."
+        ),
+    ),
+    MayaPlayblastParityTarget(
+        name="post_export_hook",
+        maya_reference="pipe.m.playblast.ui.PlayblastDialog._after_local_playblast",
+        expected_houdini_behavior=(
+            "Keep local exports successful even when optional post-export actions fail."
+        ),
+    ),
+    MayaPlayblastParityTarget(
+        name="shot_mode_upload_wiring",
+        maya_reference="pipe.m.playblast.previs.PrevisPlayblastDialog._upload_shot_playblast_to_shotgrid",
+        expected_houdini_behavior=(
+            "Wire ShotGrid uploads as an optional step after successful local output."
+        ),
+    ),
+    MayaPlayblastParityTarget(
+        name="deterministic_upload_source_selection",
+        maya_reference="pipe.m.playblast.previs.PrevisPlayblastDialog._resolve_shotgrid_upload_movie_path",
+        expected_houdini_behavior=(
+            "Resolve upload movie path deterministically with explicit destination preference."
+        ),
+    ),
+)
+
+
+@dataclass(frozen=True)
+class HoudiniPlayblastLaunchContext:
+    """Resolved inputs used by the current Houdini local playblast flow."""
+
+    shot_code: str
+    output_base: Path
+    custom_output_base: Path | None
+    upload_to_shotgrid: bool
+
+
 def launch_playblast() -> None:
     if local.is_headless():
         MessageDialog(None, "Playblast requires the Houdini UI.", "Playblast").exec_()
         return
 
     parent = local.get_main_qt_window()
-    try:
-        conn = DB.Get(DB_Config)
-    except Exception as exc:
-        log.error("ShotGrid connection failed: %s", exc, exc_info=True)
-        MessageDialog(parent, "Could not connect to ShotGrid.", "Playblast").exec_()
+    conn = _resolve_connection_or_report(parent)
+    if conn is None:
         return
+
     default_shot_code = _resolve_shot_code()
     if not default_shot_code:
         MessageDialog(
@@ -47,32 +99,90 @@ def launch_playblast() -> None:
     if not dialog.exec_():
         return
 
+    context = _build_launch_context_or_report(dialog, parent)
+    if context is None:
+        return
+
+    shot = _resolve_shot_or_report(conn, context.shot_code, parent)
+    if shot is None:
+        return
+
+    out_paths = _build_output_paths(context)
+    playblaster = HPlayblaster().configure(shot, out_paths)
+    if not _run_local_playblast_or_report(playblaster, parent):
+        return
+
+    final_primary_movie = _final_movie_path(
+        context.output_base,
+        Playblaster.PRESET.EDIT_SQ,
+    )
+    if context.upload_to_shotgrid:
+        _upload_stub(parent, final_primary_movie)
+
+    _show_success_dialog(parent, context, final_primary_movie)
+
+
+def _resolve_connection_or_report(parent: QtWidgets.QWidget | None) -> Any | None:
+    try:
+        return DB.Get(DB_Config)
+    except Exception as exc:
+        log.error("ShotGrid connection failed: %s", exc, exc_info=True)
+        MessageDialog(parent, "Could not connect to ShotGrid.", "Playblast").exec_()
+        return None
+
+
+def _build_launch_context_or_report(
+    dialog: HPlayblastDialog,
+    parent: QtWidgets.QWidget | None,
+) -> HoudiniPlayblastLaunchContext | None:
     shot_code = dialog.shot_code
     if not shot_code:
         MessageDialog(parent, "Please enter a shot code.", "Playblast").exec_()
-        return
+        return None
 
+    output_base, custom_output_base = dialog.resolve_output_base_paths()
+    if output_base is None:
+        MessageDialog(parent, "Unable to build export path.", "Playblast").exec_()
+        return None
+
+    return HoudiniPlayblastLaunchContext(
+        shot_code=shot_code,
+        output_base=output_base,
+        custom_output_base=custom_output_base,
+        upload_to_shotgrid=dialog.upload_to_shotgrid,
+    )
+
+
+def _resolve_shot_or_report(
+    conn: Any,
+    shot_code: str,
+    parent: QtWidgets.QWidget | None,
+) -> Any | None:
     try:
-        shot = conn.get_shot_by_code(shot_code)
+        return conn.get_shot_by_code(shot_code)
     except Exception as exc:
         log.error("Shot lookup failed for %s: %s", shot_code, exc, exc_info=True)
         MessageDialog(
             parent, f"Shot '{shot_code}' not found in ShotGrid.", "Playblast"
         ).exec_()
-        return
+        return None
 
-    output_base, custom_base = dialog.resolve_output_base_paths()
-    if output_base is None:
-        MessageDialog(parent, "Unable to build export path.", "Playblast").exec_()
-        return
 
-    out_paths: dict[Playblaster.PRESET, list[Path | str]] = {
-        Playblaster.PRESET.EDIT_SQ: [output_base]
+def _build_output_paths(
+    context: HoudiniPlayblastLaunchContext,
+) -> dict[Playblaster.PRESET, list[Path | str]]:
+    output_paths: dict[Playblaster.PRESET, list[Path | str]] = {
+        Playblaster.PRESET.EDIT_SQ: [context.output_base]
     }
-    if custom_base is not None:
-        out_paths[Playblaster.PRESET.EDIT_SQ].append(custom_base)
-    playblaster = HPlayblaster().configure(shot, out_paths)
+    if context.custom_output_base is not None:
+        output_paths[Playblaster.PRESET.EDIT_SQ].append(context.custom_output_base)
+    return output_paths
 
+
+def _run_local_playblast_or_report(
+    playblaster: HPlayblaster,
+    parent: QtWidgets.QWidget | None,
+) -> bool:
     try:
         playblaster.playblast()
     except Exception as exc:
@@ -80,16 +190,26 @@ def launch_playblast() -> None:
         MessageDialog(
             parent, "Playblast failed. Check the console for details.", "Playblast"
         ).exec_()
-        return
+        return False
+    return True
 
-    final_path = Path(str(output_base) + f".{Playblaster.PRESET.EDIT_SQ.ext}")
-    if dialog.upload_to_shotgrid:
-        _upload_stub(parent, final_path)
 
-    message = f"Playblast saved to:\n{final_path}"
-    if custom_base is not None:
-        custom_final = Path(str(custom_base) + f".{Playblaster.PRESET.EDIT_SQ.ext}")
-        message = f"{message}\n\nAdditional export:\n{custom_final}"
+def _final_movie_path(output_base: str | Path, preset: Playblaster.PRESET) -> Path:
+    return Path(str(output_base) + f".{preset.ext}")
+
+
+def _show_success_dialog(
+    parent: QtWidgets.QWidget | None,
+    context: HoudiniPlayblastLaunchContext,
+    final_primary_movie: Path,
+) -> None:
+    message = f"Playblast saved to:\n{final_primary_movie}"
+    if context.custom_output_base is not None:
+        custom_final_movie = _final_movie_path(
+            context.custom_output_base,
+            Playblaster.PRESET.EDIT_SQ,
+        )
+        message = f"{message}\n\nAdditional export:\n{custom_final_movie}"
     MessageDialog(parent, message, "Playblast").exec_()
 
 
@@ -119,7 +239,15 @@ def _resolve_shot_code() -> str | None:
 
 
 def _upload_stub(parent: QtWidgets.QWidget | None, movie_path: Path) -> None:
-    log.info("ShotGrid upload requested for %s (not implemented yet).", movie_path)
+    artist_display_name = resolve_artist_display_name().strip()
+    if artist_display_name:
+        log.info(
+            "ShotGrid upload requested for %s by %s (not implemented yet).",
+            movie_path,
+            artist_display_name,
+        )
+    else:
+        log.info("ShotGrid upload requested for %s (not implemented yet).", movie_path)
     MessageDialog(
         parent, "ShotGrid upload is not implemented yet.", "Playblast"
     ).exec_()

--- a/pipeline/pipe/h/playblast/tool.py
+++ b/pipeline/pipe/h/playblast/tool.py
@@ -13,6 +13,7 @@ from pipe.db import DB
 from pipe.glui.dialogs import MessageDialog
 from pipe.h import local
 from pipe.playblast_artist import resolve_artist_display_name
+from pipe.playblast_shotgrid import resolve_preferred_upload_movie_path
 from pipe.struct.db import Shot
 from pipe.util import Playblaster
 
@@ -76,8 +77,16 @@ class HoudiniPlayblastLaunchContext:
     custom_camera_path: str | None
     custom_frame_range: tuple[int, int] | None
     custom_shot_code: str
-    output_bases: tuple[Path, ...]
+    output_destinations: tuple["ResolvedOutputDestination", ...]
     upload_to_shotgrid: bool
+
+
+@dataclass(frozen=True)
+class ResolvedOutputDestination:
+    """Resolved output base path paired with its destination label."""
+
+    destination_name: str
+    output_base: Path
 
 
 def launch_playblast() -> None:
@@ -113,10 +122,15 @@ def launch_playblast() -> None:
     if not _run_local_playblast_or_report(playblaster, parent):
         return
 
-    final_movies = _final_movie_paths(context.output_bases, Playblaster.PRESET.EDIT_SQ)
-    primary_movie = final_movies[0]
+    final_movies = _ordered_final_movie_paths_for_upload(context)
     if context.source_mode == "shot" and context.upload_to_shotgrid:
-        _upload_stub(parent, primary_movie)
+        upload_movie = _resolve_shotgrid_upload_movie_path(context)
+        if upload_movie is None:
+            log.warning(
+                "ShotGrid upload requested but no valid movie output was found in selected destinations."
+            )
+        else:
+            _upload_stub(parent, upload_movie)
 
     _show_success_dialog(parent, final_movies)
 
@@ -134,8 +148,20 @@ def _build_launch_context_or_report(
     dialog: HPlayblastDialog,
     parent: QtWidgets.QWidget | None,
 ) -> HoudiniPlayblastLaunchContext | None:
-    output_bases = tuple(dialog.resolve_selected_output_bases())
-    if not output_bases:
+    output_bases_by_destination = dialog.resolve_output_bases_by_destination()
+    if not output_bases_by_destination:
+        MessageDialog(parent, "Unable to build export path.", "Playblast").exec_()
+        return None
+
+    output_destinations = tuple(
+        ResolvedOutputDestination(
+            destination_name=destination_name,
+            output_base=output_bases_by_destination[destination_name],
+        )
+        for destination_name in HPlayblastDialog.DESTINATION_ORDER
+        if destination_name in output_bases_by_destination
+    )
+    if not output_destinations:
         MessageDialog(parent, "Unable to build export path.", "Playblast").exec_()
         return None
 
@@ -155,7 +181,7 @@ def _build_launch_context_or_report(
         custom_camera_path=dialog.custom_camera_path,
         custom_frame_range=custom_frame_range,
         custom_shot_code=dialog.custom_shot_code,
-        output_bases=output_bases,
+        output_destinations=output_destinations,
         upload_to_shotgrid=dialog.upload_to_shotgrid,
     )
 
@@ -203,7 +229,11 @@ def _build_custom_mode_shot(context: HoudiniPlayblastLaunchContext) -> Shot | No
 def _build_output_paths(
     context: HoudiniPlayblastLaunchContext,
 ) -> dict[Playblaster.PRESET, list[Path | str]]:
-    return {Playblaster.PRESET.EDIT_SQ: list(context.output_bases)}
+    return {
+        Playblaster.PRESET.EDIT_SQ: [
+            destination.output_base for destination in context.output_destinations
+        ]
+    }
 
 
 def _run_local_playblast_or_report(
@@ -225,11 +255,35 @@ def _final_movie_path(output_base: str | Path, preset: Playblaster.PRESET) -> Pa
     return Path(str(output_base) + f".{preset.ext}")
 
 
-def _final_movie_paths(
-    output_bases: tuple[Path, ...],
-    preset: Playblaster.PRESET,
+def _ordered_final_movie_paths_for_upload(
+    context: HoudiniPlayblastLaunchContext,
 ) -> list[Path]:
-    return [_final_movie_path(base, preset) for base in output_bases]
+    return [
+        _final_movie_path(destination.output_base, Playblaster.PRESET.EDIT_SQ)
+        for destination in context.output_destinations
+    ]
+
+
+def _preferred_edit_movie_paths_for_upload(
+    context: HoudiniPlayblastLaunchContext,
+) -> list[Path]:
+    for destination in context.output_destinations:
+        if destination.destination_name != HPlayblastDialog.DESTINATION_EDIT:
+            continue
+        return [_final_movie_path(destination.output_base, Playblaster.PRESET.EDIT_SQ)]
+    return []
+
+
+def _resolve_shotgrid_upload_movie_path(
+    context: HoudiniPlayblastLaunchContext,
+) -> Path | None:
+    """Resolve upload path deterministically: prefer Edit, then destination order."""
+    ordered_paths = _ordered_final_movie_paths_for_upload(context)
+    preferred_paths = _preferred_edit_movie_paths_for_upload(context)
+    return resolve_preferred_upload_movie_path(
+        ordered_paths,
+        preferred_paths=preferred_paths,
+    )
 
 
 def _show_success_dialog(

--- a/pipeline/pipe/h/playblast/tool.py
+++ b/pipeline/pipe/h/playblast/tool.py
@@ -4,7 +4,7 @@ import logging
 import re
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 import hou
 from env_sg import DB_Config
@@ -13,6 +13,7 @@ from pipe.db import DB
 from pipe.glui.dialogs import MessageDialog
 from pipe.h import local
 from pipe.playblast_artist import resolve_artist_display_name
+from pipe.struct.db import Shot
 from pipe.util import Playblaster
 
 from .playblaster import HPlayblaster
@@ -68,11 +69,14 @@ MAYA_PARITY_TARGETS: tuple[MayaPlayblastParityTarget, ...] = (
 
 @dataclass(frozen=True)
 class HoudiniPlayblastLaunchContext:
-    """Resolved inputs used by the current Houdini local playblast flow."""
+    """Resolved inputs used by the Houdini playblast launch flow."""
 
-    shot_code: str
-    output_base: Path
-    custom_output_base: Path | None
+    source_mode: Literal["shot", "custom"]
+    shot_code: str | None
+    custom_camera_path: str | None
+    custom_frame_range: tuple[int, int] | None
+    custom_shot_code: str
+    output_bases: tuple[Path, ...]
     upload_to_shotgrid: bool
 
 
@@ -87,13 +91,6 @@ def launch_playblast() -> None:
         return
 
     default_shot_code = _resolve_shot_code()
-    if not default_shot_code:
-        MessageDialog(
-            parent,
-            "Could not determine the current shot from the scene.",
-            "Playblast",
-        ).exec_()
-        return
 
     dialog = HPlayblastDialog(parent, conn, default_shot_code)
     if not dialog.exec_():
@@ -103,23 +100,25 @@ def launch_playblast() -> None:
     if context is None:
         return
 
-    shot = _resolve_shot_or_report(conn, context.shot_code, parent)
+    shot = _resolve_source_shot_or_report(conn, context, parent)
     if shot is None:
         return
 
     out_paths = _build_output_paths(context)
-    playblaster = HPlayblaster().configure(shot, out_paths)
+    playblaster = HPlayblaster().configure(
+        shot,
+        out_paths,
+        camera_path=context.custom_camera_path,
+    )
     if not _run_local_playblast_or_report(playblaster, parent):
         return
 
-    final_primary_movie = _final_movie_path(
-        context.output_base,
-        Playblaster.PRESET.EDIT_SQ,
-    )
-    if context.upload_to_shotgrid:
-        _upload_stub(parent, final_primary_movie)
+    final_movies = _final_movie_paths(context.output_bases, Playblaster.PRESET.EDIT_SQ)
+    primary_movie = final_movies[0]
+    if context.source_mode == "shot" and context.upload_to_shotgrid:
+        _upload_stub(parent, primary_movie)
 
-    _show_success_dialog(parent, context, final_primary_movie)
+    _show_success_dialog(parent, final_movies)
 
 
 def _resolve_connection_or_report(parent: QtWidgets.QWidget | None) -> Any | None:
@@ -135,29 +134,41 @@ def _build_launch_context_or_report(
     dialog: HPlayblastDialog,
     parent: QtWidgets.QWidget | None,
 ) -> HoudiniPlayblastLaunchContext | None:
-    shot_code = dialog.shot_code
-    if not shot_code:
-        MessageDialog(parent, "Please enter a shot code.", "Playblast").exec_()
-        return None
-
-    output_base, custom_output_base = dialog.resolve_output_base_paths()
-    if output_base is None:
+    output_bases = tuple(dialog.resolve_selected_output_bases())
+    if not output_bases:
         MessageDialog(parent, "Unable to build export path.", "Playblast").exec_()
         return None
 
+    source_mode = dialog.selected_source_mode
+    shot_code = dialog.shot_code if source_mode == "shot" else None
+    if source_mode == "shot" and not shot_code:
+        MessageDialog(
+            parent, "No shot code was found for Shot Playblast.", "Playblast"
+        ).exec_()
+        return None
+
+    custom_frame_range = dialog.custom_frame_range if source_mode == "custom" else None
+
     return HoudiniPlayblastLaunchContext(
+        source_mode=source_mode,
         shot_code=shot_code,
-        output_base=output_base,
-        custom_output_base=custom_output_base,
+        custom_camera_path=dialog.custom_camera_path,
+        custom_frame_range=custom_frame_range,
+        custom_shot_code=dialog.custom_shot_code,
+        output_bases=output_bases,
         upload_to_shotgrid=dialog.upload_to_shotgrid,
     )
 
 
-def _resolve_shot_or_report(
+def _resolve_source_shot_or_report(
     conn: Any,
-    shot_code: str,
+    context: HoudiniPlayblastLaunchContext,
     parent: QtWidgets.QWidget | None,
-) -> Any | None:
+) -> Shot | None:
+    if context.source_mode == "custom":
+        return _build_custom_mode_shot(context)
+
+    shot_code = context.shot_code or ""
     try:
         return conn.get_shot_by_code(shot_code)
     except Exception as exc:
@@ -168,15 +179,31 @@ def _resolve_shot_or_report(
         return None
 
 
+def _build_custom_mode_shot(context: HoudiniPlayblastLaunchContext) -> Shot | None:
+    if context.custom_frame_range is None:
+        return None
+
+    cut_in, cut_out = context.custom_frame_range
+    if cut_out < cut_in:
+        cut_out = cut_in
+
+    return Shot(
+        code=context.custom_shot_code,
+        id=0,
+        assets=[],
+        cut_in=cut_in,
+        cut_out=cut_out,
+        cut_duration=max(0, cut_out - cut_in),
+        sequence=None,
+        set=None,
+        sets=[],
+    )
+
+
 def _build_output_paths(
     context: HoudiniPlayblastLaunchContext,
 ) -> dict[Playblaster.PRESET, list[Path | str]]:
-    output_paths: dict[Playblaster.PRESET, list[Path | str]] = {
-        Playblaster.PRESET.EDIT_SQ: [context.output_base]
-    }
-    if context.custom_output_base is not None:
-        output_paths[Playblaster.PRESET.EDIT_SQ].append(context.custom_output_base)
-    return output_paths
+    return {Playblaster.PRESET.EDIT_SQ: list(context.output_bases)}
 
 
 def _run_local_playblast_or_report(
@@ -198,18 +225,24 @@ def _final_movie_path(output_base: str | Path, preset: Playblaster.PRESET) -> Pa
     return Path(str(output_base) + f".{preset.ext}")
 
 
+def _final_movie_paths(
+    output_bases: tuple[Path, ...],
+    preset: Playblaster.PRESET,
+) -> list[Path]:
+    return [_final_movie_path(base, preset) for base in output_bases]
+
+
 def _show_success_dialog(
-    parent: QtWidgets.QWidget | None,
-    context: HoudiniPlayblastLaunchContext,
-    final_primary_movie: Path,
+    parent: QtWidgets.QWidget | None, final_movies: list[Path]
 ) -> None:
-    message = f"Playblast saved to:\n{final_primary_movie}"
-    if context.custom_output_base is not None:
-        custom_final_movie = _final_movie_path(
-            context.custom_output_base,
-            Playblaster.PRESET.EDIT_SQ,
-        )
-        message = f"{message}\n\nAdditional export:\n{custom_final_movie}"
+    if not final_movies:
+        message = "Playblast export completed, but no output files were resolved."
+        MessageDialog(parent, message, "Playblast").exec_()
+        return
+
+    message_lines = ["Playblast saved to:"]
+    message_lines.extend(str(path) for path in final_movies)
+    message = "\n".join(message_lines)
     MessageDialog(parent, message, "Playblast").exec_()
 
 

--- a/pipeline/pipe/h/playblast/ui.py
+++ b/pipeline/pipe/h/playblast/ui.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -10,7 +9,7 @@ from shared.util import get_edit_path
 from pipe.glui.dialogs import DialogButtons
 
 from .constants import DEFAULT_RESOLUTION
-from .paths import build_custom_output_base_path, build_output_base_path
+from .paths import build_output_base_paths
 
 if TYPE_CHECKING:
     from pipe.db import DB
@@ -26,7 +25,6 @@ class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
         default_shot_code: str | None = None,
     ) -> None:
         super().__init__(parent)
-        self._timestamp = datetime.now()
         self._conn = conn  # remove this if you remove the parameter
 
         self._init_buttons(True, "Playblast", "Cancel")
@@ -95,24 +93,29 @@ class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
     def upload_to_shotgrid(self) -> bool:
         return self._upload_cb.isChecked()
 
-    @property
-    def output_base_path(self) -> Path | None:
+    def resolve_output_base_paths(self) -> tuple[Path | None, Path | None]:
         shot_code = self.shot_code
         if not shot_code:
-            return None
-        return build_output_base_path(self.department, shot_code, self._timestamp)
+            return None, None
+
+        custom_dir = (
+            self._custom_export_dir() if self._custom_export_cb.isChecked() else None
+        )
+        return build_output_base_paths(
+            self.department,
+            shot_code,
+            custom_dir=custom_dir,
+        )
+
+    @property
+    def output_base_path(self) -> Path | None:
+        output_base, _ = self.resolve_output_base_paths()
+        return output_base
 
     @property
     def custom_output_base_path(self) -> Path | None:
-        if not self._custom_export_cb.isChecked():
-            return None
-        custom_dir = self._custom_export_dir()
-        if custom_dir is None:
-            return None
-        shot_code = self.shot_code
-        if not shot_code:
-            return None
-        return build_custom_output_base_path(custom_dir, shot_code, self._timestamp)
+        _, custom_output_base = self.resolve_output_base_paths()
+        return custom_output_base
 
     def _toggle_custom_export(self, enabled: bool) -> None:
         self._custom_export_row.setVisible(enabled)
@@ -136,7 +139,7 @@ class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
         return Path(text).expanduser()
 
     def _update_export_paths(self) -> None:
-        output_base = self.output_base_path
+        output_base, _ = self.resolve_output_base_paths()
         if output_base is None:
             self._export_path_label.setText("No shot code available.")
         else:

--- a/pipeline/pipe/h/playblast/ui.py
+++ b/pipeline/pipe/h/playblast/ui.py
@@ -134,14 +134,10 @@ class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
         if not selected_destination_dirs:
             return {}
 
-        output_prefix = self._output_prefix_for_selected_mode()
-        if not output_prefix:
+        output_basename = self._resolved_output_basename(selected_destination_dirs)
+        if not output_basename:
             return {}
 
-        output_basename = resolve_versioned_playblast_basename(
-            output_prefix,
-            selected_destination_dirs.values(),
-        )
         return {
             destination_name: destination_dir / output_basename
             for destination_name, destination_dir in selected_destination_dirs.items()
@@ -588,28 +584,35 @@ class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
         return "Playblast Custom"
 
     def _preview_output_paths_by_destination(self) -> dict[str, str]:
-        output_prefix = self._output_prefix_for_selected_mode()
-        if not output_prefix:
+        selected_destination_dirs = self._resolved_destination_directories(
+            include_unselected=False
+        )
+        if not selected_destination_dirs:
             return {}
 
-        destination_dirs = self._resolved_destination_directories(
-            include_unselected=True
-        )
-        if not destination_dirs:
-            return {}
+        output_basename = self._resolved_output_basename(selected_destination_dirs)
+        if not output_basename:
+            return {name: str(path) for name, path in selected_destination_dirs.items()}
+
+        return {
+            destination_name: str(destination_path / output_basename)
+            for destination_name, destination_path in selected_destination_dirs.items()
+        }
+
+    def _resolved_output_basename(
+        self, destination_dirs: dict[str, Path]
+    ) -> str | None:
+        output_prefix = self._output_prefix_for_selected_mode()
+        if not output_prefix or not destination_dirs:
+            return None
 
         try:
-            output_basename = resolve_versioned_playblast_basename(
+            return resolve_versioned_playblast_basename(
                 output_prefix,
                 destination_dirs.values(),
             )
         except Exception:
-            return {name: str(path) for name, path in destination_dirs.items()}
-
-        return {
-            destination_name: str(destination_path / output_basename)
-            for destination_name, destination_path in destination_dirs.items()
-        }
+            return None
 
     def _resolved_destination_directories(
         self,

--- a/pipeline/pipe/h/playblast/ui.py
+++ b/pipeline/pipe/h/playblast/ui.py
@@ -1,23 +1,70 @@
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
+import hou
 from Qt import QtCore, QtWidgets
 from shared.util import get_edit_path
 
 from pipe.glui.dialogs import DialogButtons
+from pipe.playblast_naming import resolve_versioned_playblast_basename
 
-from .constants import DEFAULT_RESOLUTION
-from .paths import build_output_base_paths
+from .paths import build_edit_output_directory
 
 if TYPE_CHECKING:
     from pipe.db import DB
+    from pipe.struct.db import Shot
+
+
+SOURCE_MODE = Literal["shot", "custom"]
 
 DEPARTMENTS = ("anim", "comp", "fx", "lighting", "previs")
 
 
+@dataclass(frozen=True)
+class DestinationOption:
+    name: str
+    tooltip: str
+
+
 class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
+    SHOT_TAB_INDEX = 0
+    CUSTOM_TAB_INDEX = 1
+
+    DESTINATION_EDIT = "Send to Edit"
+    DESTINATION_CURRENT = "Current Folder"
+    DESTINATION_CUSTOM = "Custom Folder"
+    DESTINATION_ORDER = (
+        DESTINATION_EDIT,
+        DESTINATION_CURRENT,
+        DESTINATION_CUSTOM,
+    )
+
+    CURRENT_VIEWPORT_CAMERA_TOKEN = "__current_viewport_camera__"
+
+    _conn: DB
+    _custom_camera: QtWidgets.QComboBox
+    _custom_folder_field: QtWidgets.QLineEdit
+    _custom_folder_row: QtWidgets.QWidget
+    _custom_in: QtWidgets.QSpinBox
+    _custom_out: QtWidgets.QSpinBox
+    _default_shot_code: str
+    _dept_combo: QtWidgets.QComboBox
+    _destination_checkboxes: dict[str, QtWidgets.QCheckBox]
+    _destination_path_labels: dict[str, QtWidgets.QLabel]
+    _main_layout: QtWidgets.QVBoxLayout
+    _shot: Shot | None
+    _shot_camera_value: QtWidgets.QLabel
+    _shot_code_value: QtWidgets.QLabel
+    _shot_range_value: QtWidgets.QLabel
+    _shotgrid_description_field: QtWidgets.QLineEdit
+    _shotgrid_description_row: QtWidgets.QWidget
+    _shotgrid_upload_checkbox: QtWidgets.QCheckBox
+    _source_tabs: QtWidgets.QTabWidget
+    _validation_label: QtWidgets.QLabel
+
     def __init__(
         self,
         parent: QtWidgets.QWidget | None,
@@ -25,87 +72,74 @@ class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
         default_shot_code: str | None = None,
     ) -> None:
         super().__init__(parent)
-        self._conn = conn  # remove this if you remove the parameter
+        self._conn = conn
+        self._default_shot_code = (default_shot_code or "").strip()
+        self._shot = self._resolve_shot_context(self._default_shot_code)
+        self._destination_checkboxes = {}
+        self._destination_path_labels = {}
 
-        self._init_buttons(True, "Playblast", "Cancel")
+        self._init_buttons(True, "Playblast Shot", "Cancel")
         self.setWindowTitle("Houdini Playblast")
 
-        layout = QtWidgets.QVBoxLayout(self)
-        form = QtWidgets.QFormLayout()
-        layout.addLayout(form)
-
-        self._shot_field = QtWidgets.QLineEdit(default_shot_code or "")
-        self._shot_field.setReadOnly(True)
-        form.addRow("Shot", self._shot_field)
-
-        self._dept_combo = QtWidgets.QComboBox()
-        self._dept_combo.addItems(DEPARTMENTS)
-        form.addRow("Department", self._dept_combo)
-
-        self._export_path_label = QtWidgets.QLabel(
-            "Select a department to preview output"
-        )
-        self._export_path_label.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
-        form.addRow("Export Path", self._export_path_label)
-
-        w, h = DEFAULT_RESOLUTION
-        resolution_label = QtWidgets.QLabel(f"{w}x{h}")
-        resolution_label.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
-        form.addRow("Resolution", resolution_label)
-
-        self._custom_export_cb = QtWidgets.QCheckBox("Additional export path")
-        self._custom_export_field = QtWidgets.QLineEdit()
-        self._custom_export_field.setPlaceholderText("Select a folder")
-        self._custom_export_button = QtWidgets.QPushButton("Browse")
-
-        custom_row = QtWidgets.QHBoxLayout()
-        custom_row.addWidget(self._custom_export_field)
-        custom_row.addWidget(self._custom_export_button)
-
-        self._custom_export_row = QtWidgets.QWidget()
-        self._custom_export_row.setLayout(custom_row)
-        form.addRow(self._custom_export_cb, self._custom_export_row)
-
-        self._upload_cb = QtWidgets.QCheckBox(
-            "Upload to ShotGrid (not yet implemented)"
-        )
-        layout.addWidget(self._upload_cb)
-
-        layout.addWidget(self.buttons)
-
-        self._dept_combo.currentTextChanged.connect(self._update_export_paths)
-        self._custom_export_cb.toggled.connect(self._toggle_custom_export)
-        self._custom_export_field.textChanged.connect(self._update_export_paths)
-        self._custom_export_button.clicked.connect(self._browse_custom_export_dir)
-
-        self._custom_export_row.setVisible(False)
-        self._update_export_paths()
+        self._setup_ui()
+        self._set_default_source_tab()
+        self._update_ui_state()
 
     @property
     def shot_code(self) -> str:
-        return self._shot_field.text().strip()
+        return self._shot_code_value.text().strip()
 
     @property
     def department(self) -> str:
-        return self._dept_combo.currentText()
+        return str(self._dept_combo.currentText()).strip()
+
+    @property
+    def selected_source_mode(self) -> SOURCE_MODE:
+        return (
+            "shot"
+            if self._source_tabs.currentIndex() == self.SHOT_TAB_INDEX
+            else "custom"
+        )
 
     @property
     def upload_to_shotgrid(self) -> bool:
-        return self._upload_cb.isChecked()
+        return self._shotgrid_upload_checkbox.isChecked()
+
+    @property
+    def shotgrid_description(self) -> str:
+        return self._shotgrid_description_field.text().strip()
+
+    @property
+    def custom_frame_range(self) -> tuple[int, int]:
+        return (self._custom_in.value(), self._custom_out.value())
+
+    @property
+    def custom_camera_path(self) -> str | None:
+        camera_data = self._custom_camera.currentData()
+        camera_token = str(camera_data or "").strip()
+        if not camera_token or camera_token == self.CURRENT_VIEWPORT_CAMERA_TOKEN:
+            return None
+        return camera_token
+
+    @property
+    def custom_shot_code(self) -> str:
+        scene_stem = self._scene_stem()
+        if scene_stem:
+            return scene_stem
+        return "custom"
 
     def resolve_output_base_paths(self) -> tuple[Path | None, Path | None]:
-        shot_code = self.shot_code
-        if not shot_code:
+        """Backward-compatible output helper used by the current launch tool."""
+        output_by_destination = self.resolve_output_bases_by_destination()
+        if not output_by_destination:
             return None, None
 
-        custom_dir = (
-            self._custom_export_dir() if self._custom_export_cb.isChecked() else None
-        )
-        return build_output_base_paths(
-            self.department,
-            shot_code,
-            custom_dir=custom_dir,
-        )
+        primary_output = output_by_destination.get(self.DESTINATION_EDIT)
+        if primary_output is None:
+            primary_output = next(iter(output_by_destination.values()))
+
+        custom_output = output_by_destination.get(self.DESTINATION_CUSTOM)
+        return primary_output, custom_output
 
     @property
     def output_base_path(self) -> Path | None:
@@ -114,33 +148,589 @@ class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
 
     @property
     def custom_output_base_path(self) -> Path | None:
-        _, custom_output_base = self.resolve_output_base_paths()
-        return custom_output_base
+        _, custom_output = self.resolve_output_base_paths()
+        return custom_output
 
-    def _toggle_custom_export(self, enabled: bool) -> None:
-        self._custom_export_row.setVisible(enabled)
-        if not enabled:
-            self._custom_export_field.clear()
-        self._update_export_paths()
+    def resolve_output_bases_by_destination(self) -> dict[str, Path]:
+        selected_dirs = self._selected_destination_directories_by_name()
+        if not selected_dirs:
+            return {}
 
-    def _browse_custom_export_dir(self) -> None:
-        base_dir = str(get_edit_path())
-        selection = QtWidgets.QFileDialog.getExistingDirectory(
-            self, "Select Additional Export Folder", base_dir
+        output_prefix = self._output_prefix_for_selected_mode()
+        if not output_prefix:
+            return {}
+
+        output_basename = resolve_versioned_playblast_basename(
+            output_prefix,
+            selected_dirs.values(),
         )
-        if selection:
-            self._custom_export_field.setText(selection)
+        return {
+            destination_name: destination_dir / output_basename
+            for destination_name, destination_dir in selected_dirs.items()
+        }
 
-    def _custom_export_dir(self) -> Path | None:
-        text = self._custom_export_field.text().strip()
-        if not text:
+    def resolve_selected_output_bases(self) -> list[Path]:
+        output_by_destination = self.resolve_output_bases_by_destination()
+        return [
+            output_by_destination[destination_name]
+            for destination_name in self.DESTINATION_ORDER
+            if destination_name in output_by_destination
+        ]
+
+    def _setup_ui(self) -> None:
+        self._main_layout = QtWidgets.QVBoxLayout(self)
+        self._build_header_section()
+        self._build_export_setup_section()
+        self._build_buttons()
+
+    def _build_header_section(self) -> None:
+        title = QtWidgets.QLabel("Houdini Playblast")
+        title.setStyleSheet("font-size: 24px; font-weight: 700;")
+        title.setAlignment(QtCore.Qt.AlignCenter)
+        title.setToolTip("Playblast export tool for Houdini viewport output.")
+
+        subtitle = QtWidgets.QLabel(
+            "Choose source mode, choose destinations, then export"
+        )
+        subtitle.setAlignment(QtCore.Qt.AlignCenter)
+        subtitle.setToolTip(
+            "Workflow: choose Shot or Custom source, choose destinations, then export."
+        )
+
+        self._main_layout.addWidget(title)
+        self._main_layout.addWidget(subtitle)
+
+    def _build_export_setup_section(self) -> None:
+        setup_group = QtWidgets.QGroupBox("1. Export Setup")
+        setup_layout = QtWidgets.QVBoxLayout(setup_group)
+
+        setup_layout.addWidget(self._build_export_source_section())
+        setup_layout.addWidget(self._build_destination_section())
+
+        self._validation_label = QtWidgets.QLabel()
+        self._validation_label.setStyleSheet("color: #b00020;")
+        self._validation_label.setToolTip(
+            "Validation feedback. Export is disabled until this message is cleared."
+        )
+        self._validation_label.setVisible(False)
+        setup_layout.addWidget(self._validation_label)
+
+        self._main_layout.addWidget(setup_group)
+
+    def _build_export_source_section(self) -> QtWidgets.QGroupBox:
+        source_group = QtWidgets.QGroupBox("")
+        source_layout = QtWidgets.QVBoxLayout(source_group)
+
+        self._source_tabs = QtWidgets.QTabWidget()
+        self._source_tabs.addTab(self._build_shot_source_tab(), "Shot Playblast")
+        self._source_tabs.addTab(self._build_custom_source_tab(), "Custom Playblast")
+        self._source_tabs.currentChanged.connect(self._on_source_mode_changed)
+        self._source_tabs.setToolTip(
+            "Choose source mode: shot metadata from pipeline context or manual custom settings."
+        )
+
+        tab_bar = self._source_tabs.tabBar()
+        tab_bar.setTabToolTip(
+            self.SHOT_TAB_INDEX,
+            "Uses detected shot context and ShotGrid cut range for this file.",
+        )
+        tab_bar.setTabToolTip(
+            self.CUSTOM_TAB_INDEX,
+            "Uses manual camera and frame range for non-shot testing or exploratory output.",
+        )
+
+        source_layout.addWidget(self._source_tabs)
+        return source_group
+
+    def _build_shot_source_tab(self) -> QtWidgets.QWidget:
+        shot_tab = QtWidgets.QWidget()
+        shot_layout = QtWidgets.QGridLayout(shot_tab)
+
+        shot_layout.addWidget(QtWidgets.QLabel("Source"), 0, 0)
+        shot_source_value = QtWidgets.QLabel("Pipeline Shot Context")
+        shot_source_value.setToolTip(
+            "Shot mode uses shot context detected from the Houdini scene."
+        )
+        shot_layout.addWidget(shot_source_value, 0, 1)
+
+        shot_layout.addWidget(QtWidgets.QLabel("Shot"), 1, 0)
+        self._shot_code_value = QtWidgets.QLabel("-")
+        self._shot_code_value.setToolTip("Detected shot code.")
+        shot_layout.addWidget(self._shot_code_value, 1, 1)
+
+        shot_layout.addWidget(QtWidgets.QLabel("Camera"), 2, 0)
+        self._shot_camera_value = QtWidgets.QLabel("-")
+        self._shot_camera_value.setToolTip(
+            "Viewport camera currently used by the Houdini playblast capture."
+        )
+        shot_layout.addWidget(self._shot_camera_value, 2, 1)
+
+        shot_layout.addWidget(QtWidgets.QLabel("Frame Range"), 3, 0)
+        self._shot_range_value = QtWidgets.QLabel("-")
+        self._shot_range_value.setToolTip("ShotGrid cut range for the detected shot.")
+        shot_layout.addWidget(self._shot_range_value, 3, 1)
+
+        shot_layout.addWidget(QtWidgets.QLabel("ShotGrid"), 4, 0)
+        self._shotgrid_upload_checkbox = QtWidgets.QCheckBox("Upload to ShotGrid")
+        self._shotgrid_upload_checkbox.setToolTip(
+            "When enabled, this shot playblast will also upload to ShotGrid."
+        )
+        self._shotgrid_upload_checkbox.toggled.connect(self._on_shotgrid_upload_toggled)
+        shot_layout.addWidget(self._shotgrid_upload_checkbox, 4, 1)
+
+        self._shotgrid_description_row = QtWidgets.QWidget()
+        shotgrid_description_layout = QtWidgets.QHBoxLayout(
+            self._shotgrid_description_row
+        )
+        shotgrid_description_layout.setContentsMargins(0, 0, 0, 0)
+        shotgrid_description_layout.addWidget(QtWidgets.QLabel("Description"))
+        self._shotgrid_description_field = QtWidgets.QLineEdit()
+        self._shotgrid_description_field.setPlaceholderText(
+            "Optional ShotGrid version description"
+        )
+        self._shotgrid_description_field.setToolTip(
+            "Optional notes for the ShotGrid Version description."
+        )
+        shotgrid_description_layout.addWidget(self._shotgrid_description_field)
+        shot_layout.addWidget(self._shotgrid_description_row, 5, 0, 1, 2)
+        self._sync_shotgrid_description_visibility()
+        return shot_tab
+
+    def _build_custom_source_tab(self) -> QtWidgets.QWidget:
+        custom_tab = QtWidgets.QWidget()
+        custom_layout = QtWidgets.QGridLayout(custom_tab)
+
+        custom_layout.addWidget(QtWidgets.QLabel("Source"), 0, 0)
+        custom_source_value = QtWidgets.QLabel("Manual Custom Settings")
+        custom_source_value.setToolTip(
+            "Custom mode is intended for testing and non-shot scene playblasts."
+        )
+        custom_layout.addWidget(custom_source_value, 0, 1, 1, 3)
+
+        timeline_in, timeline_out = self._timeline_range()
+        self._custom_in = QtWidgets.QSpinBox(self, minimum=-100000, maximum=100000)
+        self._custom_out = QtWidgets.QSpinBox(self, minimum=-100000, maximum=100000)
+        self._custom_in.setValue(timeline_in)
+        self._custom_out.setValue(timeline_out)
+        self._custom_out.setMinimum(self._custom_in.value())
+        self._custom_in.setToolTip("Custom start frame for this playblast.")
+        self._custom_out.setToolTip("Custom end frame for this playblast.")
+        self._custom_in.valueChanged.connect(self._on_custom_in_changed)
+        self._custom_out.valueChanged.connect(self._on_custom_settings_changed)
+
+        custom_layout.addWidget(QtWidgets.QLabel("Custom In"), 1, 0)
+        custom_layout.addWidget(self._custom_in, 1, 1)
+        custom_layout.addWidget(QtWidgets.QLabel("Custom Out"), 1, 2)
+        custom_layout.addWidget(self._custom_out, 1, 3)
+
+        custom_layout.addWidget(QtWidgets.QLabel("Camera"), 2, 0)
+        self._custom_camera = QtWidgets.QComboBox()
+        self._populate_custom_camera_options()
+        self._custom_camera.setToolTip("Camera used for custom mode playblast capture.")
+        self._custom_camera.currentTextChanged.connect(self._on_custom_settings_changed)
+        custom_layout.addWidget(self._custom_camera, 2, 1, 1, 3)
+
+        return custom_tab
+
+    def _build_destination_section(self) -> QtWidgets.QGroupBox:
+        destination_group = QtWidgets.QGroupBox("Save Destinations")
+        destination_layout = QtWidgets.QVBoxLayout(destination_group)
+
+        department_row = QtWidgets.QWidget()
+        department_row_layout = QtWidgets.QHBoxLayout(department_row)
+        department_row_layout.setContentsMargins(0, 0, 0, 0)
+        department_row_layout.addWidget(QtWidgets.QLabel("Edit Department"))
+        self._dept_combo = QtWidgets.QComboBox()
+        self._dept_combo.addItems(DEPARTMENTS)
+        self._dept_combo.setToolTip(
+            "Department subfolder used for Send to Edit output paths."
+        )
+        self._dept_combo.currentTextChanged.connect(self._on_department_changed)
+        department_row_layout.addWidget(self._dept_combo)
+        department_row_layout.addStretch()
+        destination_layout.addWidget(department_row)
+
+        for destination in self._destination_options():
+            row_widget = QtWidgets.QWidget()
+            row_layout = QtWidgets.QHBoxLayout(row_widget)
+            row_layout.setContentsMargins(0, 0, 0, 0)
+
+            destination_toggle = QtWidgets.QCheckBox(destination.name)
+            destination_toggle.setChecked(destination.name == self.DESTINATION_EDIT)
+            destination_toggle.setToolTip(destination.tooltip)
+            destination_toggle.toggled.connect(self._on_destination_toggled)
+            self._destination_checkboxes[destination.name] = destination_toggle
+            row_layout.addWidget(destination_toggle)
+
+            destination_path_label = QtWidgets.QLabel("")
+            destination_path_label.setToolTip(
+                f"Resolved output path for {destination.name}."
+            )
+            destination_path_label.setTextInteractionFlags(
+                QtCore.Qt.TextSelectableByMouse
+            )
+            self._destination_path_labels[destination.name] = destination_path_label
+            row_layout.addWidget(destination_path_label)
+            row_layout.addStretch()
+            destination_layout.addWidget(row_widget)
+
+        self._align_destination_checkboxes()
+        self._custom_folder_row = self._build_custom_folder_row()
+        destination_layout.addWidget(self._custom_folder_row)
+        return destination_group
+
+    def _build_custom_folder_row(self) -> QtWidgets.QWidget:
+        custom_path_row = QtWidgets.QWidget()
+        custom_path_layout = QtWidgets.QHBoxLayout(custom_path_row)
+        custom_path_layout.setContentsMargins(24, 0, 0, 0)
+
+        custom_path_layout.addWidget(QtWidgets.QLabel("Custom Folder Path"))
+        self._custom_folder_field = QtWidgets.QLineEdit()
+        self._custom_folder_field.setText(str(get_edit_path()))
+        self._custom_folder_field.setToolTip(
+            "Directory used when Custom Folder destination is enabled."
+        )
+        self._custom_folder_field.textChanged.connect(self._on_custom_path_changed)
+        custom_path_layout.addWidget(self._custom_folder_field)
+
+        browse_button = QtWidgets.QPushButton("Browse")
+        browse_button.setToolTip("Choose a custom output directory.")
+        browse_button.clicked.connect(self._browse_custom_folder)
+        custom_path_layout.addWidget(browse_button)
+        return custom_path_row
+
+    def _build_buttons(self) -> None:
+        ok_button = self.buttons.button(QtWidgets.QDialogButtonBox.Ok)
+        if ok_button is not None:
+            ok_button.setToolTip("Run playblast with the current settings.")
+
+        cancel_button = self.buttons.button(QtWidgets.QDialogButtonBox.Cancel)
+        if cancel_button is not None:
+            cancel_button.setToolTip("Close without exporting.")
+
+        self.buttons.accepted.connect(self.accept)
+        self.buttons.rejected.connect(self.reject)
+        self._main_layout.addWidget(self.buttons)
+
+    @staticmethod
+    def _destination_options() -> tuple[DestinationOption, ...]:
+        return (
+            DestinationOption(
+                HPlayblastDialog.DESTINATION_EDIT,
+                "Export playblast movie to the edit dailies folder.",
+            ),
+            DestinationOption(
+                HPlayblastDialog.DESTINATION_CURRENT,
+                "Export playblast movie next to the current HIP scene file.",
+            ),
+            DestinationOption(
+                HPlayblastDialog.DESTINATION_CUSTOM,
+                "Export playblast movie to a manually selected folder.",
+            ),
+        )
+
+    def _resolve_shot_context(self, shot_code: str) -> Shot | None:
+        if not shot_code:
             return None
-        # expanduser() doesn’t really throw for normal strings, but keep it simple.
-        return Path(text).expanduser()
+        try:
+            return self._conn.get_shot_by_code(shot_code)
+        except Exception:
+            return None
 
-    def _update_export_paths(self) -> None:
-        output_base, _ = self.resolve_output_base_paths()
-        if output_base is None:
-            self._export_path_label.setText("No shot code available.")
+    def _set_default_source_tab(self) -> None:
+        has_shot_context = self._shot is not None
+        self._source_tabs.setTabEnabled(self.SHOT_TAB_INDEX, has_shot_context)
+        self._source_tabs.setCurrentIndex(
+            self.SHOT_TAB_INDEX if has_shot_context else self.CUSTOM_TAB_INDEX
+        )
+
+    def _align_destination_checkboxes(self) -> None:
+        destination_column_width = max(
+            (
+                checkbox.sizeHint().width()
+                for checkbox in self._destination_checkboxes.values()
+            ),
+            default=0,
+        )
+        for checkbox in self._destination_checkboxes.values():
+            checkbox.setFixedWidth(destination_column_width)
+
+    def _update_ui_state(self) -> None:
+        self._refresh_shot_context_fields()
+        self._sync_custom_folder_row_visibility()
+        self._sync_shotgrid_description_visibility()
+        self._refresh_destination_path_labels()
+        self._update_action_state()
+
+    def _refresh_shot_context_fields(self) -> None:
+        if self._shot is None:
+            self._shot_code_value.setText(self._default_shot_code or "-")
+            self._shot_range_value.setText("-")
         else:
-            self._export_path_label.setText(str(output_base))
+            self._shot_code_value.setText(self._shot.code)
+            self._shot_range_value.setText(
+                f"{self._shot.cut_in} - {self._shot.cut_out}"
+            )
+
+        self._shot_camera_value.setText(self._current_viewport_camera_label())
+
+    def _sync_custom_folder_row_visibility(self) -> None:
+        is_custom_destination_selected = self._is_destination_selected(
+            self.DESTINATION_CUSTOM
+        )
+        self._custom_folder_row.setVisible(is_custom_destination_selected)
+        self._custom_folder_field.setEnabled(is_custom_destination_selected)
+
+    def _sync_shotgrid_description_visibility(self) -> None:
+        show_description = (
+            self.selected_source_mode == "shot" and self.upload_to_shotgrid
+        )
+        self._shotgrid_description_row.setVisible(show_description)
+        self._shotgrid_description_field.setEnabled(show_description)
+
+    def _refresh_destination_path_labels(self) -> None:
+        preview_paths = self._preview_output_bases_by_destination()
+        for destination_name, path_label in self._destination_path_labels.items():
+            preview_path = preview_paths.get(destination_name, "")
+            if preview_path:
+                path_label.setText(f"-> {preview_path}")
+            elif (
+                destination_name == self.DESTINATION_CUSTOM
+                and self._is_destination_selected(self.DESTINATION_CUSTOM)
+            ):
+                path_label.setText("-> (select custom folder)")
+            else:
+                path_label.setText("->")
+
+    def _update_action_state(self) -> None:
+        ok_button = self.buttons.button(QtWidgets.QDialogButtonBox.Ok)
+        if ok_button is None:
+            return
+
+        ok_button.setText(self._action_button_text())
+        validation_error = self._validate_state()
+        ok_button.setEnabled(validation_error is None)
+        self._validation_label.setText(validation_error or "")
+        self._validation_label.setVisible(validation_error is not None)
+
+    def _validate_state(self) -> str | None:
+        mode = self.selected_source_mode
+
+        if mode == "shot":
+            if self._shot is None:
+                return (
+                    "No shot context is available. Switch to Custom Playblast or open a "
+                    "pipeline shot scene."
+                )
+
+        if mode == "custom":
+            if self._custom_out.value() < self._custom_in.value():
+                return "Custom Out must be greater than or equal to Custom In."
+
+            if not str(self._custom_camera.currentText()).strip():
+                return "Choose a camera for Custom Playblast."
+
+        if not self._selected_destination_directories_by_name():
+            return "Select at least one save destination."
+
+        if (
+            self._is_destination_selected(self.DESTINATION_CUSTOM)
+            and self._custom_directory() is None
+        ):
+            return "Custom Folder path is required when Custom Folder destination is enabled."
+
+        output_prefix = self._output_prefix_for_selected_mode()
+        if not output_prefix:
+            return "Could not determine a valid output prefix for this playblast."
+
+        return None
+
+    def _action_button_text(self) -> str:
+        if self.selected_source_mode == "shot":
+            return "Playblast Shot"
+        return "Playblast Custom"
+
+    def _output_prefix_for_selected_mode(self) -> str:
+        if self.selected_source_mode == "shot":
+            return self.shot_code
+
+        scene_stem = self._scene_stem()
+        if scene_stem:
+            return f"customPB_{scene_stem}"
+        return "customPB"
+
+    def _preview_output_bases_by_destination(self) -> dict[str, str]:
+        output_prefix = self._output_prefix_for_selected_mode()
+        if not output_prefix:
+            return {}
+
+        destination_dirs = self._destination_directories_for_preview()
+        if not destination_dirs:
+            return {}
+
+        try:
+            output_basename = resolve_versioned_playblast_basename(
+                output_prefix,
+                destination_dirs.values(),
+            )
+        except Exception:
+            return {name: str(path) for name, path in destination_dirs.items()}
+
+        return {
+            destination_name: str(destination_path / output_basename)
+            for destination_name, destination_path in destination_dirs.items()
+        }
+
+    def _destination_directories_for_preview(self) -> dict[str, Path]:
+        directories: dict[str, Path] = {}
+        for destination_name in self.DESTINATION_ORDER:
+            destination_directory = self._resolved_destination_directory(
+                destination_name
+            )
+            if destination_directory is None:
+                continue
+            directories[destination_name] = destination_directory
+        return directories
+
+    def _selected_destination_directories_by_name(self) -> dict[str, Path]:
+        directories: dict[str, Path] = {}
+        for destination_name in self.DESTINATION_ORDER:
+            if not self._is_destination_selected(destination_name):
+                continue
+            destination_directory = self._resolved_destination_directory(
+                destination_name
+            )
+            if destination_directory is None:
+                continue
+            directories[destination_name] = destination_directory
+        return directories
+
+    def _is_destination_selected(self, destination_name: str) -> bool:
+        checkbox = self._destination_checkboxes.get(destination_name)
+        return bool(checkbox and checkbox.isChecked())
+
+    def _resolved_destination_directory(self, destination_name: str) -> Path | None:
+        if destination_name == self.DESTINATION_EDIT:
+            return build_edit_output_directory(self.department)
+
+        if destination_name == self.DESTINATION_CURRENT:
+            return self._current_scene_directory()
+
+        if destination_name == self.DESTINATION_CUSTOM:
+            return self._custom_directory()
+
+        return None
+
+    def _current_scene_directory(self) -> Path:
+        try:
+            return Path(hou.hipFile.path()).expanduser().resolve().parent
+        except Exception:
+            return Path.cwd()
+
+    def _custom_directory(self) -> Path | None:
+        custom_path_text = self._custom_folder_field.text().strip()
+        if not custom_path_text:
+            return None
+        return Path(custom_path_text).expanduser()
+
+    def _browse_custom_folder(self) -> None:
+        start_directory = str(self._custom_directory() or get_edit_path())
+        selected_directory = QtWidgets.QFileDialog.getExistingDirectory(
+            self,
+            "Select Custom Playblast Folder",
+            start_directory,
+        )
+        if selected_directory:
+            self._custom_folder_field.setText(selected_directory)
+
+    def _populate_custom_camera_options(self) -> None:
+        self._custom_camera.clear()
+        self._custom_camera.addItem(
+            "Current Viewport Camera",
+            self.CURRENT_VIEWPORT_CAMERA_TOKEN,
+        )
+
+        for camera_path in self._available_camera_paths():
+            self._custom_camera.addItem(camera_path, camera_path)
+
+    @staticmethod
+    def _available_camera_paths() -> list[str]:
+        object_context = hou.node("/obj")
+        if object_context is None:
+            return []
+
+        cameras: list[str] = []
+        object_nodes = [object_context, *object_context.allSubChildren()]
+        for node in object_nodes:
+            try:
+                if node.type().category() != hou.objNodeTypeCategory():
+                    continue
+                if node.type().name() not in {"cam", "camera"}:
+                    continue
+            except Exception:
+                continue
+            cameras.append(node.path())
+
+        return sorted(set(cameras))
+
+    @staticmethod
+    def _timeline_range() -> tuple[int, int]:
+        try:
+            range_start, range_end = hou.playbar.playbackRange()
+            start = int(round(range_start))
+            end = int(round(range_end))
+        except Exception:
+            current_frame = int(round(hou.frame()))
+            start = current_frame
+            end = current_frame
+
+        if end < start:
+            end = start
+        return start, end
+
+    @staticmethod
+    def _scene_stem() -> str:
+        try:
+            return Path(hou.hipFile.path()).stem.strip()
+        except Exception:
+            return ""
+
+    @staticmethod
+    def _current_viewport_camera_label() -> str:
+        try:
+            scene_viewer = hou.ui.paneTabOfType(hou.paneTabType.SceneViewer)
+            if scene_viewer is None:
+                return "Current Viewport Camera"
+
+            viewport = scene_viewer.curViewport()
+            if viewport is None:
+                return "Current Viewport Camera"
+
+            camera_node = viewport.camera()
+            if camera_node is None:
+                return "Current Viewport Camera"
+            return camera_node.path()
+        except Exception:
+            return "Current Viewport Camera"
+
+    def _on_source_mode_changed(self, _index: int) -> None:
+        self._update_ui_state()
+
+    def _on_destination_toggled(self, _checked: bool) -> None:
+        self._update_ui_state()
+
+    def _on_custom_path_changed(self, _path: str) -> None:
+        self._update_ui_state()
+
+    def _on_custom_in_changed(self, in_frame: int) -> None:
+        self._custom_out.setMinimum(in_frame)
+        self._update_ui_state()
+
+    def _on_custom_settings_changed(self, *_args) -> None:
+        self._update_ui_state()
+
+    def _on_department_changed(self, _department: str) -> None:
+        self._update_ui_state()
+
+    def _on_shotgrid_upload_toggled(self, _enabled: bool) -> None:
+        self._update_ui_state()

--- a/pipeline/pipe/h/playblast/ui.py
+++ b/pipeline/pipe/h/playblast/ui.py
@@ -82,6 +82,7 @@ class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
         self.setWindowTitle("Houdini Playblast")
 
         self._setup_ui()
+        self._wire_ui_signals()
         self._set_default_source_tab()
         self._update_ui_state()
 
@@ -95,11 +96,9 @@ class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
 
     @property
     def selected_source_mode(self) -> SOURCE_MODE:
-        return (
-            "shot"
-            if self._source_tabs.currentIndex() == self.SHOT_TAB_INDEX
-            else "custom"
-        )
+        if self._source_tabs.currentIndex() == self.SHOT_TAB_INDEX:
+            return "shot"
+        return "custom"
 
     @property
     def upload_to_shotgrid(self) -> bool:
@@ -128,32 +127,11 @@ class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
             return scene_stem
         return "custom"
 
-    def resolve_output_base_paths(self) -> tuple[Path | None, Path | None]:
-        """Backward-compatible output helper used by the current launch tool."""
-        output_by_destination = self.resolve_output_bases_by_destination()
-        if not output_by_destination:
-            return None, None
-
-        primary_output = output_by_destination.get(self.DESTINATION_EDIT)
-        if primary_output is None:
-            primary_output = next(iter(output_by_destination.values()))
-
-        custom_output = output_by_destination.get(self.DESTINATION_CUSTOM)
-        return primary_output, custom_output
-
-    @property
-    def output_base_path(self) -> Path | None:
-        output_base, _ = self.resolve_output_base_paths()
-        return output_base
-
-    @property
-    def custom_output_base_path(self) -> Path | None:
-        _, custom_output = self.resolve_output_base_paths()
-        return custom_output
-
     def resolve_output_bases_by_destination(self) -> dict[str, Path]:
-        selected_dirs = self._selected_destination_directories_by_name()
-        if not selected_dirs:
+        selected_destination_dirs = self._resolved_destination_directories(
+            include_unselected=False
+        )
+        if not selected_destination_dirs:
             return {}
 
         output_prefix = self._output_prefix_for_selected_mode()
@@ -162,20 +140,12 @@ class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
 
         output_basename = resolve_versioned_playblast_basename(
             output_prefix,
-            selected_dirs.values(),
+            selected_destination_dirs.values(),
         )
         return {
             destination_name: destination_dir / output_basename
-            for destination_name, destination_dir in selected_dirs.items()
+            for destination_name, destination_dir in selected_destination_dirs.items()
         }
-
-    def resolve_selected_output_bases(self) -> list[Path]:
-        output_by_destination = self.resolve_output_bases_by_destination()
-        return [
-            output_by_destination[destination_name]
-            for destination_name in self.DESTINATION_ORDER
-            if destination_name in output_by_destination
-        ]
 
     def _setup_ui(self) -> None:
         self._main_layout = QtWidgets.QVBoxLayout(self)
@@ -183,12 +153,36 @@ class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
         self._build_export_setup_section()
         self._build_buttons()
 
+    def _wire_ui_signals(self) -> None:
+        self._source_tabs.currentChanged.connect(self._on_ui_input_changed)
+        self._dept_combo.currentTextChanged.connect(self._on_ui_input_changed)
+
+        self._shotgrid_upload_checkbox.toggled.connect(self._on_ui_input_changed)
+        self._custom_folder_field.textChanged.connect(self._on_ui_input_changed)
+        self._custom_camera.currentTextChanged.connect(self._on_ui_input_changed)
+        self._custom_out.valueChanged.connect(self._on_ui_input_changed)
+
+        for checkbox in self._destination_checkboxes.values():
+            checkbox.toggled.connect(self._on_ui_input_changed)
+
+        self._custom_in.valueChanged.connect(self._on_custom_in_changed)
+
     def _build_header_section(self) -> None:
+        title_label = self._build_title_label()
+        subtitle_label = self._build_subtitle_label()
+        self._main_layout.addWidget(title_label)
+        self._main_layout.addWidget(subtitle_label)
+
+    @staticmethod
+    def _build_title_label() -> QtWidgets.QLabel:
         title = QtWidgets.QLabel("Houdini Playblast")
         title.setStyleSheet("font-size: 24px; font-weight: 700;")
         title.setAlignment(QtCore.Qt.AlignCenter)
         title.setToolTip("Playblast export tool for Houdini viewport output.")
+        return title
 
+    @staticmethod
+    def _build_subtitle_label() -> QtWidgets.QLabel:
         subtitle = QtWidgets.QLabel(
             "Choose source mode, choose destinations, then export"
         )
@@ -196,40 +190,38 @@ class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
         subtitle.setToolTip(
             "Workflow: choose Shot or Custom source, choose destinations, then export."
         )
-
-        self._main_layout.addWidget(title)
-        self._main_layout.addWidget(subtitle)
+        return subtitle
 
     def _build_export_setup_section(self) -> None:
-        setup_group = QtWidgets.QGroupBox("1. Export Setup")
-        setup_layout = QtWidgets.QVBoxLayout(setup_group)
+        export_setup_group = QtWidgets.QGroupBox("1. Export Setup")
+        export_setup_layout = QtWidgets.QVBoxLayout(export_setup_group)
 
-        setup_layout.addWidget(self._build_export_source_section())
-        setup_layout.addWidget(self._build_destination_section())
+        export_setup_layout.addWidget(self._build_export_source_section())
+        export_setup_layout.addWidget(self._build_destination_section())
+        export_setup_layout.addWidget(self._build_validation_label())
 
-        self._validation_label = QtWidgets.QLabel()
-        self._validation_label.setStyleSheet("color: #b00020;")
-        self._validation_label.setToolTip(
-            "Validation feedback. Export is disabled until this message is cleared."
-        )
-        self._validation_label.setVisible(False)
-        setup_layout.addWidget(self._validation_label)
-
-        self._main_layout.addWidget(setup_group)
+        self._main_layout.addWidget(export_setup_group)
 
     def _build_export_source_section(self) -> QtWidgets.QGroupBox:
-        source_group = QtWidgets.QGroupBox("")
-        source_layout = QtWidgets.QVBoxLayout(source_group)
+        export_source_group = QtWidgets.QGroupBox("")
+        export_source_layout = QtWidgets.QVBoxLayout(export_source_group)
 
-        self._source_tabs = QtWidgets.QTabWidget()
-        self._source_tabs.addTab(self._build_shot_source_tab(), "Shot Playblast")
-        self._source_tabs.addTab(self._build_custom_source_tab(), "Custom Playblast")
-        self._source_tabs.currentChanged.connect(self._on_source_mode_changed)
-        self._source_tabs.setToolTip(
+        self._source_tabs = self._build_source_tabs()
+        export_source_layout.addWidget(self._source_tabs)
+        return export_source_group
+
+    def _build_source_tabs(self) -> QtWidgets.QTabWidget:
+        source_tabs = QtWidgets.QTabWidget()
+        source_tabs.addTab(self._build_shot_source_tab(), "Shot Playblast")
+        source_tabs.addTab(self._build_custom_source_tab(), "Custom Playblast")
+        source_tabs.setToolTip(
             "Choose source mode: shot metadata from pipeline context or manual custom settings."
         )
+        self._apply_source_tab_tooltips(source_tabs)
+        return source_tabs
 
-        tab_bar = self._source_tabs.tabBar()
+    def _apply_source_tab_tooltips(self, source_tabs: QtWidgets.QTabWidget) -> None:
+        tab_bar = source_tabs.tabBar()
         tab_bar.setTabToolTip(
             self.SHOT_TAB_INDEX,
             "Uses detected shot context and ShotGrid cut range for this file.",
@@ -239,51 +231,57 @@ class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
             "Uses manual camera and frame range for non-shot testing or exploratory output.",
         )
 
-        source_layout.addWidget(self._source_tabs)
-        return source_group
-
     def _build_shot_source_tab(self) -> QtWidgets.QWidget:
         shot_tab = QtWidgets.QWidget()
         shot_layout = QtWidgets.QGridLayout(shot_tab)
 
-        shot_layout.addWidget(QtWidgets.QLabel("Source"), 0, 0)
-        shot_source_value = QtWidgets.QLabel("Pipeline Shot Context")
-        shot_source_value.setToolTip(
-            "Shot mode uses shot context detected from the Houdini scene."
+        self._add_shot_source_mode_row(shot_layout)
+        self._add_shot_code_row(shot_layout)
+        self._add_shot_camera_row(shot_layout)
+        self._add_shot_range_row(shot_layout)
+        self._add_shotgrid_upload_row(shot_layout)
+        self._add_shotgrid_description_row(shot_layout)
+        return shot_tab
+
+    def _add_shot_source_mode_row(self, layout: QtWidgets.QGridLayout) -> None:
+        layout.addWidget(QtWidgets.QLabel("Source"), 0, 0)
+        source_value = QtWidgets.QLabel("Pipeline Shot Context")
+        source_value.setToolTip("Shot mode uses shot context detected from the scene.")
+        layout.addWidget(source_value, 0, 1)
+
+    def _add_shot_code_row(self, layout: QtWidgets.QGridLayout) -> None:
+        layout.addWidget(QtWidgets.QLabel("Shot"), 1, 0)
+        self._shot_code_value = self._build_value_label("Detected shot code.")
+        layout.addWidget(self._shot_code_value, 1, 1)
+
+    def _add_shot_camera_row(self, layout: QtWidgets.QGridLayout) -> None:
+        layout.addWidget(QtWidgets.QLabel("Camera"), 2, 0)
+        self._shot_camera_value = self._build_value_label(
+            "Viewport camera currently used by capture."
         )
-        shot_layout.addWidget(shot_source_value, 0, 1)
+        layout.addWidget(self._shot_camera_value, 2, 1)
 
-        shot_layout.addWidget(QtWidgets.QLabel("Shot"), 1, 0)
-        self._shot_code_value = QtWidgets.QLabel("-")
-        self._shot_code_value.setToolTip("Detected shot code.")
-        shot_layout.addWidget(self._shot_code_value, 1, 1)
-
-        shot_layout.addWidget(QtWidgets.QLabel("Camera"), 2, 0)
-        self._shot_camera_value = QtWidgets.QLabel("-")
-        self._shot_camera_value.setToolTip(
-            "Viewport camera currently used by the Houdini playblast capture."
+    def _add_shot_range_row(self, layout: QtWidgets.QGridLayout) -> None:
+        layout.addWidget(QtWidgets.QLabel("Frame Range"), 3, 0)
+        self._shot_range_value = self._build_value_label(
+            "ShotGrid cut range for the detected shot."
         )
-        shot_layout.addWidget(self._shot_camera_value, 2, 1)
+        layout.addWidget(self._shot_range_value, 3, 1)
 
-        shot_layout.addWidget(QtWidgets.QLabel("Frame Range"), 3, 0)
-        self._shot_range_value = QtWidgets.QLabel("-")
-        self._shot_range_value.setToolTip("ShotGrid cut range for the detected shot.")
-        shot_layout.addWidget(self._shot_range_value, 3, 1)
-
-        shot_layout.addWidget(QtWidgets.QLabel("ShotGrid"), 4, 0)
+    def _add_shotgrid_upload_row(self, layout: QtWidgets.QGridLayout) -> None:
+        layout.addWidget(QtWidgets.QLabel("ShotGrid"), 4, 0)
         self._shotgrid_upload_checkbox = QtWidgets.QCheckBox("Upload to ShotGrid")
         self._shotgrid_upload_checkbox.setToolTip(
             "When enabled, this shot playblast will also upload to ShotGrid."
         )
-        self._shotgrid_upload_checkbox.toggled.connect(self._on_shotgrid_upload_toggled)
-        shot_layout.addWidget(self._shotgrid_upload_checkbox, 4, 1)
+        layout.addWidget(self._shotgrid_upload_checkbox, 4, 1)
 
+    def _add_shotgrid_description_row(self, layout: QtWidgets.QGridLayout) -> None:
         self._shotgrid_description_row = QtWidgets.QWidget()
-        shotgrid_description_layout = QtWidgets.QHBoxLayout(
-            self._shotgrid_description_row
-        )
-        shotgrid_description_layout.setContentsMargins(0, 0, 0, 0)
-        shotgrid_description_layout.addWidget(QtWidgets.QLabel("Description"))
+        description_layout = QtWidgets.QHBoxLayout(self._shotgrid_description_row)
+        description_layout.setContentsMargins(0, 0, 0, 0)
+        description_layout.addWidget(QtWidgets.QLabel("Description"))
+
         self._shotgrid_description_field = QtWidgets.QLineEdit()
         self._shotgrid_description_field.setPlaceholderText(
             "Optional ShotGrid version description"
@@ -291,22 +289,33 @@ class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
         self._shotgrid_description_field.setToolTip(
             "Optional notes for the ShotGrid Version description."
         )
-        shotgrid_description_layout.addWidget(self._shotgrid_description_field)
-        shot_layout.addWidget(self._shotgrid_description_row, 5, 0, 1, 2)
-        self._sync_shotgrid_description_visibility()
-        return shot_tab
+        description_layout.addWidget(self._shotgrid_description_field)
+        layout.addWidget(self._shotgrid_description_row, 5, 0, 1, 2)
+
+    @staticmethod
+    def _build_value_label(tooltip: str) -> QtWidgets.QLabel:
+        label = QtWidgets.QLabel("-")
+        label.setToolTip(tooltip)
+        return label
 
     def _build_custom_source_tab(self) -> QtWidgets.QWidget:
         custom_tab = QtWidgets.QWidget()
         custom_layout = QtWidgets.QGridLayout(custom_tab)
 
-        custom_layout.addWidget(QtWidgets.QLabel("Source"), 0, 0)
-        custom_source_value = QtWidgets.QLabel("Manual Custom Settings")
-        custom_source_value.setToolTip(
+        self._add_custom_source_mode_row(custom_layout)
+        self._add_custom_frame_range_row(custom_layout)
+        self._add_custom_camera_row(custom_layout)
+        return custom_tab
+
+    def _add_custom_source_mode_row(self, layout: QtWidgets.QGridLayout) -> None:
+        layout.addWidget(QtWidgets.QLabel("Source"), 0, 0)
+        source_value = QtWidgets.QLabel("Manual Custom Settings")
+        source_value.setToolTip(
             "Custom mode is intended for testing and non-shot scene playblasts."
         )
-        custom_layout.addWidget(custom_source_value, 0, 1, 1, 3)
+        layout.addWidget(source_value, 0, 1, 1, 3)
 
+    def _add_custom_frame_range_row(self, layout: QtWidgets.QGridLayout) -> None:
         timeline_in, timeline_out = self._timeline_range()
         self._custom_in = QtWidgets.QSpinBox(self, minimum=-100000, maximum=100000)
         self._custom_out = QtWidgets.QSpinBox(self, minimum=-100000, maximum=100000)
@@ -315,89 +324,98 @@ class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
         self._custom_out.setMinimum(self._custom_in.value())
         self._custom_in.setToolTip("Custom start frame for this playblast.")
         self._custom_out.setToolTip("Custom end frame for this playblast.")
-        self._custom_in.valueChanged.connect(self._on_custom_in_changed)
-        self._custom_out.valueChanged.connect(self._on_custom_settings_changed)
 
-        custom_layout.addWidget(QtWidgets.QLabel("Custom In"), 1, 0)
-        custom_layout.addWidget(self._custom_in, 1, 1)
-        custom_layout.addWidget(QtWidgets.QLabel("Custom Out"), 1, 2)
-        custom_layout.addWidget(self._custom_out, 1, 3)
+        layout.addWidget(QtWidgets.QLabel("Custom In"), 1, 0)
+        layout.addWidget(self._custom_in, 1, 1)
+        layout.addWidget(QtWidgets.QLabel("Custom Out"), 1, 2)
+        layout.addWidget(self._custom_out, 1, 3)
 
-        custom_layout.addWidget(QtWidgets.QLabel("Camera"), 2, 0)
+    def _add_custom_camera_row(self, layout: QtWidgets.QGridLayout) -> None:
+        layout.addWidget(QtWidgets.QLabel("Camera"), 2, 0)
         self._custom_camera = QtWidgets.QComboBox()
         self._populate_custom_camera_options()
         self._custom_camera.setToolTip("Camera used for custom mode playblast capture.")
-        self._custom_camera.currentTextChanged.connect(self._on_custom_settings_changed)
-        custom_layout.addWidget(self._custom_camera, 2, 1, 1, 3)
-
-        return custom_tab
+        layout.addWidget(self._custom_camera, 2, 1, 1, 3)
 
     def _build_destination_section(self) -> QtWidgets.QGroupBox:
         destination_group = QtWidgets.QGroupBox("Save Destinations")
         destination_layout = QtWidgets.QVBoxLayout(destination_group)
 
-        department_row = QtWidgets.QWidget()
-        department_row_layout = QtWidgets.QHBoxLayout(department_row)
-        department_row_layout.setContentsMargins(0, 0, 0, 0)
-        department_row_layout.addWidget(QtWidgets.QLabel("Edit Department"))
-        self._dept_combo = QtWidgets.QComboBox()
-        self._dept_combo.addItems(DEPARTMENTS)
-        self._dept_combo.setToolTip(
-            "Department subfolder used for Send to Edit output paths."
-        )
-        self._dept_combo.currentTextChanged.connect(self._on_department_changed)
-        department_row_layout.addWidget(self._dept_combo)
-        department_row_layout.addStretch()
-        destination_layout.addWidget(department_row)
-
-        for destination in self._destination_options():
-            row_widget = QtWidgets.QWidget()
-            row_layout = QtWidgets.QHBoxLayout(row_widget)
-            row_layout.setContentsMargins(0, 0, 0, 0)
-
-            destination_toggle = QtWidgets.QCheckBox(destination.name)
-            destination_toggle.setChecked(destination.name == self.DESTINATION_EDIT)
-            destination_toggle.setToolTip(destination.tooltip)
-            destination_toggle.toggled.connect(self._on_destination_toggled)
-            self._destination_checkboxes[destination.name] = destination_toggle
-            row_layout.addWidget(destination_toggle)
-
-            destination_path_label = QtWidgets.QLabel("")
-            destination_path_label.setToolTip(
-                f"Resolved output path for {destination.name}."
+        destination_layout.addWidget(self._build_edit_department_row())
+        for destination_option in self._destination_options():
+            destination_layout.addWidget(
+                self._build_destination_option_row(destination_option)
             )
-            destination_path_label.setTextInteractionFlags(
-                QtCore.Qt.TextSelectableByMouse
-            )
-            self._destination_path_labels[destination.name] = destination_path_label
-            row_layout.addWidget(destination_path_label)
-            row_layout.addStretch()
-            destination_layout.addWidget(row_widget)
 
         self._align_destination_checkboxes()
         self._custom_folder_row = self._build_custom_folder_row()
         destination_layout.addWidget(self._custom_folder_row)
         return destination_group
 
-    def _build_custom_folder_row(self) -> QtWidgets.QWidget:
-        custom_path_row = QtWidgets.QWidget()
-        custom_path_layout = QtWidgets.QHBoxLayout(custom_path_row)
-        custom_path_layout.setContentsMargins(24, 0, 0, 0)
+    def _build_edit_department_row(self) -> QtWidgets.QWidget:
+        department_row = QtWidgets.QWidget()
+        department_layout = QtWidgets.QHBoxLayout(department_row)
+        department_layout.setContentsMargins(0, 0, 0, 0)
 
-        custom_path_layout.addWidget(QtWidgets.QLabel("Custom Folder Path"))
+        department_layout.addWidget(QtWidgets.QLabel("Edit Department"))
+        self._dept_combo = QtWidgets.QComboBox()
+        self._dept_combo.addItems(DEPARTMENTS)
+        self._dept_combo.setToolTip(
+            "Department subfolder used for Send to Edit output paths."
+        )
+        department_layout.addWidget(self._dept_combo)
+        department_layout.addStretch()
+        return department_row
+
+    def _build_destination_option_row(
+        self,
+        destination_option: DestinationOption,
+    ) -> QtWidgets.QWidget:
+        row_widget = QtWidgets.QWidget()
+        row_layout = QtWidgets.QHBoxLayout(row_widget)
+        row_layout.setContentsMargins(0, 0, 0, 0)
+
+        destination_toggle = QtWidgets.QCheckBox(destination_option.name)
+        destination_toggle.setChecked(destination_option.name == self.DESTINATION_EDIT)
+        destination_toggle.setToolTip(destination_option.tooltip)
+        self._destination_checkboxes[destination_option.name] = destination_toggle
+        row_layout.addWidget(destination_toggle)
+
+        path_label = QtWidgets.QLabel("")
+        path_label.setToolTip(f"Resolved output path for {destination_option.name}.")
+        path_label.setTextInteractionFlags(QtCore.Qt.TextSelectableByMouse)
+        self._destination_path_labels[destination_option.name] = path_label
+        row_layout.addWidget(path_label)
+        row_layout.addStretch()
+        return row_widget
+
+    def _build_custom_folder_row(self) -> QtWidgets.QWidget:
+        custom_folder_row = QtWidgets.QWidget()
+        custom_folder_layout = QtWidgets.QHBoxLayout(custom_folder_row)
+        custom_folder_layout.setContentsMargins(24, 0, 0, 0)
+
+        custom_folder_layout.addWidget(QtWidgets.QLabel("Custom Folder Path"))
         self._custom_folder_field = QtWidgets.QLineEdit()
         self._custom_folder_field.setText(str(get_edit_path()))
         self._custom_folder_field.setToolTip(
             "Directory used when Custom Folder destination is enabled."
         )
-        self._custom_folder_field.textChanged.connect(self._on_custom_path_changed)
-        custom_path_layout.addWidget(self._custom_folder_field)
+        custom_folder_layout.addWidget(self._custom_folder_field)
 
         browse_button = QtWidgets.QPushButton("Browse")
         browse_button.setToolTip("Choose a custom output directory.")
         browse_button.clicked.connect(self._browse_custom_folder)
-        custom_path_layout.addWidget(browse_button)
-        return custom_path_row
+        custom_folder_layout.addWidget(browse_button)
+        return custom_folder_row
+
+    def _build_validation_label(self) -> QtWidgets.QLabel:
+        self._validation_label = QtWidgets.QLabel()
+        self._validation_label.setStyleSheet("color: #b00020;")
+        self._validation_label.setToolTip(
+            "Validation feedback. Export is disabled until this message is cleared."
+        )
+        self._validation_label.setVisible(False)
+        return self._validation_label
 
     def _build_buttons(self) -> None:
         ok_button = self.buttons.button(QtWidgets.QDialogButtonBox.Ok)
@@ -440,9 +458,10 @@ class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
     def _set_default_source_tab(self) -> None:
         has_shot_context = self._shot is not None
         self._source_tabs.setTabEnabled(self.SHOT_TAB_INDEX, has_shot_context)
-        self._source_tabs.setCurrentIndex(
+        default_index = (
             self.SHOT_TAB_INDEX if has_shot_context else self.CUSTOM_TAB_INDEX
         )
+        self._source_tabs.setCurrentIndex(default_index)
 
     def _align_destination_checkboxes(self) -> None:
         destination_column_width = max(
@@ -475,11 +494,9 @@ class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
         self._shot_camera_value.setText(self._current_viewport_camera_label())
 
     def _sync_custom_folder_row_visibility(self) -> None:
-        is_custom_destination_selected = self._is_destination_selected(
-            self.DESTINATION_CUSTOM
-        )
-        self._custom_folder_row.setVisible(is_custom_destination_selected)
-        self._custom_folder_field.setEnabled(is_custom_destination_selected)
+        show_custom_folder_row = self._is_destination_selected(self.DESTINATION_CUSTOM)
+        self._custom_folder_row.setVisible(show_custom_folder_row)
+        self._custom_folder_field.setEnabled(show_custom_folder_row)
 
     def _sync_shotgrid_description_visibility(self) -> None:
         show_description = (
@@ -489,18 +506,24 @@ class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
         self._shotgrid_description_field.setEnabled(show_description)
 
     def _refresh_destination_path_labels(self) -> None:
-        preview_paths = self._preview_output_bases_by_destination()
+        preview_paths = self._preview_output_paths_by_destination()
         for destination_name, path_label in self._destination_path_labels.items():
             preview_path = preview_paths.get(destination_name, "")
             if preview_path:
                 path_label.setText(f"-> {preview_path}")
-            elif (
-                destination_name == self.DESTINATION_CUSTOM
-                and self._is_destination_selected(self.DESTINATION_CUSTOM)
-            ):
+                continue
+
+            if self._is_missing_custom_path_preview(destination_name):
                 path_label.setText("-> (select custom folder)")
-            else:
-                path_label.setText("->")
+                continue
+
+            path_label.setText("->")
+
+    def _is_missing_custom_path_preview(self, destination_name: str) -> bool:
+        return (
+            destination_name == self.DESTINATION_CUSTOM
+            and self._is_destination_selected(self.DESTINATION_CUSTOM)
+        )
 
     def _update_action_state(self) -> None:
         ok_button = self.buttons.button(QtWidgets.QDialogButtonBox.Ok)
@@ -508,29 +531,43 @@ class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
             return
 
         ok_button.setText(self._action_button_text())
-        validation_error = self._validate_state()
+        validation_error = self._validate_target_destination_state()
         ok_button.setEnabled(validation_error is None)
         self._validation_label.setText(validation_error or "")
         self._validation_label.setVisible(validation_error is not None)
 
-    def _validate_state(self) -> str | None:
-        mode = self.selected_source_mode
+    def _validate_target_destination_state(self) -> str | None:
+        source_error = self._validate_source_state()
+        if source_error:
+            return source_error
 
-        if mode == "shot":
+        destination_error = self._validate_destination_state()
+        if destination_error:
+            return destination_error
+
+        output_prefix_error = self._validate_output_prefix_state()
+        if output_prefix_error:
+            return output_prefix_error
+
+        return None
+
+    def _validate_source_state(self) -> str | None:
+        if self.selected_source_mode == "shot":
             if self._shot is None:
                 return (
                     "No shot context is available. Switch to Custom Playblast or open a "
                     "pipeline shot scene."
                 )
+            return None
 
-        if mode == "custom":
-            if self._custom_out.value() < self._custom_in.value():
-                return "Custom Out must be greater than or equal to Custom In."
+        if self._custom_out.value() < self._custom_in.value():
+            return "Custom Out must be greater than or equal to Custom In."
+        if not str(self._custom_camera.currentText()).strip():
+            return "Choose a camera for Custom Playblast."
+        return None
 
-            if not str(self._custom_camera.currentText()).strip():
-                return "Choose a camera for Custom Playblast."
-
-        if not self._selected_destination_directories_by_name():
+    def _validate_destination_state(self) -> str | None:
+        if not self._resolved_destination_directories(include_unselected=False):
             return "Select at least one save destination."
 
         if (
@@ -538,33 +575,26 @@ class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
             and self._custom_directory() is None
         ):
             return "Custom Folder path is required when Custom Folder destination is enabled."
-
-        output_prefix = self._output_prefix_for_selected_mode()
-        if not output_prefix:
-            return "Could not determine a valid output prefix for this playblast."
-
         return None
+
+    def _validate_output_prefix_state(self) -> str | None:
+        if self._output_prefix_for_selected_mode():
+            return None
+        return "Could not determine a valid output prefix for this playblast."
 
     def _action_button_text(self) -> str:
         if self.selected_source_mode == "shot":
             return "Playblast Shot"
         return "Playblast Custom"
 
-    def _output_prefix_for_selected_mode(self) -> str:
-        if self.selected_source_mode == "shot":
-            return self.shot_code
-
-        scene_stem = self._scene_stem()
-        if scene_stem:
-            return f"customPB_{scene_stem}"
-        return "customPB"
-
-    def _preview_output_bases_by_destination(self) -> dict[str, str]:
+    def _preview_output_paths_by_destination(self) -> dict[str, str]:
         output_prefix = self._output_prefix_for_selected_mode()
         if not output_prefix:
             return {}
 
-        destination_dirs = self._destination_directories_for_preview()
+        destination_dirs = self._resolved_destination_directories(
+            include_unselected=True
+        )
         if not destination_dirs:
             return {}
 
@@ -581,45 +611,48 @@ class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
             for destination_name, destination_path in destination_dirs.items()
         }
 
-    def _destination_directories_for_preview(self) -> dict[str, Path]:
+    def _resolved_destination_directories(
+        self,
+        *,
+        include_unselected: bool,
+    ) -> dict[str, Path]:
         directories: dict[str, Path] = {}
         for destination_name in self.DESTINATION_ORDER:
-            destination_directory = self._resolved_destination_directory(
+            if not include_unselected and not self._is_destination_selected(
                 destination_name
-            )
-            if destination_directory is None:
+            ):
                 continue
-            directories[destination_name] = destination_directory
-        return directories
 
-    def _selected_destination_directories_by_name(self) -> dict[str, Path]:
-        directories: dict[str, Path] = {}
-        for destination_name in self.DESTINATION_ORDER:
-            if not self._is_destination_selected(destination_name):
-                continue
             destination_directory = self._resolved_destination_directory(
                 destination_name
             )
             if destination_directory is None:
                 continue
             directories[destination_name] = destination_directory
+
         return directories
 
     def _is_destination_selected(self, destination_name: str) -> bool:
-        checkbox = self._destination_checkboxes.get(destination_name)
-        return bool(checkbox and checkbox.isChecked())
+        destination_checkbox = self._destination_checkboxes.get(destination_name)
+        return bool(destination_checkbox and destination_checkbox.isChecked())
 
     def _resolved_destination_directory(self, destination_name: str) -> Path | None:
         if destination_name == self.DESTINATION_EDIT:
             return build_edit_output_directory(self.department)
-
         if destination_name == self.DESTINATION_CURRENT:
             return self._current_scene_directory()
-
         if destination_name == self.DESTINATION_CUSTOM:
             return self._custom_directory()
-
         return None
+
+    def _output_prefix_for_selected_mode(self) -> str:
+        if self.selected_source_mode == "shot":
+            return self.shot_code
+
+        scene_stem = self._scene_stem()
+        if scene_stem:
+            return f"customPB_{scene_stem}"
+        return "customPB"
 
     def _current_scene_directory(self) -> Path:
         try:
@@ -659,7 +692,7 @@ class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
         if object_context is None:
             return []
 
-        cameras: list[str] = []
+        camera_paths: list[str] = []
         object_nodes = [object_context, *object_context.allSubChildren()]
         for node in object_nodes:
             try:
@@ -669,9 +702,9 @@ class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
                     continue
             except Exception:
                 continue
-            cameras.append(node.path())
+            camera_paths.append(node.path())
 
-        return sorted(set(cameras))
+        return sorted(set(camera_paths))
 
     @staticmethod
     def _timeline_range() -> tuple[int, int]:
@@ -713,24 +746,9 @@ class HPlayblastDialog(QtWidgets.QDialog, DialogButtons):
         except Exception:
             return "Current Viewport Camera"
 
-    def _on_source_mode_changed(self, _index: int) -> None:
-        self._update_ui_state()
-
-    def _on_destination_toggled(self, _checked: bool) -> None:
-        self._update_ui_state()
-
-    def _on_custom_path_changed(self, _path: str) -> None:
-        self._update_ui_state()
-
     def _on_custom_in_changed(self, in_frame: int) -> None:
         self._custom_out.setMinimum(in_frame)
         self._update_ui_state()
 
-    def _on_custom_settings_changed(self, *_args) -> None:
-        self._update_ui_state()
-
-    def _on_department_changed(self, _department: str) -> None:
-        self._update_ui_state()
-
-    def _on_shotgrid_upload_toggled(self, _enabled: bool) -> None:
+    def _on_ui_input_changed(self, *_args) -> None:
         self._update_ui_state()

--- a/pipeline/pipe/m/playblast/anim.py
+++ b/pipeline/pipe/m/playblast/anim.py
@@ -46,7 +46,7 @@ class AnimPlayblastDialog(PlayblastDialog):
     SG_ID = "sg"
     CUSTOM_ID = "custom"
 
-    def __init__(self, parent):
+    def __init__(self, parent) -> None:
         self._conn = DB.Get(DB_Config)
         try:
             code = str(mc.fileInfo("code", query=True)[0])
@@ -76,54 +76,71 @@ class AnimPlayblastDialog(PlayblastDialog):
         ]
         super().__init__(parent, self._shot_dialog_configs, "LnD Anim Playblast")
 
-    def _setup_ui(self):
+    def _setup_ui(self) -> None:
         super()._setup_ui()
+        self._disable_shotgrid_target_when_missing()
+        self.add_context_widget(self._build_pass_settings_widget())
+        self.add_context_widget(self._build_custom_shot_settings_widget())
 
-        # disable the SG option if we can't find this shot in SG
+    def _disable_shotgrid_target_when_missing(self) -> None:
         if not self._shot:
-            self._enabled_shot_cbs[self.SG_ID].toggle()
-            self._enabled_shot_cbs[self.SG_ID].setEnabled(False)
+            shotgrid_toggle = self._enabled_shot_cbs[self.SG_ID]
+            shotgrid_toggle.setChecked(False)
+            shotgrid_toggle.setEnabled(False)
 
-        anim_settings_widget = QWidget(self)
-        anim_settings_layout = QGridLayout(anim_settings_widget)
+    def _build_pass_settings_widget(self) -> QWidget:
+        pass_settings_widget = QWidget(self)
+        pass_settings_layout = QGridLayout(pass_settings_widget)
         self._shot_pass = QComboBox(self)
         self._shot_pass.addItems(["Blocking #", "Polish #"])
         self._shot_pass.setEditable(True)
         self._shot_pass.setValidator(
-            QRegExpValidator(QRegExp("(?:Blocking|Polish) #\d+"))
+            QRegExpValidator(QRegExp(r"^(?:Blocking|Polish) #\d+$"))
         )
-        anim_settings_layout.addWidget(QLabel("Pass"), 0, 0)
-        anim_settings_layout.addWidget(self._shot_pass, 0, 1, 1, 2)
-        self.add_context_widget(anim_settings_widget)
+        pass_settings_layout.addWidget(QLabel("Pass"), 0, 0)
+        pass_settings_layout.addWidget(self._shot_pass, 0, 1, 1, 2)
+        return pass_settings_widget
 
-        # Create UI for custom shot
-        custom_shot_widget = QWidget(self)
-        custom_shot_layout = QGridLayout(custom_shot_widget)
+    def _build_custom_shot_settings_widget(self) -> QWidget:
+        custom_settings_widget = QWidget(self)
+        custom_settings_layout = QGridLayout(custom_settings_widget)
 
         self._custom_in = QSpinBox(self, maximum=10000, minimum=0, value=1001)
         self._custom_out = QSpinBox(self, maximum=10000, minimum=0, value=1100)
-        custom_shot_layout.addWidget(QLabel("Custom In"), 1, 1)
-        custom_shot_layout.addWidget(self._custom_in, 1, 2)
-        custom_shot_layout.addWidget(QLabel("Custom Out"), 1, 3)
-        custom_shot_layout.addWidget(self._custom_out, 1, 4)
+        custom_settings_layout.addWidget(QLabel("Custom In"), 1, 1)
+        custom_settings_layout.addWidget(self._custom_in, 1, 2)
+        custom_settings_layout.addWidget(QLabel("Custom Out"), 1, 3)
+        custom_settings_layout.addWidget(self._custom_out, 1, 4)
 
         self._custom_camera = QComboBox(self)
-        camera_names = (
-            mc.ls(cameras=True, visible=True) or mc.ls(cameras=True) or ["persp"]
-        )
+        camera_names = self._get_available_camera_names()
         self._custom_camera.addItems(camera_names)
         self._custom_camera.setCurrentIndex(0)
-        escaped_names = [re.escape(camera_name) for camera_name in camera_names]
-        validator_pattern = f"(?:{'|'.join(escaped_names)})"
+        validator_pattern = self._build_camera_validator_pattern(camera_names)
         self._custom_camera.setValidator(QRegExpValidator(QRegExp(validator_pattern)))
-        custom_shot_layout.addWidget(QLabel("Custom Camera"), 2, 1)
-        custom_shot_layout.addWidget(self._custom_camera, 2, 2, 1, 2)
+        custom_settings_layout.addWidget(QLabel("Custom Camera"), 2, 1)
+        custom_settings_layout.addWidget(self._custom_camera, 2, 2, 1, 2)
 
-        # disable UI if custom shot not enabled
-        (escb := self._enabled_shot_cbs[self.CUSTOM_ID]).toggled.connect(
-            checkbox_callback_helper(escb, custom_shot_widget)
+        custom_toggle = self._enabled_shot_cbs[self.CUSTOM_ID]
+        custom_toggle.toggled.connect(
+            checkbox_callback_helper(custom_toggle, custom_settings_widget)
         )
-        self.add_context_widget(custom_shot_widget)
+        return custom_settings_widget
+
+    @staticmethod
+    def _get_available_camera_names() -> list[str]:
+        return mc.ls(cameras=True, visible=True) or mc.ls(cameras=True) or ["persp"]
+
+    @staticmethod
+    def _build_camera_validator_pattern(camera_names: list[str]) -> str:
+        escaped_names = [re.escape(camera_name) for camera_name in camera_names]
+        return f"^(?:{'|'.join(escaped_names)})$"
+
+    def _dialog_config_for_id(self, dialog_id: str) -> MShotDialogConfig:
+        for dialog_config in self._shot_dialog_configs:
+            if dialog_config.id == dialog_id:
+                return dialog_config
+        raise ValueError(f"Missing dialog config for id: {dialog_id}")
 
     def _generate_config(self) -> MPlayblastConfig:
         timestamp = datetime.now().strftime("%m-%d-%y_%H:%M:%S")
@@ -131,14 +148,17 @@ class AnimPlayblastDialog(PlayblastDialog):
 
         if self.is_shot_enabled(self.SG_ID):
             assert self._shot is not None
-            sg_config = next(c for c in self._shot_dialog_configs if c.id == self.SG_ID)
+            shotgrid_dialog_config = self._dialog_config_for_id(self.SG_ID)
             shots.append(
                 MShotPlayblastConfig(
                     camera=self._get_shot_camera_path(),
                     shot=self._shot,
                     paths=self.save_locations_to_paths(
                         self.SG_ID,
-                        (sl[0] for sl in sg_config.save_locs),
+                        (
+                            save_location
+                            for save_location, _ in shotgrid_dialog_config.save_locs
+                        ),
                         f"{self._shot.code}_{timestamp}",
                     ),
                     tails=(5, 5),
@@ -146,26 +166,30 @@ class AnimPlayblastDialog(PlayblastDialog):
             )
 
         if self.is_shot_enabled(self.CUSTOM_ID):
-            custom_config = next(
-                c for c in self._shot_dialog_configs if c.id == self.CUSTOM_ID
-            )
+            custom_dialog_config = self._dialog_config_for_id(self.CUSTOM_ID)
             output_name = (
                 f"customPB_{self._shot.code}_{timestamp}"
                 if self._shot
                 else f"customPB_{timestamp}"
             )
+            custom_in_frame = self._custom_in.value()
+            custom_out_frame = self._custom_out.value()
+            cut_duration = max(0, custom_out_frame - custom_in_frame)
             shots.append(
                 MShotPlayblastConfig(
                     camera=self._custom_camera.currentText(),
                     shot=dummy_shot(
                         "custom",
-                        inv := self._custom_in.value(),
-                        outv := self._custom_out.value(),
-                        cut_duration=outv - inv,
+                        custom_in_frame,
+                        custom_out_frame,
+                        cut_duration=cut_duration,
                     ),
                     paths=self.save_locations_to_paths(
                         self.CUSTOM_ID,
-                        (sl[0] for sl in custom_config.save_locs),
+                        (
+                            save_location
+                            for save_location, _ in custom_dialog_config.save_locs
+                        ),
                         output_name,
                     ),
                 )

--- a/pipeline/pipe/m/playblast/anim.py
+++ b/pipeline/pipe/m/playblast/anim.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
-from datetime import datetime
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import maya.cmds as mc
@@ -14,6 +14,10 @@ from shared.util import get_edit_path
 
 from pipe.db import DB
 from pipe.m.shotfile.anim import _find_usd_shotcam
+from pipe.playblast_naming import (
+    playblast_date_folder,
+    resolve_versioned_playblast_basename,
+)
 from pipe.util import Playblaster, checkbox_callback_helper
 
 from .struct import (
@@ -39,7 +43,7 @@ class AnimPlayblastDialog(PlayblastDialog):
     class SAVE_LOCS(PlayblastDialog.SAVE_LOCS):
         EDIT = SaveLocation(
             "Send to Edit",
-            get_edit_path() / "anim" / datetime.now().strftime("%m-%d-%y"),
+            lambda: get_edit_path() / "anim" / playblast_date_folder(),
             Playblaster.PRESET.EDIT_SQ,
         )
 
@@ -142,24 +146,51 @@ class AnimPlayblastDialog(PlayblastDialog):
                 return dialog_config
         raise ValueError(f"Missing dialog config for id: {dialog_id}")
 
+    def _enabled_destination_directories(
+        self, dialog_id: str, locations: list[SaveLocation]
+    ) -> list[Path]:
+        directories: list[Path] = []
+        for location in locations:
+            if not self.is_location_enabled(dialog_id, location.name):
+                continue
+            destination_dir = str(location.path).strip()
+            if destination_dir:
+                directories.append(Path(destination_dir))
+        return directories
+
+    def _resolve_output_name(
+        self,
+        dialog_id: str,
+        locations: list[SaveLocation],
+        prefix: str,
+    ) -> str:
+        return resolve_versioned_playblast_basename(
+            prefix,
+            self._enabled_destination_directories(dialog_id, locations),
+        )
+
     def _generate_config(self) -> MPlayblastConfig:
-        timestamp = datetime.now().strftime("%m-%d-%y_%H:%M:%S")
         shots: list[MShotPlayblastConfig] = []
 
         if self.is_shot_enabled(self.SG_ID):
             assert self._shot is not None
             shotgrid_dialog_config = self._dialog_config_for_id(self.SG_ID)
+            shotgrid_locations = [
+                save_location for save_location, _ in shotgrid_dialog_config.save_locs
+            ]
+            shotgrid_output_name = self._resolve_output_name(
+                self.SG_ID,
+                shotgrid_locations,
+                self._shot.code,
+            )
             shots.append(
                 MShotPlayblastConfig(
                     camera=self._get_shot_camera_path(),
                     shot=self._shot,
                     paths=self.save_locations_to_paths(
                         self.SG_ID,
-                        (
-                            save_location
-                            for save_location, _ in shotgrid_dialog_config.save_locs
-                        ),
-                        f"{self._shot.code}_{timestamp}",
+                        shotgrid_locations,
+                        shotgrid_output_name,
                     ),
                     tails=(5, 5),
                 )
@@ -167,10 +198,14 @@ class AnimPlayblastDialog(PlayblastDialog):
 
         if self.is_shot_enabled(self.CUSTOM_ID):
             custom_dialog_config = self._dialog_config_for_id(self.CUSTOM_ID)
-            output_name = (
-                f"customPB_{self._shot.code}_{timestamp}"
-                if self._shot
-                else f"customPB_{timestamp}"
+            custom_locations = [
+                save_location for save_location, _ in custom_dialog_config.save_locs
+            ]
+            custom_prefix = f"customPB_{self._shot.code}" if self._shot else "customPB"
+            output_name = self._resolve_output_name(
+                self.CUSTOM_ID,
+                custom_locations,
+                custom_prefix,
             )
             custom_in_frame = self._custom_in.value()
             custom_out_frame = self._custom_out.value()
@@ -186,10 +221,7 @@ class AnimPlayblastDialog(PlayblastDialog):
                     ),
                     paths=self.save_locations_to_paths(
                         self.CUSTOM_ID,
-                        (
-                            save_location
-                            for save_location, _ in custom_dialog_config.save_locs
-                        ),
+                        custom_locations,
                         output_name,
                     ),
                 )

--- a/pipeline/pipe/m/playblast/anim.py
+++ b/pipeline/pipe/m/playblast/anim.py
@@ -2,14 +2,28 @@ from __future__ import annotations
 
 import logging
 import re
+from collections import defaultdict
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 import maya.cmds as mc
 from env_sg import DB_Config
-from Qt.QtCore import QRegExp
-from Qt.QtGui import QRegExpValidator
-from Qt.QtWidgets import QComboBox, QGridLayout, QLabel, QSpinBox, QWidget
+from Qt import QtCore
+from Qt.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDialogButtonBox,
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QSpinBox,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+)
 from shared.util import get_edit_path
 
 from pipe.db import DB
@@ -18,12 +32,11 @@ from pipe.playblast_naming import (
     playblast_date_folder,
     resolve_versioned_playblast_basename,
 )
-from pipe.util import Playblaster, checkbox_callback_helper
+from pipe.util import Playblaster
 
 from .struct import (
     HudDefinition,
     MPlayblastConfig,
-    MShotDialogConfig,
     MShotPlayblastConfig,
     SaveLocation,
     dummy_shot,
@@ -37,8 +50,33 @@ log = logging.getLogger(__name__)
 
 
 class AnimPlayblastDialog(PlayblastDialog):
-    _conn: DB
+    _context_banner: QLabel
+    _custom_camera: QComboBox
+    _custom_folder_row: QWidget
+    _custom_in: QSpinBox
+    _custom_out: QSpinBox
+    _destination_checkboxes: dict[str, QCheckBox]
+    _destination_path_labels: dict[str, QLabel]
+    _save_locations_by_name: dict[str, SaveLocation]
+    _source_tabs: QTabWidget
+    _shot_camera_value: QLabel
+    _shot_code_value: QLabel
+    _shot_range_value: QLabel
     _shot: Shot | None
+    _shot_pass: QComboBox
+    _validation_label: QLabel
+
+    SHOT_TAB_INDEX = 0
+    CUSTOM_TAB_INDEX = 1
+    BOTH_TAB_INDEX = 2
+
+    SOURCE_MODE = Literal["shot", "custom", "both"]
+
+    CONTEXT_BANNER_STYLE = (
+        "padding: 8px; border: 1px solid #c3cfdb; background: #e3ebf5; color: #666;"
+    )
+
+    PASS_PATTERN = re.compile(r"^(?:Blocking|Polish) #\d+$")
 
     class SAVE_LOCS(PlayblastDialog.SAVE_LOCS):
         EDIT = SaveLocation(
@@ -47,185 +85,570 @@ class AnimPlayblastDialog(PlayblastDialog):
             Playblaster.PRESET.EDIT_SQ,
         )
 
-    SG_ID = "sg"
-    CUSTOM_ID = "custom"
-
     def __init__(self, parent) -> None:
-        self._conn = DB.Get(DB_Config)
-        try:
-            code = str(mc.fileInfo("code", query=True)[0])
-            self._shot = self._conn.get_shot_by_code(code)
-        except Exception:
-            self._shot = None
-
-        self._shot_dialog_configs = [
-            MShotDialogConfig(
-                id=self.SG_ID,
-                name="Shot (from SG)",
-                save_locs=[
-                    (self.SAVE_LOCS.EDIT, False),
-                    (self.SAVE_LOCS.CURRENT, True),
-                    (self.SAVE_LOCS.CUSTOM, False),
-                ],
-            ),
-            MShotDialogConfig(
-                id=self.CUSTOM_ID,
-                name="Custom",
-                save_locs=[
-                    (self.SAVE_LOCS.EDIT, False),
-                    (self.SAVE_LOCS.CURRENT, True),
-                    (self.SAVE_LOCS.CUSTOM, False),
-                ],
-            ),
-        ]
-        super().__init__(parent, self._shot_dialog_configs, "LnD Anim Playblast")
+        self._shot = self._resolve_pipeline_shot_context()
+        self._destination_checkboxes = {}
+        self._destination_path_labels = {}
+        self._save_locations_by_name = {
+            location.name: location for location in self._destination_locations()
+        }
+        super().__init__(parent, [], "SKD Anim Playblast")
 
     def _setup_ui(self) -> None:
-        super()._setup_ui()
-        self._disable_shotgrid_target_when_missing()
-        self.add_context_widget(self._build_pass_settings_widget())
-        self.add_context_widget(self._build_custom_shot_settings_widget())
+        self._central_widget = QWidget()
+        self.setCentralWidget(self._central_widget)
+        self._main_layout = QVBoxLayout()
+        self._central_widget.setLayout(self._main_layout)
 
-    def _disable_shotgrid_target_when_missing(self) -> None:
-        if not self._shot:
-            shotgrid_toggle = self._enabled_shot_cbs[self.SG_ID]
-            shotgrid_toggle.setChecked(False)
-            shotgrid_toggle.setEnabled(False)
+        self._build_header_section()
+        self._build_targets_section()
+        self._build_render_options_section()
+        self._build_buttons()
+        self._set_default_source_tab()
+        self._update_ui_state()
 
-    def _build_pass_settings_widget(self) -> QWidget:
-        pass_settings_widget = QWidget(self)
-        pass_settings_layout = QGridLayout(pass_settings_widget)
-        self._shot_pass = QComboBox(self)
-        self._shot_pass.addItems(["Blocking #", "Polish #"])
-        self._shot_pass.setEditable(True)
-        self._shot_pass.setValidator(
-            QRegExpValidator(QRegExp(r"^(?:Blocking|Polish) #\d+$"))
+    def _build_header_section(self) -> None:
+        title = QLabel("SKD Anim Playblast")
+        title.setStyleSheet("font-size: 24px; font-weight: 700;")
+        title.setAlignment(QtCore.Qt.AlignCenter)
+
+        subtitle = QLabel("Choose source mode, choose destinations, then export.")
+        subtitle.setAlignment(QtCore.Qt.AlignCenter)
+        subtitle.setToolTip(
+            "High-level workflow: choose source, choose destinations, then export."
         )
-        pass_settings_layout.addWidget(QLabel("Pass"), 0, 0)
-        pass_settings_layout.addWidget(self._shot_pass, 0, 1, 1, 2)
-        return pass_settings_widget
 
-    def _build_custom_shot_settings_widget(self) -> QWidget:
-        custom_settings_widget = QWidget(self)
-        custom_settings_layout = QGridLayout(custom_settings_widget)
+        self._main_layout.addWidget(title)
+        self._main_layout.addWidget(subtitle)
 
-        self._custom_in = QSpinBox(self, maximum=10000, minimum=0, value=1001)
-        self._custom_out = QSpinBox(self, maximum=10000, minimum=0, value=1100)
-        custom_settings_layout.addWidget(QLabel("Custom In"), 1, 1)
-        custom_settings_layout.addWidget(self._custom_in, 1, 2)
-        custom_settings_layout.addWidget(QLabel("Custom Out"), 1, 3)
-        custom_settings_layout.addWidget(self._custom_out, 1, 4)
+    def _build_targets_section(self) -> None:
+        setup_group = QGroupBox("1. Export Setup")
+        setup_layout = QVBoxLayout(setup_group)
+
+        self._context_banner = QLabel()
+        self._context_banner.setWordWrap(True)
+        self._context_banner.setStyleSheet(self.CONTEXT_BANNER_STYLE)
+        self._context_banner.setToolTip(
+            "Live context for selected export mode: shot, camera, and frame range."
+        )
+        setup_layout.addWidget(self._context_banner)
+
+        setup_layout.addWidget(self._build_export_source_section())
+        setup_layout.addWidget(self._build_destination_section())
+
+        self._validation_label = QLabel()
+        self._validation_label.setStyleSheet("color: #b00020;")
+        self._validation_label.setToolTip(
+            "Validation feedback. Export is disabled until this message is cleared."
+        )
+        self._validation_label.setVisible(False)
+        setup_layout.addWidget(self._validation_label)
+
+        self._main_layout.addWidget(setup_group)
+
+    def _build_export_source_section(self) -> QGroupBox:
+        source_group = QGroupBox("")
+        source_layout = QVBoxLayout(source_group)
+
+        self._source_tabs = QTabWidget()
+        self._source_tabs.addTab(
+            self._build_shot_source_tab(), "Shot Playblast (Pipeline Shot File)"
+        )
+        self._source_tabs.addTab(
+            self._build_custom_source_tab(),
+            "Custom Playblast",
+        )
+        self._source_tabs.addTab(self._build_both_source_tab(), "Both")
+        self._source_tabs.currentChanged.connect(self._on_source_mode_changed)
+
+        source_tab_bar = self._source_tabs.tabBar()
+        source_tab_bar.setTabToolTip(
+            self.SHOT_TAB_INDEX,
+            "Export the pipeline shot loaded in this Maya scene.",
+        )
+        source_tab_bar.setTabToolTip(
+            self.CUSTOM_TAB_INDEX,
+            "Export a manual camera and frame range.",
+        )
+        source_tab_bar.setTabToolTip(
+            self.BOTH_TAB_INDEX,
+            "Export both the pipeline shot and custom range in one run.",
+        )
+
+        source_layout.addWidget(self._source_tabs)
+        source_layout.addWidget(self._build_pass_row())
+        return source_group
+
+    def _build_pass_row(self) -> QWidget:
+        pass_row = QWidget()
+        pass_layout = QHBoxLayout(pass_row)
+        pass_layout.setContentsMargins(0, 0, 0, 0)
+
+        pass_layout.addWidget(QLabel("Pass"))
+
+        self._shot_pass = QComboBox(self)
+        self._shot_pass.addItems(["Blocking #1", "Polish #1"])
+        self._shot_pass.setEditable(True)
+        self._shot_pass.setToolTip(
+            "Pass text shown in the HUD. Format: Blocking #<n> or Polish #<n>."
+        )
+        self._shot_pass.currentTextChanged.connect(self._on_source_settings_changed)
+        pass_layout.addWidget(self._shot_pass)
+        pass_layout.addStretch()
+
+        return pass_row
+
+    def _build_shot_source_tab(self) -> QWidget:
+        shot_tab = QWidget()
+        shot_layout = QGridLayout(shot_tab)
+
+        shot_layout.addWidget(QLabel("Source"), 0, 0)
+        source_value = QLabel("Pipeline Shot File")
+        source_value.setToolTip(
+            "Uses shot context from this scene's pipeline shot code."
+        )
+        shot_layout.addWidget(source_value, 0, 1)
+
+        shot_layout.addWidget(QLabel("Shot"), 1, 0)
+        self._shot_code_value = QLabel("-")
+        self._shot_code_value.setToolTip("Resolved pipeline shot code.")
+        shot_layout.addWidget(self._shot_code_value, 1, 1)
+
+        shot_layout.addWidget(QLabel("Camera"), 2, 0)
+        self._shot_camera_value = QLabel("-")
+        self._shot_camera_value.setToolTip("Resolved shot camera path.")
+        shot_layout.addWidget(self._shot_camera_value, 2, 1)
+
+        shot_layout.addWidget(QLabel("Frame Range"), 3, 0)
+        self._shot_range_value = QLabel("-")
+        self._shot_range_value.setToolTip("Resolved shot cut range from pipeline shot.")
+        shot_layout.addWidget(self._shot_range_value, 3, 1)
+
+        return shot_tab
+
+    def _build_custom_source_tab(self) -> QWidget:
+        custom_tab = QWidget()
+        custom_layout = QGridLayout(custom_tab)
+
+        timeline_in, timeline_out = self._timeline_range()
+        self._custom_in = QSpinBox(self, minimum=0, maximum=10000, value=timeline_in)
+        self._custom_out = QSpinBox(self, minimum=0, maximum=10000, value=timeline_out)
+        self._custom_out.setMinimum(self._custom_in.value())
+        self._custom_in.setToolTip("Start frame for custom playblast.")
+        self._custom_out.setToolTip("End frame for custom playblast.")
+        self._custom_in.valueChanged.connect(self._on_custom_in_changed)
+        self._custom_out.valueChanged.connect(self._on_source_settings_changed)
+
+        custom_layout.addWidget(QLabel("Custom In"), 0, 0)
+        custom_layout.addWidget(self._custom_in, 0, 1)
+        custom_layout.addWidget(QLabel("Custom Out"), 0, 2)
+        custom_layout.addWidget(self._custom_out, 0, 3)
 
         self._custom_camera = QComboBox(self)
-        camera_names = self._get_available_camera_names()
-        self._custom_camera.addItems(camera_names)
-        self._custom_camera.setCurrentIndex(0)
-        validator_pattern = self._build_camera_validator_pattern(camera_names)
-        self._custom_camera.setValidator(QRegExpValidator(QRegExp(validator_pattern)))
-        custom_settings_layout.addWidget(QLabel("Custom Camera"), 2, 1)
-        custom_settings_layout.addWidget(self._custom_camera, 2, 2, 1, 2)
+        self._custom_camera.addItems(self._available_custom_cameras())
+        self._custom_camera.setToolTip("Camera used for custom playblast output.")
+        self._custom_camera.currentTextChanged.connect(self._on_source_settings_changed)
+        custom_layout.addWidget(QLabel("Custom Camera"), 1, 0)
+        custom_layout.addWidget(self._custom_camera, 1, 1, 1, 3)
 
-        custom_toggle = self._enabled_shot_cbs[self.CUSTOM_ID]
-        custom_toggle.toggled.connect(
-            checkbox_callback_helper(custom_toggle, custom_settings_widget)
+        return custom_tab
+
+    def _build_both_source_tab(self) -> QWidget:
+        both_tab = QWidget()
+        both_layout = QVBoxLayout(both_tab)
+
+        message = QLabel(
+            "Both mode exports:\n"
+            "1) Shot Playblast (Pipeline Shot File)\n"
+            "2) Custom Playblast (manual camera + range)"
         )
-        return custom_settings_widget
+        message.setWordWrap(True)
+        message.setToolTip(
+            "This mode exports both sources in one run using the same destination selection."
+        )
+        both_layout.addWidget(message)
+        both_layout.addStretch()
+        return both_tab
+
+    def _build_destination_section(self) -> QGroupBox:
+        destination_group = QGroupBox("Save Destinations")
+        destination_layout = QVBoxLayout(destination_group)
+
+        for location in self._destination_locations():
+            row_widget = QWidget()
+            row_layout = QHBoxLayout(row_widget)
+            row_layout.setContentsMargins(0, 0, 0, 0)
+
+            toggle = QCheckBox(location.name)
+            toggle.setChecked(self._default_destination_enabled(location))
+            toggle.setToolTip(f"Enable export to {location.name}.")
+            toggle.toggled.connect(self._on_destination_changed)
+            self._destination_checkboxes[location.name] = toggle
+            row_layout.addWidget(toggle)
+
+            path_label = QLabel("")
+            path_label.setToolTip(f"Resolved output directory for {location.name}.")
+            self._destination_path_labels[location.name] = path_label
+            row_layout.addWidget(path_label)
+            row_layout.addStretch()
+            destination_layout.addWidget(row_widget)
+
+        self._align_destination_path_columns()
+
+        self._custom_folder_row = self._build_destination_path_row()
+        destination_layout.addWidget(self._custom_folder_row)
+        return destination_group
+
+    def _align_destination_path_columns(self) -> None:
+        destination_column_width = max(
+            (
+                checkbox.sizeHint().width()
+                for checkbox in self._destination_checkboxes.values()
+            ),
+            default=0,
+        )
+        for checkbox in self._destination_checkboxes.values():
+            checkbox.setFixedWidth(destination_column_width)
+
+    def _build_destination_path_row(self) -> QWidget:
+        custom_path_row = QWidget()
+        custom_path_layout = QHBoxLayout(custom_path_row)
+        custom_path_layout.setContentsMargins(24, 0, 0, 0)
+
+        custom_path_layout.addWidget(QLabel("Custom Folder Path"))
+
+        self._custom_folder_field = QLineEdit()
+        self._custom_folder_field.setText(self._default_custom_folder_path())
+        self._custom_folder_field.setToolTip(
+            "Directory used when Custom Folder destination is enabled."
+        )
+        self._custom_folder_field.textChanged.connect(self._on_custom_path_changed)
+        custom_path_layout.addWidget(self._custom_folder_field)
+
+        browse_button = QPushButton("Browse")
+        browse_button.setToolTip("Choose a custom output directory.")
+        browse_button.clicked.connect(self._set_custom_folder)
+        custom_path_layout.addWidget(browse_button)
+        return custom_path_row
+
+    def _build_render_options_section(self) -> None:
+        options_group = QGroupBox("2. Viewport Options")
+        options_layout = QVBoxLayout(options_group)
+        options_layout.addWidget(
+            self._build_viewport_options_widget(self._resolve_active_model_panel())
+        )
+        self._apply_viewport_option_tooltips()
+        self._main_layout.addWidget(options_group)
+
+    def _build_buttons(self) -> None:
+        self._init_buttons(has_cancel_button=True, ok_name="Playblast Shot")
+        self.buttons.rejected.connect(self.close)
+        self.buttons.accepted.connect(self.do_export)
+
+        ok_button = self.buttons.button(QDialogButtonBox.Ok)
+        if ok_button is not None:
+            ok_button.setToolTip(
+                "Start playblast with current source and destination selections."
+            )
+
+        cancel_button = self.buttons.button(QDialogButtonBox.Cancel)
+        if cancel_button is not None:
+            cancel_button.setToolTip("Close without exporting.")
+
+        self._main_layout.addWidget(self.buttons)
+
+    def _apply_viewport_option_tooltips(self) -> None:
+        self._use_lighting.setToolTip("Use viewport lighting for playblast capture.")
+        self._use_shadows.setToolTip("Render viewport shadows in playblast.")
+        self._use_ssao.setToolTip(
+            "Enable viewport anti-aliasing (SSAO/multi-sample setting)."
+        )
+        self._use_hardware_fog.setToolTip(
+            "Include hardware fog from viewport settings."
+        )
+        self._use_dof.setToolTip("Include camera depth of field in playblast.")
+
+    def _set_default_source_tab(self) -> None:
+        has_shot_context = self._shot is not None
+        self._source_tabs.setTabEnabled(self.SHOT_TAB_INDEX, has_shot_context)
+        self._source_tabs.setTabEnabled(self.BOTH_TAB_INDEX, has_shot_context)
+
+        default_index = (
+            self.SHOT_TAB_INDEX if has_shot_context else self.CUSTOM_TAB_INDEX
+        )
+        self._source_tabs.setCurrentIndex(default_index)
 
     @staticmethod
-    def _get_available_camera_names() -> list[str]:
-        return mc.ls(cameras=True, visible=True) or mc.ls(cameras=True) or ["persp"]
+    def _resolve_pipeline_shot_context() -> Shot | None:
+        conn = DB.Get(DB_Config)
+        try:
+            code = str(mc.fileInfo("code", query=True)[0]).strip()
+        except Exception:
+            return None
+
+        if not code:
+            return None
+
+        try:
+            return conn.get_shot_by_code(code)
+        except Exception:
+            return None
 
     @staticmethod
-    def _build_camera_validator_pattern(camera_names: list[str]) -> str:
-        escaped_names = [re.escape(camera_name) for camera_name in camera_names]
-        return f"^(?:{'|'.join(escaped_names)})$"
+    def _timeline_range() -> tuple[int, int]:
+        cut_in = int(mc.playbackOptions(minTime=True, query=True))
+        cut_out = int(mc.playbackOptions(maxTime=True, query=True))
+        if cut_out < cut_in:
+            cut_out = cut_in
+        return cut_in, cut_out
 
-    def _dialog_config_for_id(self, dialog_id: str) -> MShotDialogConfig:
-        for dialog_config in self._shot_dialog_configs:
-            if dialog_config.id == dialog_id:
-                return dialog_config
-        raise ValueError(f"Missing dialog config for id: {dialog_id}")
+    @staticmethod
+    def _available_custom_cameras() -> list[str]:
+        return [
+            str(c)
+            for c in (
+                mc.ls(cameras=True, visible=True) or mc.ls(cameras=True) or ["persp"]
+            )
+        ]
 
-    def _enabled_destination_directories(
-        self, dialog_id: str, locations: list[SaveLocation]
-    ) -> list[Path]:
-        directories: list[Path] = []
-        for location in locations:
-            if not self.is_location_enabled(dialog_id, location.name):
+    @staticmethod
+    def _destination_locations() -> list[SaveLocation]:
+        return [
+            AnimPlayblastDialog.SAVE_LOCS.EDIT,
+            AnimPlayblastDialog.SAVE_LOCS.CURRENT,
+            AnimPlayblastDialog.SAVE_LOCS.CUSTOM,
+        ]
+
+    def _default_destination_enabled(self, location: SaveLocation) -> bool:
+        return location.name == self.SAVE_LOCS.CURRENT.name
+
+    def _selected_source_mode(self) -> SOURCE_MODE:
+        current_index = self._source_tabs.currentIndex()
+        if current_index == self.SHOT_TAB_INDEX:
+            return "shot"
+        if current_index == self.CUSTOM_TAB_INDEX:
+            return "custom"
+        return "both"
+
+    def _selected_destination_locations(self) -> list[SaveLocation]:
+        selected: list[SaveLocation] = []
+        for location in self._destination_locations():
+            toggle = self._destination_checkboxes.get(location.name)
+            if toggle and toggle.isChecked():
+                selected.append(location)
+        return selected
+
+    def _is_custom_destination_selected(self) -> bool:
+        custom_checkbox = self._destination_checkboxes.get(self.SAVE_LOCS.CUSTOM.name)
+        return bool(custom_checkbox and custom_checkbox.isChecked())
+
+    def _paths_for_filename(
+        self, filename: str
+    ) -> dict[Playblaster.PRESET, list[str | Path]]:
+        paths: dict[Playblaster.PRESET, list[str | Path]] = defaultdict(list)
+        for location in self._selected_destination_locations():
+            destination_dir = self._resolved_destination_path(location).strip()
+            if not destination_dir:
                 continue
-            destination_dir = str(location.path).strip()
+            paths[location.preset].append(str(Path(destination_dir) / filename))
+        return paths
+
+    def _selected_destination_directories(self) -> list[Path]:
+        directories: list[Path] = []
+        for location in self._selected_destination_locations():
+            destination_dir = self._resolved_destination_path(location).strip()
             if destination_dir:
                 directories.append(Path(destination_dir))
         return directories
 
-    def _resolve_output_name(
-        self,
-        dialog_id: str,
-        locations: list[SaveLocation],
-        prefix: str,
-    ) -> str:
+    def _resolve_output_name(self, prefix: str) -> str:
         return resolve_versioned_playblast_basename(
             prefix,
-            self._enabled_destination_directories(dialog_id, locations),
+            self._selected_destination_directories(),
+        )
+
+    def _resolved_destination_path(self, location: SaveLocation) -> str:
+        if location.name == self.SAVE_LOCS.CUSTOM.name:
+            return self._custom_folder_field.text().strip()
+        return str(location.path)
+
+    def _refresh_destination_path_labels(self) -> None:
+        for location_name, path_label in self._destination_path_labels.items():
+            location = self._save_locations_by_name[location_name]
+            path_label.setText(f"-> {self._resolved_destination_path(location)}")
+
+    def _refresh_context_banner(self) -> None:
+        mode = self._selected_source_mode()
+
+        if mode in {"shot", "both"}:
+            if self._shot is None:
+                banner_text = (
+                    "No pipeline shot context detected. Open a pipeline shot file "
+                    "or switch to Custom Playblast."
+                )
+                self._shot_code_value.setText("-")
+                self._shot_camera_value.setText("-")
+                self._shot_range_value.setText("-")
+            else:
+                camera_path = self._get_shot_camera_path() or "<missing camera>"
+                banner_text = (
+                    f"Detected shot: {self._shot.code} | "
+                    f"Camera: {camera_path} | "
+                    f"Range: {self._shot.cut_in}-{self._shot.cut_out}"
+                )
+                self._shot_code_value.setText(self._shot.code)
+                self._shot_camera_value.setText(camera_path)
+                self._shot_range_value.setText(
+                    f"{self._shot.cut_in} - {self._shot.cut_out}"
+                )
+        else:
+            if self._shot is None:
+                banner_text = "No shot context detected. Custom Playblast is active."
+            else:
+                banner_text = (
+                    f"Detected shot: {self._shot.code}. "
+                    "Custom Playblast is active and will use manual camera/range settings."
+                )
+
+        self._context_banner.setText(banner_text)
+
+    def _sync_custom_path_row_visibility(self) -> None:
+        is_visible = self._is_custom_destination_selected()
+        self._custom_folder_row.setVisible(is_visible)
+        self._custom_folder_field.setEnabled(is_visible)
+
+    def _validate_pass_text(self) -> str | None:
+        pass_text = str(self._shot_pass.currentText()).strip()
+        if not self.PASS_PATTERN.fullmatch(pass_text):
+            return "Pass must be formatted like 'Blocking #1' or 'Polish #1'."
+        return None
+
+    def _validate_target_destination_state(self) -> str | None:
+        mode = self._selected_source_mode()
+
+        if mode in {"shot", "both"}:
+            if self._shot is None:
+                return (
+                    "No pipeline shot context was found. Use a pipeline shot file "
+                    "or switch to Custom Playblast."
+                )
+            if not self._get_shot_camera_path():
+                return "Could not resolve a shot camera path for this shot."
+
+        if mode in {"custom", "both"}:
+            if self._custom_out.value() < self._custom_in.value():
+                return "Custom Out must be greater than or equal to Custom In."
+            if not str(self._custom_camera.currentText()).strip():
+                return "Choose a camera for Custom Playblast."
+
+        pass_error = self._validate_pass_text()
+        if pass_error:
+            return pass_error
+
+        if not self._selected_destination_locations():
+            return "Select at least one save destination."
+
+        if (
+            self._is_custom_destination_selected()
+            and not self._custom_folder_field.text().strip()
+        ):
+            return "Custom Folder path is required when Custom Folder destination is enabled."
+
+        return None
+
+    def _action_button_text(self) -> str:
+        mode = self._selected_source_mode()
+        if mode == "shot":
+            return "Playblast Shot"
+        if mode == "custom":
+            return "Playblast Custom"
+        return "Playblast Shot + Custom"
+
+    def _update_action_state(self) -> None:
+        ok_button = self.buttons.button(QDialogButtonBox.Ok)
+        if ok_button is None:
+            return
+
+        ok_button.setText(self._action_button_text())
+        validation_error = self._validate_target_destination_state()
+        ok_button.setEnabled(validation_error is None)
+        self._validation_label.setText(validation_error or "")
+        self._validation_label.setVisible(validation_error is not None)
+
+    def _update_ui_state(self) -> None:
+        self._sync_custom_path_row_visibility()
+        self._refresh_destination_path_labels()
+        self._refresh_context_banner()
+        self._update_action_state()
+
+    def _on_source_mode_changed(self, _index: int) -> None:
+        self._update_ui_state()
+
+    def _on_destination_changed(self, _checked: bool) -> None:
+        self._update_ui_state()
+
+    def _on_custom_path_changed(self, _path: str) -> None:
+        self._update_ui_state()
+
+    def _on_custom_in_changed(self, in_frame: int) -> None:
+        self._custom_out.setMinimum(in_frame)
+        self._update_ui_state()
+
+    def _on_source_settings_changed(self, *_args) -> None:
+        self._update_ui_state()
+
+    def _refresh_summary(self, *_args) -> None:
+        self._update_ui_state()
+
+    def _hud_shot_label(self) -> str:
+        if self._shot is not None:
+            return self._shot.code
+        return "No shot code found"
+
+    def _build_shot_playblast_config(self) -> MShotPlayblastConfig:
+        if self._shot is None:
+            raise ValueError("No pipeline shot context is available.")
+
+        shot_output_name = self._resolve_output_name(self._shot.code)
+        return MShotPlayblastConfig(
+            camera=self._get_shot_camera_path(),
+            shot=self._shot,
+            paths=self._paths_for_filename(shot_output_name),
+            tails=(5, 5),
+            use_sequencer=False,
+        )
+
+    def _build_custom_playblast_config(self) -> MShotPlayblastConfig:
+        custom_in = self._custom_in.value()
+        custom_out = self._custom_out.value()
+        custom_prefix = f"customPB_{self._shot.code}" if self._shot else "customPB"
+        custom_output_name = self._resolve_output_name(custom_prefix)
+
+        return MShotPlayblastConfig(
+            camera=str(self._custom_camera.currentText()),
+            shot=dummy_shot(
+                code="custom",
+                cut_in=custom_in,
+                cut_out=custom_out,
+                cut_duration=max(0, custom_out - custom_in),
+            ),
+            paths=self._paths_for_filename(custom_output_name),
+            use_sequencer=False,
         )
 
     def _generate_config(self) -> MPlayblastConfig:
+        validation_error = self._validate_target_destination_state()
+        if validation_error:
+            raise ValueError(validation_error)
+
+        mode = self._selected_source_mode()
         shots: list[MShotPlayblastConfig] = []
 
-        if self.is_shot_enabled(self.SG_ID):
-            assert self._shot is not None
-            shotgrid_dialog_config = self._dialog_config_for_id(self.SG_ID)
-            shotgrid_locations = [
-                save_location for save_location, _ in shotgrid_dialog_config.save_locs
-            ]
-            shotgrid_output_name = self._resolve_output_name(
-                self.SG_ID,
-                shotgrid_locations,
-                self._shot.code,
-            )
-            shots.append(
-                MShotPlayblastConfig(
-                    camera=self._get_shot_camera_path(),
-                    shot=self._shot,
-                    paths=self.save_locations_to_paths(
-                        self.SG_ID,
-                        shotgrid_locations,
-                        shotgrid_output_name,
-                    ),
-                    tails=(5, 5),
-                )
-            )
+        if mode in {"shot", "both"}:
+            shots.append(self._build_shot_playblast_config())
 
-        if self.is_shot_enabled(self.CUSTOM_ID):
-            custom_dialog_config = self._dialog_config_for_id(self.CUSTOM_ID)
-            custom_locations = [
-                save_location for save_location, _ in custom_dialog_config.save_locs
-            ]
-            custom_prefix = f"customPB_{self._shot.code}" if self._shot else "customPB"
-            output_name = self._resolve_output_name(
-                self.CUSTOM_ID,
-                custom_locations,
-                custom_prefix,
-            )
-            custom_in_frame = self._custom_in.value()
-            custom_out_frame = self._custom_out.value()
-            cut_duration = max(0, custom_out_frame - custom_in_frame)
-            shots.append(
-                MShotPlayblastConfig(
-                    camera=self._custom_camera.currentText(),
-                    shot=dummy_shot(
-                        "custom",
-                        custom_in_frame,
-                        custom_out_frame,
-                        cut_duration=cut_duration,
-                    ),
-                    paths=self.save_locations_to_paths(
-                        self.CUSTOM_ID,
-                        custom_locations,
-                        output_name,
-                    ),
-                )
-            )
+        if mode in {"custom", "both"}:
+            shots.append(self._build_custom_playblast_config())
 
         return MPlayblastConfig(
             builtin_huds=[
@@ -237,15 +660,13 @@ class AnimPlayblastDialog(PlayblastDialog):
                 PlayblastDialog.CUSTOM_HUDS.FILENAME,
                 PlayblastDialog.CUSTOM_HUDS.ARTIST,
                 HudDefinition(
-                    "LnDshot",
-                    command=lambda: (
-                        self._shot.code if self._shot else "No shot code found"
-                    ),
+                    "SKD_shot",
+                    command=self._hud_shot_label,
                     section=7,
                     event="SceneSaved",
                 ),
                 HudDefinition(
-                    "LnDpass",
+                    "SKD_pass",
                     command=lambda: self._shot_pass.currentText(),
                     label="Pass:",
                     section=5,
@@ -262,8 +683,9 @@ class AnimPlayblastDialog(PlayblastDialog):
 
     def _get_shot_camera_path(self) -> str | None:
         """Resolve the USD shot camera in Maya, supporting both legacy and current hierarchies."""
-        cam = _find_usd_shotcam()
-        if cam:
-            return cam
+        camera_path = _find_usd_shotcam()
+        if camera_path:
+            return camera_path
+
         log.warning("No USD shot camera found; falling back to legacy path.")
         return "|__mayaUsd__|shotCamParent|shotCam"

--- a/pipeline/pipe/m/playblast/anim.py
+++ b/pipeline/pipe/m/playblast/anim.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from datetime import datetime
 from typing import TYPE_CHECKING
 
@@ -93,8 +94,7 @@ class AnimPlayblastDialog(PlayblastDialog):
         )
         anim_settings_layout.addWidget(QLabel("Pass"), 0, 0)
         anim_settings_layout.addWidget(self._shot_pass, 0, 1, 1, 2)
-
-        self._main_layout.insertWidget(2, anim_settings_widget)
+        self.add_context_widget(anim_settings_widget)
 
         # Create UI for custom shot
         custom_shot_widget = QWidget(self)
@@ -108,9 +108,14 @@ class AnimPlayblastDialog(PlayblastDialog):
         custom_shot_layout.addWidget(self._custom_out, 1, 4)
 
         self._custom_camera = QComboBox(self)
-        self._custom_camera.addItems(cameras := mc.ls(cameras=True, visible=True))
+        camera_names = (
+            mc.ls(cameras=True, visible=True) or mc.ls(cameras=True) or ["persp"]
+        )
+        self._custom_camera.addItems(camera_names)
         self._custom_camera.setCurrentIndex(0)
-        self._custom_camera.setValidator(QRegExpValidator(QRegExp("|".join(cameras))))
+        escaped_names = [re.escape(camera_name) for camera_name in camera_names]
+        validator_pattern = f"(?:{'|'.join(escaped_names)})"
+        self._custom_camera.setValidator(QRegExpValidator(QRegExp(validator_pattern)))
         custom_shot_layout.addWidget(QLabel("Custom Camera"), 2, 1)
         custom_shot_layout.addWidget(self._custom_camera, 2, 2, 1, 2)
 
@@ -118,8 +123,7 @@ class AnimPlayblastDialog(PlayblastDialog):
         (escb := self._enabled_shot_cbs[self.CUSTOM_ID]).toggled.connect(
             checkbox_callback_helper(escb, custom_shot_widget)
         )
-
-        self._main_layout.insertWidget(3, custom_shot_widget)
+        self.add_context_widget(custom_shot_widget)
 
     def _generate_config(self) -> MPlayblastConfig:
         timestamp = datetime.now().strftime("%m-%d-%y_%H:%M:%S")
@@ -178,9 +182,9 @@ class AnimPlayblastDialog(PlayblastDialog):
                 PlayblastDialog.CUSTOM_HUDS.ARTIST,
                 HudDefinition(
                     "LnDshot",
-                    command=lambda: self._shot.code
-                    if self._shot
-                    else "No shot code found",
+                    command=lambda: (
+                        self._shot.code if self._shot else "No shot code found"
+                    ),
                     section=7,
                     event="SceneSaved",
                 ),

--- a/pipeline/pipe/m/playblast/anim.py
+++ b/pipeline/pipe/m/playblast/anim.py
@@ -28,6 +28,7 @@ from shared.util import get_edit_path
 
 from pipe.db import DB
 from pipe.m.shotfile.anim import _find_usd_shotcam
+from pipe.playblast_artist import resolve_artist_display_name
 from pipe.playblast_naming import (
     playblast_date_folder,
     resolve_versioned_playblast_basename,
@@ -47,7 +48,7 @@ from .struct import (
     SaveLocation,
     dummy_shot,
 )
-from .ui import PlayblastDialog, resolve_artist_display_name
+from .ui import PlayblastDialog
 
 if TYPE_CHECKING:
     from pipe.struct.db import Shot

--- a/pipeline/pipe/m/playblast/anim.py
+++ b/pipeline/pipe/m/playblast/anim.py
@@ -32,6 +32,12 @@ from pipe.playblast_naming import (
     playblast_date_folder,
     resolve_versioned_playblast_basename,
 )
+from pipe.playblast_shotgrid import (
+    PlayblastVersionUploadRequest,
+    default_version_name_from_movie_path,
+    resolve_preferred_upload_movie_path,
+    upload_playblast_version,
+)
 from pipe.util import Playblaster
 
 from .struct import (
@@ -41,7 +47,7 @@ from .struct import (
     SaveLocation,
     dummy_shot,
 )
-from .ui import PlayblastDialog
+from .ui import PlayblastDialog, resolve_artist_display_name
 
 if TYPE_CHECKING:
     from pipe.struct.db import Shot
@@ -60,6 +66,9 @@ class AnimPlayblastDialog(PlayblastDialog):
     _source_tabs: QTabWidget
     _shot_camera_value: QLabel
     _shot_code_value: QLabel
+    _shotgrid_description_field: QLineEdit
+    _shotgrid_description_row: QWidget
+    _shotgrid_upload_checkbox: QCheckBox
     _shot_range_value: QLabel
     _shot: Shot | None
     _shot_pass: QComboBox
@@ -207,6 +216,31 @@ class AnimPlayblastDialog(PlayblastDialog):
             "Resolved cut range from the detected pipeline shot."
         )
         shot_layout.addWidget(self._shot_range_value, 3, 1)
+
+        shot_layout.addWidget(QLabel("ShotGrid"), 4, 0)
+        self._shotgrid_upload_checkbox = QCheckBox("Upload to ShotGrid")
+        self._shotgrid_upload_checkbox.setChecked(False)
+        self._shotgrid_upload_checkbox.setToolTip(
+            "When enabled, this Shot playblast will also create a ShotGrid Version and upload the movie."
+        )
+        self._shotgrid_upload_checkbox.toggled.connect(self._on_shotgrid_upload_toggled)
+        shot_layout.addWidget(self._shotgrid_upload_checkbox, 4, 1)
+
+        self._shotgrid_description_row = QWidget()
+        shotgrid_description_layout = QHBoxLayout(self._shotgrid_description_row)
+        shotgrid_description_layout.setContentsMargins(0, 0, 0, 0)
+        shotgrid_description_layout.addWidget(QLabel("Description"))
+        self._shotgrid_description_field = QLineEdit()
+        self._shotgrid_description_field.setPlaceholderText(
+            "Optional ShotGrid version description"
+        )
+        self._shotgrid_description_field.setToolTip(
+            "Optional notes saved to the ShotGrid Version description when upload is enabled."
+        )
+        shotgrid_description_layout.addWidget(self._shotgrid_description_field)
+        shot_layout.addWidget(self._shotgrid_description_row, 5, 0, 1, 2)
+
+        self._sync_shotgrid_description_visibility()
 
         return shot_tab
 
@@ -429,6 +463,152 @@ class AnimPlayblastDialog(PlayblastDialog):
             paths[location.preset].append(str(Path(destination_dir) / filename))
         return paths
 
+    @staticmethod
+    def _final_movie_path_for_base(
+        output_base: str | Path,
+        preset: Playblaster.PRESET,
+    ) -> Path:
+        return Path(str(output_base) + f".{preset.ext}")
+
+    def _final_movie_paths_for_location(
+        self,
+        shot_config: MShotPlayblastConfig,
+        location: SaveLocation,
+    ) -> list[Path]:
+        destination_dir = Path(self._resolved_destination_path(location)).expanduser()
+        resolved_destination_dir = destination_dir.resolve()
+
+        matching_paths: list[Path] = []
+        for output_base in shot_config.paths.get(location.preset, []):
+            resolved_output_base = Path(str(output_base)).expanduser().resolve()
+            if resolved_output_base.parent != resolved_destination_dir:
+                continue
+            matching_paths.append(
+                self._final_movie_path_for_base(resolved_output_base, location.preset)
+            )
+        return matching_paths
+
+    def _ordered_final_movie_paths_for_upload(
+        self,
+        shot_config: MShotPlayblastConfig,
+    ) -> list[Path]:
+        """Return deterministic output path order for upload path resolution."""
+
+        ordered_paths: list[Path] = []
+        seen_paths: set[Path] = set()
+
+        for location in self._destination_locations():
+            for output_path in self._final_movie_paths_for_location(
+                shot_config, location
+            ):
+                if output_path in seen_paths:
+                    continue
+                seen_paths.add(output_path)
+                ordered_paths.append(output_path)
+
+        for preset, output_bases in shot_config.paths.items():
+            for output_base in output_bases:
+                output_path = self._final_movie_path_for_base(output_base, preset)
+                resolved_output_path = output_path.expanduser().resolve()
+                if resolved_output_path in seen_paths:
+                    continue
+                seen_paths.add(resolved_output_path)
+                ordered_paths.append(resolved_output_path)
+
+        return ordered_paths
+
+    def _preferred_edit_movie_paths_for_upload(
+        self,
+        shot_config: MShotPlayblastConfig,
+    ) -> list[Path]:
+        edit_location = self._save_locations_by_name.get(self.SAVE_LOCS.EDIT.name)
+        if edit_location is None:
+            return []
+        return self._final_movie_paths_for_location(shot_config, edit_location)
+
+    def _resolve_shotgrid_upload_movie_path(
+        self,
+        config: MPlayblastConfig,
+    ) -> Path | None:
+        """Resolve upload movie path with stable preference ordering.
+
+        Preference order:
+        1) valid `Send to Edit` output
+        2) first valid output from the deterministic export order
+        """
+        if not config.shots:
+            return None
+
+        shot_config = config.shots[0]
+        preferred_paths = self._preferred_edit_movie_paths_for_upload(shot_config)
+        output_paths = self._ordered_final_movie_paths_for_upload(shot_config)
+        return resolve_preferred_upload_movie_path(
+            output_paths,
+            preferred_paths=preferred_paths,
+        )
+
+    def _should_upload_shot_playblast_to_shotgrid(self) -> bool:
+        return (
+            self._selected_source_mode() == "shot"
+            and self._is_shotgrid_upload_requested()
+        )
+
+    def _upload_shot_playblast_to_shotgrid(
+        self,
+        config: MPlayblastConfig,
+    ) -> list[str]:
+        if not config.shots:
+            return ["ShotGrid Upload: Skipped - no shot output was generated."]
+
+        shot_code = str(config.shots[0].shot.code or "").strip()
+        if not shot_code:
+            return ["ShotGrid Upload: Skipped - shot code is missing."]
+
+        movie_path = self._resolve_shotgrid_upload_movie_path(config)
+        if movie_path is None:
+            return [
+                "ShotGrid Upload: Skipped - no valid playblast movie file was found."
+            ]
+
+        version_name = default_version_name_from_movie_path(movie_path)
+        if not version_name:
+            version_name = f"{shot_code}_playblast"
+
+        artist_name = resolve_artist_display_name().strip() or None
+        upload_request = PlayblastVersionUploadRequest(
+            shot_code=shot_code,
+            movie_path=movie_path,
+            version_name=version_name,
+            description=self._shotgrid_upload_description() or None,
+            path_to_frames=str(movie_path),
+            artist_display_name=artist_name,
+        )
+
+        try:
+            upload_result = upload_playblast_version(upload_request)
+        except Exception as exc:
+            log.exception("ShotGrid upload failed for shot '%s'", shot_code)
+            return [f"ShotGrid Upload: Failed - {exc}"]
+
+        message_lines: list[str] = []
+        if upload_result.ok:
+            success_message = (
+                f"ShotGrid Upload: Success - {upload_result.version_name}"
+                f" (shot {upload_result.shot_code})."
+            )
+            if upload_result.version_id is not None:
+                success_message = (
+                    f"{success_message} Version ID: {upload_result.version_id}."
+                )
+            message_lines.append(success_message)
+        else:
+            message_lines.append(f"ShotGrid Upload: Failed - {upload_result.message}")
+
+        for warning in upload_result.warnings:
+            message_lines.append(f"ShotGrid Warning: {warning}")
+
+        return message_lines
+
     def _selected_destination_directories(self) -> list[Path]:
         directories: list[Path] = []
         for location in self._selected_destination_locations():
@@ -469,6 +649,17 @@ class AnimPlayblastDialog(PlayblastDialog):
         is_visible = self._is_custom_destination_selected()
         self._custom_folder_row.setVisible(is_visible)
         self._custom_folder_field.setEnabled(is_visible)
+
+    def _sync_shotgrid_description_visibility(self) -> None:
+        show_description = self._is_shotgrid_upload_requested()
+        self._shotgrid_description_row.setVisible(show_description)
+        self._shotgrid_description_field.setEnabled(show_description)
+
+    def _is_shotgrid_upload_requested(self) -> bool:
+        return self._shotgrid_upload_checkbox.isChecked()
+
+    def _shotgrid_upload_description(self) -> str:
+        return self._shotgrid_description_field.text().strip()
 
     def _validate_pass_text(self) -> str | None:
         pass_text = str(self._shot_pass.currentText()).strip()
@@ -531,6 +722,7 @@ class AnimPlayblastDialog(PlayblastDialog):
         self._refresh_source_tab_availability()
         self._refresh_shot_context_fields()
         self._sync_custom_path_row_visibility()
+        self._sync_shotgrid_description_visibility()
         self._refresh_destination_path_labels()
         self._update_action_state()
 
@@ -550,8 +742,19 @@ class AnimPlayblastDialog(PlayblastDialog):
     def _on_source_settings_changed(self, *_args) -> None:
         self._update_ui_state()
 
+    def _on_shotgrid_upload_toggled(self, _enabled: bool) -> None:
+        self._update_ui_state()
+
     def _refresh_summary(self, *_args) -> None:
         self._update_ui_state()
+
+    def _after_local_playblast(
+        self,
+        config: MPlayblastConfig,
+    ) -> list[str]:
+        if not self._should_upload_shot_playblast_to_shotgrid():
+            return []
+        return self._upload_shot_playblast_to_shotgrid(config)
 
     def _hud_shot_label(self) -> str:
         if self._shot is not None:

--- a/pipeline/pipe/m/playblast/anim.py
+++ b/pipeline/pipe/m/playblast/anim.py
@@ -2,43 +2,18 @@ from __future__ import annotations
 
 import logging
 import re
-from collections import defaultdict
-from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
-import maya.cmds as mc
-from env_sg import DB_Config
-from Qt import QtCore
 from Qt.QtWidgets import (
-    QCheckBox,
     QComboBox,
-    QDialogButtonBox,
-    QGridLayout,
-    QGroupBox,
     QHBoxLayout,
     QLabel,
-    QLineEdit,
-    QPushButton,
-    QSpinBox,
-    QTabWidget,
-    QVBoxLayout,
     QWidget,
 )
 from shared.util import get_edit_path
 
-from pipe.db import DB
 from pipe.m.shotfile.anim import _find_usd_shotcam
-from pipe.playblast_artist import resolve_artist_display_name
-from pipe.playblast_naming import (
-    playblast_date_folder,
-    resolve_versioned_playblast_basename,
-)
-from pipe.playblast_shotgrid import (
-    PlayblastVersionUploadRequest,
-    default_version_name_from_movie_path,
-    resolve_preferred_upload_movie_path,
-    upload_playblast_version,
-)
+from pipe.playblast_naming import playblast_date_folder
 from pipe.util import Playblaster
 
 from .struct import (
@@ -46,39 +21,15 @@ from .struct import (
     MPlayblastConfig,
     MShotPlayblastConfig,
     SaveLocation,
-    dummy_shot,
 )
 from .ui import PlayblastDialog
-
-if TYPE_CHECKING:
-    from pipe.struct.db import Shot
 
 log = logging.getLogger(__name__)
 
 
 class AnimPlayblastDialog(PlayblastDialog):
-    _custom_camera: QComboBox
-    _custom_folder_row: QWidget
-    _custom_in: QSpinBox
-    _custom_out: QSpinBox
-    _destination_checkboxes: dict[str, QCheckBox]
-    _destination_path_labels: dict[str, QLabel]
-    _save_locations_by_name: dict[str, SaveLocation]
-    _source_tabs: QTabWidget
     _shot_camera_value: QLabel
-    _shot_code_value: QLabel
-    _shotgrid_description_field: QLineEdit
-    _shotgrid_description_row: QWidget
-    _shotgrid_upload_checkbox: QCheckBox
-    _shot_range_value: QLabel
-    _shot: Shot | None
     _shot_pass: QComboBox
-    _validation_label: QLabel
-
-    SHOT_TAB_INDEX = 0
-    CUSTOM_TAB_INDEX = 1
-
-    SOURCE_MODE = Literal["shot", "custom"]
 
     PASS_PATTERN = re.compile(r"^(?:Blocking|Polish) #\d+$")
 
@@ -90,88 +41,9 @@ class AnimPlayblastDialog(PlayblastDialog):
         )
 
     def __init__(self, parent) -> None:
-        self._shot = self._resolve_pipeline_shot_context()
-        self._destination_checkboxes = {}
-        self._destination_path_labels = {}
-        self._save_locations_by_name = {
-            location.name: location for location in self._destination_locations()
-        }
-        super().__init__(parent, [], "SKD Anim Playblast")
+        super().__init__(parent, windowTitle="SKD Anim Playblast")
 
-    def _setup_ui(self) -> None:
-        self._central_widget = QWidget()
-        self.setCentralWidget(self._central_widget)
-        self._main_layout = QVBoxLayout()
-        self._central_widget.setLayout(self._main_layout)
-
-        self._build_header_section()
-        self._build_targets_section()
-        self._build_render_options_section()
-        self._build_buttons()
-        self._set_default_source_tab()
-        self._update_ui_state()
-
-    def _build_header_section(self) -> None:
-        title = QLabel("SKD Anim Playblast")
-        title.setStyleSheet("font-size: 24px; font-weight: 700;")
-        title.setAlignment(QtCore.Qt.AlignCenter)
-
-        subtitle = QLabel("Choose source mode, choose destinations, then export")
-        subtitle.setAlignment(QtCore.Qt.AlignCenter)
-        subtitle.setToolTip(
-            "High-level workflow: choose source, choose destinations, then export."
-        )
-
-        self._main_layout.addWidget(title)
-        self._main_layout.addWidget(subtitle)
-
-    def _build_targets_section(self) -> None:
-        setup_group = QGroupBox("1. Export Setup")
-        setup_layout = QVBoxLayout(setup_group)
-
-        setup_layout.addWidget(self._build_export_source_section())
-        setup_layout.addWidget(self._build_destination_section())
-
-        self._validation_label = QLabel()
-        self._validation_label.setStyleSheet("color: #b00020;")
-        self._validation_label.setToolTip(
-            "Validation feedback. Export is disabled until this message is cleared."
-        )
-        self._validation_label.setVisible(False)
-        setup_layout.addWidget(self._validation_label)
-
-        self._main_layout.addWidget(setup_group)
-
-    def _build_export_source_section(self) -> QGroupBox:
-        source_group = QGroupBox("")
-        source_layout = QVBoxLayout(source_group)
-
-        self._source_tabs = QTabWidget()
-        self._source_tabs.addTab(self._build_shot_source_tab(), "Shot Playblast")
-        self._source_tabs.addTab(
-            self._build_custom_source_tab(),
-            "Custom Playblast",
-        )
-        self._source_tabs.currentChanged.connect(self._on_source_mode_changed)
-        self._source_tabs.setToolTip(
-            "Select how exports are generated: shot context or manual custom range."
-        )
-
-        source_tab_bar = self._source_tabs.tabBar()
-        source_tab_bar.setTabToolTip(
-            self.SHOT_TAB_INDEX,
-            "Uses shot code metadata from this Maya scene and resolved shot camera/range.",
-        )
-        source_tab_bar.setTabToolTip(
-            self.CUSTOM_TAB_INDEX,
-            "Uses manual camera and manual frame range.",
-        )
-
-        source_layout.addWidget(self._source_tabs)
-        source_layout.addWidget(self._build_pass_row())
-        return source_group
-
-    def _build_pass_row(self) -> QWidget:
+    def _build_extra_source_options(self) -> QWidget | None:
         pass_row = QWidget()
         pass_layout = QHBoxLayout(pass_row)
         pass_layout.setContentsMargins(0, 0, 0, 0)
@@ -190,572 +62,34 @@ class AnimPlayblastDialog(PlayblastDialog):
 
         return pass_row
 
-    def _build_shot_source_tab(self) -> QWidget:
-        shot_tab = QWidget()
-        shot_layout = QGridLayout(shot_tab)
-
-        shot_layout.addWidget(QLabel("Source"), 0, 0)
-        source_value = QLabel("Pipeline Shot File")
-        source_value.setToolTip(
-            "Source is resolved from this scene's pipeline shot metadata."
-        )
-        shot_layout.addWidget(source_value, 0, 1)
-
-        shot_layout.addWidget(QLabel("Shot"), 1, 0)
-        self._shot_code_value = QLabel("-")
-        self._shot_code_value.setToolTip("Resolved pipeline shot code.")
-        shot_layout.addWidget(self._shot_code_value, 1, 1)
-
-        shot_layout.addWidget(QLabel("Camera"), 2, 0)
+    def _build_shot_camera_widget(self) -> QWidget:
         self._shot_camera_value = QLabel("-")
         self._shot_camera_value.setToolTip("Resolved shot camera path.")
-        shot_layout.addWidget(self._shot_camera_value, 2, 1)
+        return self._shot_camera_value
 
-        shot_layout.addWidget(QLabel("Frame Range"), 3, 0)
-        self._shot_range_value = QLabel("-")
-        self._shot_range_value.setToolTip(
-            "Resolved cut range from the detected pipeline shot."
-        )
-        shot_layout.addWidget(self._shot_range_value, 3, 1)
-
-        shot_layout.addWidget(QLabel("ShotGrid"), 4, 0)
-        self._shotgrid_upload_checkbox = QCheckBox("Upload to ShotGrid")
-        self._shotgrid_upload_checkbox.setChecked(False)
-        self._shotgrid_upload_checkbox.setToolTip(
-            "When enabled, this Shot playblast will also create a ShotGrid Version and upload the movie."
-        )
-        self._shotgrid_upload_checkbox.toggled.connect(self._on_shotgrid_upload_toggled)
-        shot_layout.addWidget(self._shotgrid_upload_checkbox, 4, 1)
-
-        self._shotgrid_description_row = QWidget()
-        shotgrid_description_layout = QHBoxLayout(self._shotgrid_description_row)
-        shotgrid_description_layout.setContentsMargins(0, 0, 0, 0)
-        shotgrid_description_layout.addWidget(QLabel("Description"))
-        self._shotgrid_description_field = QLineEdit()
-        self._shotgrid_description_field.setPlaceholderText(
-            "Optional ShotGrid version description"
-        )
-        self._shotgrid_description_field.setToolTip(
-            "Optional notes saved to the ShotGrid Version description when upload is enabled."
-        )
-        shotgrid_description_layout.addWidget(self._shotgrid_description_field)
-        shot_layout.addWidget(self._shotgrid_description_row, 5, 0, 1, 2)
-
-        self._sync_shotgrid_description_visibility()
-
-        return shot_tab
-
-    def _build_custom_source_tab(self) -> QWidget:
-        custom_tab = QWidget()
-        custom_layout = QGridLayout(custom_tab)
-
-        timeline_in, timeline_out = self._timeline_range()
-        self._custom_in = QSpinBox(self, minimum=0, maximum=10000, value=timeline_in)
-        self._custom_out = QSpinBox(self, minimum=0, maximum=10000, value=timeline_out)
-        self._custom_out.setMinimum(self._custom_in.value())
-        self._custom_in.setToolTip("Start frame for custom playblast.")
-        self._custom_out.setToolTip("End frame for custom playblast.")
-        self._custom_in.valueChanged.connect(self._on_custom_in_changed)
-        self._custom_out.valueChanged.connect(self._on_source_settings_changed)
-
-        custom_layout.addWidget(QLabel("Custom In"), 0, 0)
-        custom_layout.addWidget(self._custom_in, 0, 1)
-        custom_layout.addWidget(QLabel("Custom Out"), 0, 2)
-        custom_layout.addWidget(self._custom_out, 0, 3)
-
-        self._custom_camera = QComboBox(self)
-        self._custom_camera.addItems(self._available_custom_cameras())
-        self._custom_camera.setToolTip("Camera used for custom playblast output.")
-        self._custom_camera.currentTextChanged.connect(self._on_source_settings_changed)
-        custom_layout.addWidget(QLabel("Custom Camera"), 1, 0)
-        custom_layout.addWidget(self._custom_camera, 1, 1, 1, 3)
-
-        return custom_tab
-
-    def _build_destination_section(self) -> QGroupBox:
-        destination_group = QGroupBox("Save Destinations")
-        destination_layout = QVBoxLayout(destination_group)
-
-        for location in self._destination_locations():
-            row_widget = QWidget()
-            row_layout = QHBoxLayout(row_widget)
-            row_layout.setContentsMargins(0, 0, 0, 0)
-
-            toggle = QCheckBox(location.name)
-            toggle.setChecked(self._default_destination_enabled(location))
-            toggle.setToolTip(f"Enable export to {location.name}.")
-            toggle.toggled.connect(self._on_destination_changed)
-            self._destination_checkboxes[location.name] = toggle
-            row_layout.addWidget(toggle)
-
-            path_label = QLabel("")
-            path_label.setToolTip(f"Resolved output directory for {location.name}.")
-            self._destination_path_labels[location.name] = path_label
-            row_layout.addWidget(path_label)
-            row_layout.addStretch()
-            destination_layout.addWidget(row_widget)
-
-        self._align_destination_path_columns()
-
-        self._custom_folder_row = self._build_destination_path_row()
-        destination_layout.addWidget(self._custom_folder_row)
-        return destination_group
-
-    def _align_destination_path_columns(self) -> None:
-        destination_column_width = max(
-            (
-                checkbox.sizeHint().width()
-                for checkbox in self._destination_checkboxes.values()
-            ),
-            default=0,
-        )
-        for checkbox in self._destination_checkboxes.values():
-            checkbox.setFixedWidth(destination_column_width)
-
-    def _build_destination_path_row(self) -> QWidget:
-        custom_path_row = QWidget()
-        custom_path_layout = QHBoxLayout(custom_path_row)
-        custom_path_layout.setContentsMargins(24, 0, 0, 0)
-
-        custom_path_layout.addWidget(QLabel("Custom Folder Path"))
-
-        self._custom_folder_field = QLineEdit()
-        self._custom_folder_field.setText(self._default_custom_folder_path())
-        self._custom_folder_field.setToolTip(
-            "Directory used when Custom Folder destination is enabled."
-        )
-        self._custom_folder_field.textChanged.connect(self._on_custom_path_changed)
-        custom_path_layout.addWidget(self._custom_folder_field)
-
-        browse_button = QPushButton("Browse")
-        browse_button.setToolTip("Choose a custom output directory.")
-        browse_button.clicked.connect(self._set_custom_folder)
-        custom_path_layout.addWidget(browse_button)
-        return custom_path_row
-
-    def _build_render_options_section(self) -> None:
-        options_group = QGroupBox("2. Viewport Options")
-        options_layout = QVBoxLayout(options_group)
-        options_layout.addWidget(
-            self._build_viewport_options_widget(self._resolve_active_model_panel())
-        )
-        self._apply_viewport_option_tooltips()
-        self._main_layout.addWidget(options_group)
-
-    def _build_buttons(self) -> None:
-        self._init_buttons(has_cancel_button=True, ok_name="Playblast Shot")
-        self.buttons.rejected.connect(self.close)
-        self.buttons.accepted.connect(self.do_export)
-
-        ok_button = self.buttons.button(QDialogButtonBox.Ok)
-        if ok_button is not None:
-            ok_button.setToolTip(
-                "Start playblast with current source and destination selections."
-            )
-
-        cancel_button = self.buttons.button(QDialogButtonBox.Cancel)
-        if cancel_button is not None:
-            cancel_button.setToolTip("Close without exporting.")
-
-        self._main_layout.addWidget(self.buttons)
-
-    def _apply_viewport_option_tooltips(self) -> None:
-        self._use_lighting.setToolTip("Use viewport lighting for playblast capture.")
-        self._use_shadows.setToolTip("Render viewport shadows in playblast.")
-        self._use_ssao.setToolTip(
-            "Enable viewport anti-aliasing (SSAO/multi-sample setting)."
-        )
-        self._use_hardware_fog.setToolTip(
-            "Include hardware fog from viewport settings."
-        )
-        self._use_dof.setToolTip("Include camera depth of field in playblast.")
-
-    def _set_default_source_tab(self) -> None:
-        self._refresh_source_tab_availability()
-        self._source_tabs.setCurrentIndex(self._default_source_tab_index())
-
-    def _refresh_source_tab_availability(self) -> None:
-        has_shot_context = self._shot is not None
-        self._source_tabs.setTabEnabled(self.SHOT_TAB_INDEX, has_shot_context)
-
-        selected_mode = self._selected_source_mode()
-        if selected_mode == "shot" and not has_shot_context:
-            self._source_tabs.setCurrentIndex(self._default_source_tab_index())
-
-    def _default_source_tab_index(self) -> int:
-        if self._shot is not None:
-            return self.SHOT_TAB_INDEX
-        return self.CUSTOM_TAB_INDEX
-
-    @staticmethod
-    def _resolve_pipeline_shot_context() -> Shot | None:
-        try:
-            conn = DB.Get(DB_Config)
-        except Exception:
-            return None
-
-        try:
-            code = str(mc.fileInfo("code", query=True)[0]).strip()
-        except Exception:
-            return None
-
-        if not code:
-            return None
-
-        try:
-            return conn.get_shot_by_code(code)
-        except Exception:
-            return None
-
-    @staticmethod
-    def _timeline_range() -> tuple[int, int]:
-        cut_in = int(mc.playbackOptions(minTime=True, query=True))
-        cut_out = int(mc.playbackOptions(maxTime=True, query=True))
-        if cut_out < cut_in:
-            cut_out = cut_in
-        return cut_in, cut_out
-
-    @staticmethod
-    def _available_custom_cameras() -> list[str]:
-        return [
-            str(c)
-            for c in (
-                mc.ls(cameras=True, visible=True) or mc.ls(cameras=True) or ["persp"]
-            )
-        ]
-
-    @staticmethod
-    def _destination_locations() -> list[SaveLocation]:
-        return [
-            AnimPlayblastDialog.SAVE_LOCS.EDIT,
-            AnimPlayblastDialog.SAVE_LOCS.CURRENT,
-            AnimPlayblastDialog.SAVE_LOCS.CUSTOM,
-        ]
-
-    def _default_destination_enabled(self, location: SaveLocation) -> bool:
-        return location.name == self.SAVE_LOCS.CURRENT.name
-
-    def _selected_source_mode(self) -> SOURCE_MODE:
-        current_index = self._source_tabs.currentIndex()
-        if current_index == self.SHOT_TAB_INDEX:
-            return "shot"
-        return "custom"
-
-    def _selected_destination_locations(self) -> list[SaveLocation]:
-        selected: list[SaveLocation] = []
-        for location in self._destination_locations():
-            toggle = self._destination_checkboxes.get(location.name)
-            if toggle and toggle.isChecked():
-                selected.append(location)
-        return selected
-
-    def _is_custom_destination_selected(self) -> bool:
-        custom_checkbox = self._destination_checkboxes.get(self.SAVE_LOCS.CUSTOM.name)
-        return bool(custom_checkbox and custom_checkbox.isChecked())
-
-    def _paths_for_filename(
-        self, filename: str
-    ) -> dict[Playblaster.PRESET, list[str | Path]]:
-        paths: dict[Playblaster.PRESET, list[str | Path]] = defaultdict(list)
-        for location in self._selected_destination_locations():
-            destination_dir = self._resolved_destination_path(location).strip()
-            if not destination_dir:
-                continue
-            paths[location.preset].append(str(Path(destination_dir) / filename))
-        return paths
-
-    @staticmethod
-    def _final_movie_path_for_base(
-        output_base: str | Path,
-        preset: Playblaster.PRESET,
-    ) -> Path:
-        return Path(str(output_base) + f".{preset.ext}")
-
-    def _final_movie_paths_for_location(
-        self,
-        shot_config: MShotPlayblastConfig,
-        location: SaveLocation,
-    ) -> list[Path]:
-        destination_dir = Path(self._resolved_destination_path(location)).expanduser()
-        resolved_destination_dir = destination_dir.resolve()
-
-        matching_paths: list[Path] = []
-        for output_base in shot_config.paths.get(location.preset, []):
-            resolved_output_base = Path(str(output_base)).expanduser().resolve()
-            if resolved_output_base.parent != resolved_destination_dir:
-                continue
-            matching_paths.append(
-                self._final_movie_path_for_base(resolved_output_base, location.preset)
-            )
-        return matching_paths
-
-    def _ordered_final_movie_paths_for_upload(
-        self,
-        shot_config: MShotPlayblastConfig,
-    ) -> list[Path]:
-        """Return deterministic output path order for upload path resolution."""
-
-        ordered_paths: list[Path] = []
-        seen_paths: set[Path] = set()
-
-        for location in self._destination_locations():
-            for output_path in self._final_movie_paths_for_location(
-                shot_config, location
-            ):
-                if output_path in seen_paths:
-                    continue
-                seen_paths.add(output_path)
-                ordered_paths.append(output_path)
-
-        for preset, output_bases in shot_config.paths.items():
-            for output_base in output_bases:
-                output_path = self._final_movie_path_for_base(output_base, preset)
-                resolved_output_path = output_path.expanduser().resolve()
-                if resolved_output_path in seen_paths:
-                    continue
-                seen_paths.add(resolved_output_path)
-                ordered_paths.append(resolved_output_path)
-
-        return ordered_paths
-
-    def _preferred_edit_movie_paths_for_upload(
-        self,
-        shot_config: MShotPlayblastConfig,
-    ) -> list[Path]:
-        edit_location = self._save_locations_by_name.get(self.SAVE_LOCS.EDIT.name)
-        if edit_location is None:
-            return []
-        return self._final_movie_paths_for_location(shot_config, edit_location)
-
-    def _resolve_shotgrid_upload_movie_path(
-        self,
-        config: MPlayblastConfig,
-    ) -> Path | None:
-        """Resolve upload movie path with stable preference ordering.
-
-        Preference order:
-        1) valid `Send to Edit` output
-        2) first valid output from the deterministic export order
-        """
-        if not config.shots:
-            return None
-
-        shot_config = config.shots[0]
-        preferred_paths = self._preferred_edit_movie_paths_for_upload(shot_config)
-        output_paths = self._ordered_final_movie_paths_for_upload(shot_config)
-        return resolve_preferred_upload_movie_path(
-            output_paths,
-            preferred_paths=preferred_paths,
-        )
-
-    def _should_upload_shot_playblast_to_shotgrid(self) -> bool:
-        return (
-            self._selected_source_mode() == "shot"
-            and self._is_shotgrid_upload_requested()
-        )
-
-    def _upload_shot_playblast_to_shotgrid(
-        self,
-        config: MPlayblastConfig,
-    ) -> list[str]:
-        if not config.shots:
-            return ["ShotGrid Upload: Skipped - no shot output was generated."]
-
-        shot_code = str(config.shots[0].shot.code or "").strip()
-        if not shot_code:
-            return ["ShotGrid Upload: Skipped - shot code is missing."]
-
-        movie_path = self._resolve_shotgrid_upload_movie_path(config)
-        if movie_path is None:
-            return [
-                "ShotGrid Upload: Skipped - no valid playblast movie file was found."
-            ]
-
-        version_name = default_version_name_from_movie_path(movie_path)
-        if not version_name:
-            version_name = f"{shot_code}_playblast"
-
-        artist_name = resolve_artist_display_name().strip() or None
-        upload_request = PlayblastVersionUploadRequest(
-            shot_code=shot_code,
-            movie_path=movie_path,
-            version_name=version_name,
-            description=self._shotgrid_upload_description() or None,
-            path_to_frames=str(movie_path),
-            artist_display_name=artist_name,
-        )
-
-        try:
-            upload_result = upload_playblast_version(upload_request)
-        except Exception as exc:
-            log.exception("ShotGrid upload failed for shot '%s'", shot_code)
-            return [f"ShotGrid Upload: Failed - {exc}"]
-
-        message_lines: list[str] = []
-        if upload_result.ok:
-            success_message = (
-                f"ShotGrid Upload: Success - {upload_result.version_name}"
-                f" (shot {upload_result.shot_code})."
-            )
-            if upload_result.version_id is not None:
-                success_message = (
-                    f"{success_message} Version ID: {upload_result.version_id}."
-                )
-            message_lines.append(success_message)
-        else:
-            message_lines.append(f"ShotGrid Upload: Failed - {upload_result.message}")
-
-        for warning in upload_result.warnings:
-            message_lines.append(f"ShotGrid Warning: {warning}")
-
-        return message_lines
-
-    def _selected_destination_directories(self) -> list[Path]:
-        directories: list[Path] = []
-        for location in self._selected_destination_locations():
-            destination_dir = self._resolved_destination_path(location).strip()
-            if destination_dir:
-                directories.append(Path(destination_dir))
-        return directories
-
-    def _resolve_output_name(self, prefix: str) -> str:
-        return resolve_versioned_playblast_basename(
-            prefix,
-            self._selected_destination_directories(),
-        )
-
-    def _resolved_destination_path(self, location: SaveLocation) -> str:
-        if location.name == self.SAVE_LOCS.CUSTOM.name:
-            return self._custom_folder_field.text().strip()
-        return str(location.path)
-
-    def _refresh_destination_path_labels(self) -> None:
-        for location_name, path_label in self._destination_path_labels.items():
-            location = self._save_locations_by_name[location_name]
-            path_label.setText(f"-> {self._resolved_destination_path(location)}")
-
-    def _refresh_shot_context_fields(self) -> None:
-        if self._shot is None:
-            self._shot_code_value.setText("-")
-            self._shot_camera_value.setText("-")
-            self._shot_range_value.setText("-")
-            return
-
-        camera_path = self._get_shot_camera_path() or "-"
-        self._shot_code_value.setText(self._shot.code)
-        self._shot_camera_value.setText(camera_path)
-        self._shot_range_value.setText(f"{self._shot.cut_in} - {self._shot.cut_out}")
-
-    def _sync_custom_path_row_visibility(self) -> None:
-        is_visible = self._is_custom_destination_selected()
-        self._custom_folder_row.setVisible(is_visible)
-        self._custom_folder_field.setEnabled(is_visible)
-
-    def _sync_shotgrid_description_visibility(self) -> None:
-        show_description = self._is_shotgrid_upload_requested()
-        self._shotgrid_description_row.setVisible(show_description)
-        self._shotgrid_description_field.setEnabled(show_description)
-
-    def _is_shotgrid_upload_requested(self) -> bool:
-        return self._shotgrid_upload_checkbox.isChecked()
-
-    def _shotgrid_upload_description(self) -> str:
-        return self._shotgrid_description_field.text().strip()
-
-    def _validate_pass_text(self) -> str | None:
-        pass_text = str(self._shot_pass.currentText()).strip()
-        if not self.PASS_PATTERN.fullmatch(pass_text):
-            return "Pass must be formatted like 'Blocking #1' or 'Polish #1'."
-        return None
-
-    def _validate_target_destination_state(self) -> str | None:
-        mode = self._selected_source_mode()
-
+    def _validate_source_state(self, mode: str) -> str | None:
         if mode == "shot":
-            if self._shot is None:
-                return (
-                    "No pipeline shot context was found. Use a pipeline shot file "
-                    "or switch to Custom Playblast."
-                )
             if not self._get_shot_camera_path():
                 return "Could not resolve a shot camera path for this shot."
-
-        if mode == "custom":
-            if self._custom_out.value() < self._custom_in.value():
-                return "Custom Out must be greater than or equal to Custom In."
-            if not str(self._custom_camera.currentText()).strip():
-                return "Choose a camera for Custom Playblast."
-
-        if mode == "shot":
-            pass_error = self._validate_pass_text()
-            if pass_error:
-                return pass_error
-
-        if not self._selected_destination_locations():
-            return "Select at least one save destination."
-
-        if (
-            self._is_custom_destination_selected()
-            and not self._custom_folder_field.text().strip()
-        ):
-            return "Custom Folder path is required when Custom Folder destination is enabled."
-
+            pass_text = str(self._shot_pass.currentText()).strip()
+            if not self.PASS_PATTERN.fullmatch(pass_text):
+                return "Pass must be formatted like 'Blocking #1' or 'Polish #1'."
         return None
 
-    def _action_button_text(self) -> str:
-        mode = self._selected_source_mode()
-        if mode == "shot":
-            return "Playblast Shot"
-        return "Playblast Custom"
+    def _refresh_custom_ui_state(self) -> None:
+        if self._shot is None:
+            self._shot_camera_value.setText("-")
+        else:
+            self._shot_camera_value.setText(self._get_shot_camera_path() or "-")
 
-    def _update_action_state(self) -> None:
-        ok_button = self.buttons.button(QDialogButtonBox.Ok)
-        if ok_button is None:
-            return
+    def _get_shot_camera_path(self) -> str | None:
+        """Resolve the USD shot camera in Maya, supporting both legacy and current hierarchies."""
+        camera_path = _find_usd_shotcam()
+        if camera_path:
+            return camera_path
 
-        ok_button.setText(self._action_button_text())
-        validation_error = self._validate_target_destination_state()
-        ok_button.setEnabled(validation_error is None)
-        self._validation_label.setText(validation_error or "")
-        self._validation_label.setVisible(validation_error is not None)
-
-    def _update_ui_state(self) -> None:
-        self._refresh_source_tab_availability()
-        self._refresh_shot_context_fields()
-        self._sync_custom_path_row_visibility()
-        self._sync_shotgrid_description_visibility()
-        self._refresh_destination_path_labels()
-        self._update_action_state()
-
-    def _on_source_mode_changed(self, _index: int) -> None:
-        self._update_ui_state()
-
-    def _on_destination_changed(self, _checked: bool) -> None:
-        self._update_ui_state()
-
-    def _on_custom_path_changed(self, _path: str) -> None:
-        self._update_ui_state()
-
-    def _on_custom_in_changed(self, in_frame: int) -> None:
-        self._custom_out.setMinimum(in_frame)
-        self._update_ui_state()
-
-    def _on_source_settings_changed(self, *_args) -> None:
-        self._update_ui_state()
-
-    def _on_shotgrid_upload_toggled(self, _enabled: bool) -> None:
-        self._update_ui_state()
-
-    def _refresh_summary(self, *_args) -> None:
-        self._update_ui_state()
-
-    def _after_local_playblast(
-        self,
-        config: MPlayblastConfig,
-    ) -> list[str]:
-        if not self._should_upload_shot_playblast_to_shotgrid():
-            return []
-        return self._upload_shot_playblast_to_shotgrid(config)
+        log.warning("No USD shot camera found; falling back to legacy path.")
+        return "|__mayaUsd__|shotCamParent|shotCam"
 
     def _hud_shot_label(self) -> str:
         if self._shot is not None:
@@ -775,29 +109,7 @@ class AnimPlayblastDialog(PlayblastDialog):
             use_sequencer=False,
         )
 
-    def _build_custom_playblast_config(self) -> MShotPlayblastConfig:
-        custom_in = self._custom_in.value()
-        custom_out = self._custom_out.value()
-        custom_prefix = f"customPB_{self._shot.code}" if self._shot else "customPB"
-        custom_output_name = self._resolve_output_name(custom_prefix)
-
-        return MShotPlayblastConfig(
-            camera=str(self._custom_camera.currentText()),
-            shot=dummy_shot(
-                code="custom",
-                cut_in=custom_in,
-                cut_out=custom_out,
-                cut_duration=max(0, custom_out - custom_in),
-            ),
-            paths=self._paths_for_filename(custom_output_name),
-            use_sequencer=False,
-        )
-
     def _generate_config(self) -> MPlayblastConfig:
-        validation_error = self._validate_target_destination_state()
-        if validation_error:
-            raise ValueError(validation_error)
-
         mode = self._selected_source_mode()
         if mode == "shot":
             shot_config = self._build_shot_playblast_config()
@@ -834,12 +146,3 @@ class AnimPlayblastDialog(PlayblastDialog):
             shots=[shot_config],
             ssao=self.use_ssao,
         )
-
-    def _get_shot_camera_path(self) -> str | None:
-        """Resolve the USD shot camera in Maya, supporting both legacy and current hierarchies."""
-        camera_path = _find_usd_shotcam()
-        if camera_path:
-            return camera_path
-
-        log.warning("No USD shot camera found; falling back to legacy path.")
-        return "|__mayaUsd__|shotCamParent|shotCam"

--- a/pipeline/pipe/m/playblast/anim.py
+++ b/pipeline/pipe/m/playblast/anim.py
@@ -50,7 +50,6 @@ log = logging.getLogger(__name__)
 
 
 class AnimPlayblastDialog(PlayblastDialog):
-    _context_banner: QLabel
     _custom_camera: QComboBox
     _custom_folder_row: QWidget
     _custom_in: QSpinBox
@@ -68,13 +67,8 @@ class AnimPlayblastDialog(PlayblastDialog):
 
     SHOT_TAB_INDEX = 0
     CUSTOM_TAB_INDEX = 1
-    BOTH_TAB_INDEX = 2
 
-    SOURCE_MODE = Literal["shot", "custom", "both"]
-
-    CONTEXT_BANNER_STYLE = (
-        "padding: 8px; border: 1px solid #c3cfdb; background: #e3ebf5; color: #666;"
-    )
+    SOURCE_MODE = Literal["shot", "custom"]
 
     PASS_PATTERN = re.compile(r"^(?:Blocking|Polish) #\d+$")
 
@@ -112,7 +106,7 @@ class AnimPlayblastDialog(PlayblastDialog):
         title.setStyleSheet("font-size: 24px; font-weight: 700;")
         title.setAlignment(QtCore.Qt.AlignCenter)
 
-        subtitle = QLabel("Choose source mode, choose destinations, then export.")
+        subtitle = QLabel("Choose source mode, choose destinations, then export")
         subtitle.setAlignment(QtCore.Qt.AlignCenter)
         subtitle.setToolTip(
             "High-level workflow: choose source, choose destinations, then export."
@@ -124,14 +118,6 @@ class AnimPlayblastDialog(PlayblastDialog):
     def _build_targets_section(self) -> None:
         setup_group = QGroupBox("1. Export Setup")
         setup_layout = QVBoxLayout(setup_group)
-
-        self._context_banner = QLabel()
-        self._context_banner.setWordWrap(True)
-        self._context_banner.setStyleSheet(self.CONTEXT_BANNER_STYLE)
-        self._context_banner.setToolTip(
-            "Live context for selected export mode: shot, camera, and frame range."
-        )
-        setup_layout.addWidget(self._context_banner)
 
         setup_layout.addWidget(self._build_export_source_section())
         setup_layout.addWidget(self._build_destination_section())
@@ -151,28 +137,24 @@ class AnimPlayblastDialog(PlayblastDialog):
         source_layout = QVBoxLayout(source_group)
 
         self._source_tabs = QTabWidget()
-        self._source_tabs.addTab(
-            self._build_shot_source_tab(), "Shot Playblast (Pipeline Shot File)"
-        )
+        self._source_tabs.addTab(self._build_shot_source_tab(), "Shot Playblast")
         self._source_tabs.addTab(
             self._build_custom_source_tab(),
             "Custom Playblast",
         )
-        self._source_tabs.addTab(self._build_both_source_tab(), "Both")
         self._source_tabs.currentChanged.connect(self._on_source_mode_changed)
+        self._source_tabs.setToolTip(
+            "Select how exports are generated: shot context or manual custom range."
+        )
 
         source_tab_bar = self._source_tabs.tabBar()
         source_tab_bar.setTabToolTip(
             self.SHOT_TAB_INDEX,
-            "Export the pipeline shot loaded in this Maya scene.",
+            "Uses shot code metadata from this Maya scene and resolved shot camera/range.",
         )
         source_tab_bar.setTabToolTip(
             self.CUSTOM_TAB_INDEX,
-            "Export a manual camera and frame range.",
-        )
-        source_tab_bar.setTabToolTip(
-            self.BOTH_TAB_INDEX,
-            "Export both the pipeline shot and custom range in one run.",
+            "Uses manual camera and manual frame range.",
         )
 
         source_layout.addWidget(self._source_tabs)
@@ -190,7 +172,7 @@ class AnimPlayblastDialog(PlayblastDialog):
         self._shot_pass.addItems(["Blocking #1", "Polish #1"])
         self._shot_pass.setEditable(True)
         self._shot_pass.setToolTip(
-            "Pass text shown in the HUD. Format: Blocking #<n> or Polish #<n>."
+            "Pass text shown in the HUD for shot exports. Format: Blocking #<n> or Polish #<n>."
         )
         self._shot_pass.currentTextChanged.connect(self._on_source_settings_changed)
         pass_layout.addWidget(self._shot_pass)
@@ -205,7 +187,7 @@ class AnimPlayblastDialog(PlayblastDialog):
         shot_layout.addWidget(QLabel("Source"), 0, 0)
         source_value = QLabel("Pipeline Shot File")
         source_value.setToolTip(
-            "Uses shot context from this scene's pipeline shot code."
+            "Source is resolved from this scene's pipeline shot metadata."
         )
         shot_layout.addWidget(source_value, 0, 1)
 
@@ -221,7 +203,9 @@ class AnimPlayblastDialog(PlayblastDialog):
 
         shot_layout.addWidget(QLabel("Frame Range"), 3, 0)
         self._shot_range_value = QLabel("-")
-        self._shot_range_value.setToolTip("Resolved shot cut range from pipeline shot.")
+        self._shot_range_value.setToolTip(
+            "Resolved cut range from the detected pipeline shot."
+        )
         shot_layout.addWidget(self._shot_range_value, 3, 1)
 
         return shot_tab
@@ -252,23 +236,6 @@ class AnimPlayblastDialog(PlayblastDialog):
         custom_layout.addWidget(self._custom_camera, 1, 1, 1, 3)
 
         return custom_tab
-
-    def _build_both_source_tab(self) -> QWidget:
-        both_tab = QWidget()
-        both_layout = QVBoxLayout(both_tab)
-
-        message = QLabel(
-            "Both mode exports:\n"
-            "1) Shot Playblast (Pipeline Shot File)\n"
-            "2) Custom Playblast (manual camera + range)"
-        )
-        message.setWordWrap(True)
-        message.setToolTip(
-            "This mode exports both sources in one run using the same destination selection."
-        )
-        both_layout.addWidget(message)
-        both_layout.addStretch()
-        return both_tab
 
     def _build_destination_section(self) -> QGroupBox:
         destination_group = QGroupBox("Save Destinations")
@@ -369,18 +336,29 @@ class AnimPlayblastDialog(PlayblastDialog):
         self._use_dof.setToolTip("Include camera depth of field in playblast.")
 
     def _set_default_source_tab(self) -> None:
+        self._refresh_source_tab_availability()
+        self._source_tabs.setCurrentIndex(self._default_source_tab_index())
+
+    def _refresh_source_tab_availability(self) -> None:
         has_shot_context = self._shot is not None
         self._source_tabs.setTabEnabled(self.SHOT_TAB_INDEX, has_shot_context)
-        self._source_tabs.setTabEnabled(self.BOTH_TAB_INDEX, has_shot_context)
 
-        default_index = (
-            self.SHOT_TAB_INDEX if has_shot_context else self.CUSTOM_TAB_INDEX
-        )
-        self._source_tabs.setCurrentIndex(default_index)
+        selected_mode = self._selected_source_mode()
+        if selected_mode == "shot" and not has_shot_context:
+            self._source_tabs.setCurrentIndex(self._default_source_tab_index())
+
+    def _default_source_tab_index(self) -> int:
+        if self._shot is not None:
+            return self.SHOT_TAB_INDEX
+        return self.CUSTOM_TAB_INDEX
 
     @staticmethod
     def _resolve_pipeline_shot_context() -> Shot | None:
-        conn = DB.Get(DB_Config)
+        try:
+            conn = DB.Get(DB_Config)
+        except Exception:
+            return None
+
         try:
             code = str(mc.fileInfo("code", query=True)[0]).strip()
         except Exception:
@@ -426,9 +404,7 @@ class AnimPlayblastDialog(PlayblastDialog):
         current_index = self._source_tabs.currentIndex()
         if current_index == self.SHOT_TAB_INDEX:
             return "shot"
-        if current_index == self.CUSTOM_TAB_INDEX:
-            return "custom"
-        return "both"
+        return "custom"
 
     def _selected_destination_locations(self) -> list[SaveLocation]:
         selected: list[SaveLocation] = []
@@ -477,40 +453,17 @@ class AnimPlayblastDialog(PlayblastDialog):
             location = self._save_locations_by_name[location_name]
             path_label.setText(f"-> {self._resolved_destination_path(location)}")
 
-    def _refresh_context_banner(self) -> None:
-        mode = self._selected_source_mode()
+    def _refresh_shot_context_fields(self) -> None:
+        if self._shot is None:
+            self._shot_code_value.setText("-")
+            self._shot_camera_value.setText("-")
+            self._shot_range_value.setText("-")
+            return
 
-        if mode in {"shot", "both"}:
-            if self._shot is None:
-                banner_text = (
-                    "No pipeline shot context detected. Open a pipeline shot file "
-                    "or switch to Custom Playblast."
-                )
-                self._shot_code_value.setText("-")
-                self._shot_camera_value.setText("-")
-                self._shot_range_value.setText("-")
-            else:
-                camera_path = self._get_shot_camera_path() or "<missing camera>"
-                banner_text = (
-                    f"Detected shot: {self._shot.code} | "
-                    f"Camera: {camera_path} | "
-                    f"Range: {self._shot.cut_in}-{self._shot.cut_out}"
-                )
-                self._shot_code_value.setText(self._shot.code)
-                self._shot_camera_value.setText(camera_path)
-                self._shot_range_value.setText(
-                    f"{self._shot.cut_in} - {self._shot.cut_out}"
-                )
-        else:
-            if self._shot is None:
-                banner_text = "No shot context detected. Custom Playblast is active."
-            else:
-                banner_text = (
-                    f"Detected shot: {self._shot.code}. "
-                    "Custom Playblast is active and will use manual camera/range settings."
-                )
-
-        self._context_banner.setText(banner_text)
+        camera_path = self._get_shot_camera_path() or "-"
+        self._shot_code_value.setText(self._shot.code)
+        self._shot_camera_value.setText(camera_path)
+        self._shot_range_value.setText(f"{self._shot.cut_in} - {self._shot.cut_out}")
 
     def _sync_custom_path_row_visibility(self) -> None:
         is_visible = self._is_custom_destination_selected()
@@ -526,7 +479,7 @@ class AnimPlayblastDialog(PlayblastDialog):
     def _validate_target_destination_state(self) -> str | None:
         mode = self._selected_source_mode()
 
-        if mode in {"shot", "both"}:
+        if mode == "shot":
             if self._shot is None:
                 return (
                     "No pipeline shot context was found. Use a pipeline shot file "
@@ -535,15 +488,16 @@ class AnimPlayblastDialog(PlayblastDialog):
             if not self._get_shot_camera_path():
                 return "Could not resolve a shot camera path for this shot."
 
-        if mode in {"custom", "both"}:
+        if mode == "custom":
             if self._custom_out.value() < self._custom_in.value():
                 return "Custom Out must be greater than or equal to Custom In."
             if not str(self._custom_camera.currentText()).strip():
                 return "Choose a camera for Custom Playblast."
 
-        pass_error = self._validate_pass_text()
-        if pass_error:
-            return pass_error
+        if mode == "shot":
+            pass_error = self._validate_pass_text()
+            if pass_error:
+                return pass_error
 
         if not self._selected_destination_locations():
             return "Select at least one save destination."
@@ -560,9 +514,7 @@ class AnimPlayblastDialog(PlayblastDialog):
         mode = self._selected_source_mode()
         if mode == "shot":
             return "Playblast Shot"
-        if mode == "custom":
-            return "Playblast Custom"
-        return "Playblast Shot + Custom"
+        return "Playblast Custom"
 
     def _update_action_state(self) -> None:
         ok_button = self.buttons.button(QDialogButtonBox.Ok)
@@ -576,9 +528,10 @@ class AnimPlayblastDialog(PlayblastDialog):
         self._validation_label.setVisible(validation_error is not None)
 
     def _update_ui_state(self) -> None:
+        self._refresh_source_tab_availability()
+        self._refresh_shot_context_fields()
         self._sync_custom_path_row_visibility()
         self._refresh_destination_path_labels()
-        self._refresh_context_banner()
         self._update_action_state()
 
     def _on_source_mode_changed(self, _index: int) -> None:
@@ -642,13 +595,10 @@ class AnimPlayblastDialog(PlayblastDialog):
             raise ValueError(validation_error)
 
         mode = self._selected_source_mode()
-        shots: list[MShotPlayblastConfig] = []
-
-        if mode in {"shot", "both"}:
-            shots.append(self._build_shot_playblast_config())
-
-        if mode in {"custom", "both"}:
-            shots.append(self._build_custom_playblast_config())
+        if mode == "shot":
+            shot_config = self._build_shot_playblast_config()
+        else:
+            shot_config = self._build_custom_playblast_config()
 
         return MPlayblastConfig(
             builtin_huds=[
@@ -677,7 +627,7 @@ class AnimPlayblastDialog(PlayblastDialog):
             hardware_fog=self.use_hardware_fog,
             lighting=self.use_lighting,
             shadows=self.use_shadows,
-            shots=shots,
+            shots=[shot_config],
             ssao=self.use_ssao,
         )
 

--- a/pipeline/pipe/m/playblast/playblaster.py
+++ b/pipeline/pipe/m/playblast/playblaster.py
@@ -2,12 +2,12 @@ from __future__ import annotations
 
 import copy
 import logging
-import maya.cmds as mc
-
 from contextlib import contextmanager
 from typing import TYPE_CHECKING
 
+import maya.cmds as mc
 from mayacapture.capture import capture  # type: ignore[import-not-found]
+
 from pipe.m.util import maintain_selection
 from pipe.util import Playblaster
 
@@ -30,16 +30,29 @@ class MPlayblaster(Playblaster):
         self._config = config
         return self
 
+    @staticmethod
+    def _resolve_active_editor() -> str:
+        panel = str(mc.sequenceManager(query=True, modelPanel=True) or "")
+        if panel and mc.modelPanel(panel, exists=True):
+            return panel
+
+        model_panels = mc.getPanel(type="modelPanel") or []
+        if model_panels:
+            return str(model_panels[0])
+        return ""
+
     def _write_images(self, path: str) -> None:
         """Maya implementation of playblasting image frames"""
-        active_editor = str(mc.sequenceManager(query=True, modelPanel=True))
-        self._extra_kwargs["viewport_options"].update(
-            {
-                "twoSidedLighting": mc.modelEditor(
-                    active_editor, query=True, twoSidedLighting=True
-                ),
-            }
-        )
+        active_editor = self._resolve_active_editor()
+        if active_editor:
+            self._extra_kwargs["viewport_options"].update(
+                {
+                    "twoSidedLighting": mc.modelEditor(
+                        active_editor, query=True, twoSidedLighting=True
+                    ),
+                }
+            )
+
         self._extra_kwargs["viewport2_options"].update(
             {
                 **{
@@ -78,9 +91,10 @@ class MPlayblaster(Playblaster):
         )
 
     def playblast(self) -> None:
-        with applied_hud(
-            self._config.builtin_huds, self._config.custom_huds
-        ), maintain_selection():
+        with (
+            applied_hud(self._config.builtin_huds, self._config.custom_huds),
+            maintain_selection(),
+        ):
             mc.select(clear=True)
 
             # assemble kwargs from config options

--- a/pipeline/pipe/m/playblast/previs.py
+++ b/pipeline/pipe/m/playblast/previs.py
@@ -31,6 +31,7 @@ from pipe.playblast_naming import (
     playblast_date_folder,
     resolve_versioned_playblast_basename,
 )
+from pipe.playblast_shotgrid import resolve_preferred_upload_movie_path
 from pipe.util import Playblaster
 
 from .struct import (
@@ -590,6 +591,90 @@ class PrevisPlayblastDialog(PlayblastDialog):
                 continue
             paths[location.preset].append(str(Path(destination_dir) / filename))
         return paths
+
+    @staticmethod
+    def _final_movie_path_for_base(
+        output_base: str | Path,
+        preset: Playblaster.PRESET,
+    ) -> Path:
+        return Path(str(output_base) + f".{preset.ext}")
+
+    def _final_movie_paths_for_location(
+        self,
+        shot_config: MShotPlayblastConfig,
+        location: SaveLocation,
+    ) -> list[Path]:
+        destination_dir = Path(self._resolved_destination_path(location)).expanduser()
+        resolved_destination_dir = destination_dir.resolve()
+
+        matching_paths: list[Path] = []
+        for output_base in shot_config.paths.get(location.preset, []):
+            resolved_output_base = Path(str(output_base)).expanduser().resolve()
+            if resolved_output_base.parent != resolved_destination_dir:
+                continue
+            matching_paths.append(
+                self._final_movie_path_for_base(resolved_output_base, location.preset)
+            )
+        return matching_paths
+
+    def _ordered_final_movie_paths_for_upload(
+        self,
+        shot_config: MShotPlayblastConfig,
+    ) -> list[Path]:
+        """Return deterministic output path order for upload path resolution."""
+
+        ordered_paths: list[Path] = []
+        seen_paths: set[Path] = set()
+
+        for location in self._destination_locations():
+            for output_path in self._final_movie_paths_for_location(
+                shot_config, location
+            ):
+                if output_path in seen_paths:
+                    continue
+                seen_paths.add(output_path)
+                ordered_paths.append(output_path)
+
+        for preset, output_bases in shot_config.paths.items():
+            for output_base in output_bases:
+                output_path = self._final_movie_path_for_base(output_base, preset)
+                resolved_output_path = output_path.expanduser().resolve()
+                if resolved_output_path in seen_paths:
+                    continue
+                seen_paths.add(resolved_output_path)
+                ordered_paths.append(resolved_output_path)
+
+        return ordered_paths
+
+    def _preferred_edit_movie_paths_for_upload(
+        self,
+        shot_config: MShotPlayblastConfig,
+    ) -> list[Path]:
+        edit_location = self._save_locations_by_name.get(self.SAVE_LOCS.EDIT.name)
+        if edit_location is None:
+            return []
+        return self._final_movie_paths_for_location(shot_config, edit_location)
+
+    def _resolve_shotgrid_upload_movie_path(
+        self,
+        config: MPlayblastConfig,
+    ) -> Path | None:
+        """Resolve upload movie path with stable preference ordering.
+
+        Preference order:
+        1) valid `Send to Edit` output
+        2) first valid output from the deterministic export order
+        """
+        if not config.shots:
+            return None
+
+        shot_config = config.shots[0]
+        preferred_paths = self._preferred_edit_movie_paths_for_upload(shot_config)
+        output_paths = self._ordered_final_movie_paths_for_upload(shot_config)
+        return resolve_preferred_upload_movie_path(
+            output_paths,
+            preferred_paths=preferred_paths,
+        )
 
     def _selected_destination_directories(self) -> list[Path]:
         directories: list[Path] = []

--- a/pipeline/pipe/m/playblast/previs.py
+++ b/pipeline/pipe/m/playblast/previs.py
@@ -1,10 +1,27 @@
 from __future__ import annotations
 
-import logging
+from collections import defaultdict
+from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
 
 import maya.cmds as mc
+from Qt import QtCore
+from Qt.QtWidgets import (
+    QCheckBox,
+    QComboBox,
+    QDialogButtonBox,
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QSpinBox,
+    QTabWidget,
+    QVBoxLayout,
+    QWidget,
+)
 from shared.util import get_edit_path
 
 from pipe.util import Playblaster
@@ -12,21 +29,41 @@ from pipe.util import Playblaster
 from .struct import (
     HudDefinition,
     MPlayblastConfig,
-    MShotDialogConfig,
     MShotPlayblastConfig,
     SaveLocation,
     dummy_shot,
 )
 from .ui import PlayblastDialog
 
-log = logging.getLogger(__name__)
+
+@dataclass(frozen=True)
+class SequencerShotContext:
+    node: str
+    name: str
+    camera: str
+    cut_in: int
+    cut_out: int
+    cut_duration: int
 
 
 class PrevisPlayblastDialog(PlayblastDialog):
-    _camera_shot_lookup: dict[str, str]
-    _timeline_dialog_configs: list[MShotDialogConfig]
-    _sequence_dialog_configs: list[MShotDialogConfig]
-    _shot_dialog_configs: list[MShotDialogConfig]
+    _context_banner: QLabel
+    _custom_camera: QComboBox
+    _custom_folder_row: QWidget
+    _custom_in: QSpinBox
+    _custom_out: QSpinBox
+    _destination_checkboxes: dict[str, QCheckBox]
+    _destination_path_labels: dict[str, QLabel]
+    _save_locations_by_name: dict[str, SaveLocation]
+    _sequencer_shot_nodes: list[str]
+    _source_tabs: QTabWidget
+    _shot_camera_value: QLabel
+    _shot_name_value: QLabel
+    _shot_range_value: QLabel
+    _validation_label: QLabel
+
+    SHOT_TAB_INDEX = 0
+    CUSTOM_TAB_INDEX = 1
 
     class SAVE_LOCS(PlayblastDialog.SAVE_LOCS):
         EDIT = SaveLocation(
@@ -36,89 +73,206 @@ class PrevisPlayblastDialog(PlayblastDialog):
         )
 
     def __init__(self, parent) -> None:
-        shot_node_list: list[str] = mc.sequenceManager(listShots=True) or []  # type: ignore[assignment]
-        sequencer_node = str(
-            mc.sequenceManager(query=True, writableSequencer=True) or ""
-        )
-
-        # generate lookup table for matching cameras to shots
-        self._camera_shot_lookup = {
-            str(mc.shot(node, query=True, currentCamera=True)): str(
-                mc.shot(node, query=True, shotName=True)
-            )
-            for node in shot_node_list
-        }
-
-        self._shot_dialog_configs = [
-            MShotDialogConfig(
-                id=shot_node,
-                name=str(mc.shot(shot_node, query=True, shotName=True)),
-                save_locs=[
-                    (self.SAVE_LOCS.EDIT, True),
-                    (self.SAVE_LOCS.CURRENT, False),
-                    (self.SAVE_LOCS.CUSTOM, False),
-                ],
-            )
-            for shot_node in shot_node_list
+        self._sequencer_shot_nodes = [
+            str(shot_node)
+            for shot_node in (mc.sequenceManager(listShots=True) or [])
+            if mc.objExists(shot_node)
+            and not bool(mc.shot(shot_node, query=True, mute=True))
         ]
-        self._sequence_dialog_configs = []
-        if shot_node_list and sequencer_node and mc.objExists(sequencer_node):
-            self._sequence_dialog_configs = [
-                MShotDialogConfig(
-                    id=sequencer_node,
-                    name="Camera Sequencer",
-                    save_locs=[
-                        (self.SAVE_LOCS.EDIT, True),
-                        (self.SAVE_LOCS.CURRENT, True),
-                        (self.SAVE_LOCS.CUSTOM, False),
-                    ],
-                )
-            ]
+        self._destination_checkboxes = {}
+        self._destination_path_labels = {}
+        self._save_locations_by_name = {
+            location.name: location for location in self._destination_locations()
+        }
+        super().__init__(parent, [], "Bobo Previs Playblast")
 
-        self._timeline_dialog_configs = []
-        if not shot_node_list:
-            log.warning(
-                "No camera sequencer shots detected. Falling back to active timeline export."
-            )
-            self._timeline_dialog_configs = [
-                MShotDialogConfig(
-                    id="timeline_fallback",
-                    name="Active Camera Timeline",
-                    save_locs=[
-                        (self.SAVE_LOCS.EDIT, True),
-                        (self.SAVE_LOCS.CURRENT, True),
-                        (self.SAVE_LOCS.CUSTOM, False),
-                    ],
-                )
-            ]
+    def _setup_ui(self) -> None:
+        self._central_widget = QWidget()
+        self.setCentralWidget(self._central_widget)
+        self._main_layout = QVBoxLayout()
+        self._central_widget.setLayout(self._main_layout)
 
-        super().__init__(
-            parent,
-            self._shot_dialog_configs
-            + self._sequence_dialog_configs
-            + self._timeline_dialog_configs,
-            "Bobo Previs Playblast",
+        self._build_header_section()
+        self._build_targets_section()
+        self._build_render_options_section()
+        self._build_buttons()
+        self._set_default_source_tab()
+        self._update_ui_state()
+
+    def _build_header_section(self) -> None:
+        title = QLabel("Bobo Previs Playblast")
+        title.setStyleSheet("font-size: 24px; font-weight: 700;")
+        title.setAlignment(QtCore.Qt.AlignCenter)
+
+        subtitle = QLabel("Choose source mode, choose destinations, then export.")
+        subtitle.setStyleSheet("color: #666;")
+        subtitle.setAlignment(QtCore.Qt.AlignCenter)
+
+        self._main_layout.addWidget(title)
+        self._main_layout.addWidget(subtitle)
+
+    def _build_targets_section(self) -> None:
+        setup_group = QGroupBox("1. Export Setup")
+        setup_layout = QVBoxLayout(setup_group)
+
+        self._context_banner = QLabel()
+        self._context_banner.setWordWrap(True)
+        self._context_banner.setStyleSheet(
+            "padding: 6px; border: 1px solid #dcdcdc; background: #f7f7f7;"
         )
+        setup_layout.addWidget(self._context_banner)
 
-    def _do_camera_shot_lookup(self) -> str:
-        """Look up the current shot based off of the camera"""
-        if not self._camera_shot_lookup:
-            return "No shot data"
-        panel: str = mc.getPanel(withLabel="CapturePanel")  # type: ignore[assignment]
-        try:
-            if panel:
-                camera = (
-                    str(mc.modelEditor(panel, query=True, camera=True)).split("|").pop()  # type: ignore[arg-type]
-                )
-                return self._camera_shot_lookup[camera]
-        except KeyError:
-            pass
-        return "No shot data"
+        setup_layout.addWidget(self._build_export_source_section())
+        setup_layout.addWidget(self._build_destination_section())
+
+        self._validation_label = QLabel()
+        self._validation_label.setStyleSheet("color: #b00020;")
+        self._validation_label.setVisible(False)
+        setup_layout.addWidget(self._validation_label)
+
+        self._main_layout.addWidget(setup_group)
+
+    def _build_export_source_section(self) -> QGroupBox:
+        source_group = QGroupBox("Export Source")
+        source_layout = QVBoxLayout(source_group)
+
+        self._source_tabs = QTabWidget()
+        self._source_tabs.addTab(
+            self._build_shot_source_tab(), "Shot Playblast (Current Sequencer Shot)"
+        )
+        self._source_tabs.addTab(
+            self._build_custom_source_tab(),
+            "Custom Playblast (Testing / Non-shot File)",
+        )
+        self._source_tabs.currentChanged.connect(self._on_source_mode_changed)
+        source_layout.addWidget(self._source_tabs)
+        return source_group
+
+    def _build_shot_source_tab(self) -> QWidget:
+        shot_tab = QWidget()
+        shot_layout = QGridLayout(shot_tab)
+
+        shot_layout.addWidget(QLabel("Source"), 0, 0)
+        shot_layout.addWidget(QLabel("Current Sequencer Shot"), 0, 1)
+
+        shot_layout.addWidget(QLabel("Shot"), 1, 0)
+        self._shot_name_value = QLabel("-")
+        shot_layout.addWidget(self._shot_name_value, 1, 1)
+
+        shot_layout.addWidget(QLabel("Camera"), 2, 0)
+        self._shot_camera_value = QLabel("-")
+        shot_layout.addWidget(self._shot_camera_value, 2, 1)
+
+        shot_layout.addWidget(QLabel("Frame Range"), 3, 0)
+        self._shot_range_value = QLabel("-")
+        shot_layout.addWidget(self._shot_range_value, 3, 1)
+        return shot_tab
+
+    def _build_custom_source_tab(self) -> QWidget:
+        custom_tab = QWidget()
+        custom_layout = QGridLayout(custom_tab)
+
+        timeline_in, timeline_out = self._timeline_range()
+        self._custom_in = QSpinBox(self, minimum=0, maximum=10000, value=timeline_in)
+        self._custom_out = QSpinBox(self, minimum=0, maximum=10000, value=timeline_out)
+        self._custom_out.setMinimum(self._custom_in.value())
+        self._custom_in.valueChanged.connect(self._on_custom_in_changed)
+        self._custom_out.valueChanged.connect(self._on_source_settings_changed)
+
+        custom_layout.addWidget(QLabel("Custom In"), 0, 0)
+        custom_layout.addWidget(self._custom_in, 0, 1)
+        custom_layout.addWidget(QLabel("Custom Out"), 0, 2)
+        custom_layout.addWidget(self._custom_out, 0, 3)
+
+        camera_list = self._available_custom_cameras()
+        self._custom_camera = QComboBox(self)
+        self._custom_camera.addItems(camera_list)
+        self._custom_camera.currentTextChanged.connect(self._on_source_settings_changed)
+        custom_layout.addWidget(QLabel("Custom Camera"), 1, 0)
+        custom_layout.addWidget(self._custom_camera, 1, 1, 1, 3)
+        return custom_tab
+
+    def _build_destination_section(self) -> QGroupBox:
+        destination_group = QGroupBox("Save Destinations")
+        destination_layout = QVBoxLayout(destination_group)
+
+        help_label = QLabel("Select one or more destinations.")
+        help_label.setStyleSheet("color: #666;")
+        destination_layout.addWidget(help_label)
+
+        for save_location in self._destination_locations():
+            row_widget = QWidget()
+            row_layout = QHBoxLayout(row_widget)
+            row_layout.setContentsMargins(0, 0, 0, 0)
+
+            destination_toggle = QCheckBox(save_location.name)
+            destination_toggle.setChecked(
+                self._default_destination_enabled(save_location)
+            )
+            destination_toggle.toggled.connect(self._on_destination_changed)
+            self._destination_checkboxes[save_location.name] = destination_toggle
+            row_layout.addWidget(destination_toggle)
+
+            path_label = QLabel("")
+            path_label.setStyleSheet("color: #666;")
+            self._destination_path_labels[save_location.name] = path_label
+            row_layout.addWidget(path_label)
+            row_layout.addStretch()
+            destination_layout.addWidget(row_widget)
+
+        self._custom_folder_row = self._build_destination_path_row()
+        destination_layout.addWidget(self._custom_folder_row)
+        return destination_group
+
+    def _build_destination_path_row(self) -> QWidget:
+        custom_path_row = QWidget()
+        custom_path_layout = QHBoxLayout(custom_path_row)
+        custom_path_layout.setContentsMargins(24, 0, 0, 0)
+
+        custom_path_layout.addWidget(QLabel("Custom Folder Path"))
+
+        self._custom_folder_field = QLineEdit()
+        self._custom_folder_field.setText(self._default_custom_folder_path())
+        self._custom_folder_field.textChanged.connect(self._on_custom_path_changed)
+        custom_path_layout.addWidget(self._custom_folder_field)
+
+        browse_button = QPushButton("Browse")
+        browse_button.clicked.connect(self._set_custom_folder)
+        custom_path_layout.addWidget(browse_button)
+        return custom_path_row
+
+    def _build_render_options_section(self) -> None:
+        options_group = QGroupBox("2. Viewport Options")
+        options_layout = QVBoxLayout(options_group)
+        options_layout.addWidget(
+            self._build_viewport_options_widget(self._resolve_active_model_panel())
+        )
+        self._main_layout.addWidget(options_group)
+
+    def _build_buttons(self) -> None:
+        self._init_buttons(has_cancel_button=True, ok_name="Playblast Shot")
+        self.buttons.rejected.connect(self.close)
+        self.buttons.accepted.connect(self.do_export)
+        self._main_layout.addWidget(self.buttons)
+
+    def _set_default_source_tab(self) -> None:
+        has_shot_context = bool(self._sequencer_shot_nodes)
+        self._source_tabs.setTabEnabled(self.SHOT_TAB_INDEX, has_shot_context)
+        default_index = (
+            self.SHOT_TAB_INDEX if has_shot_context else self.CUSTOM_TAB_INDEX
+        )
+        self._source_tabs.setCurrentIndex(default_index)
 
     @staticmethod
-    def _scene_stem() -> str:
-        scene_name = Path(mc.file(query=True, sceneName=True)).stem  # type: ignore[arg-type]
-        return scene_name or "previs_playblast"
+    def _destination_locations() -> list[SaveLocation]:
+        return [
+            PrevisPlayblastDialog.SAVE_LOCS.EDIT,
+            PrevisPlayblastDialog.SAVE_LOCS.CURRENT,
+            PrevisPlayblastDialog.SAVE_LOCS.CUSTOM,
+        ]
+
+    def _default_destination_enabled(self, location: SaveLocation) -> bool:
+        return location.name == self.SAVE_LOCS.EDIT.name
 
     @staticmethod
     def _timeline_range() -> tuple[int, int]:
@@ -128,105 +282,251 @@ class PrevisPlayblastDialog(PlayblastDialog):
             cut_out = cut_in
         return cut_in, cut_out
 
-    def _sequencer_range(self, sequencer_node: str) -> tuple[int, int]:
-        if not sequencer_node or not mc.objExists(sequencer_node):
-            return self._timeline_range()
-        try:
-            cut_in = int(mc.getAttr(f"{sequencer_node}.minFrame"))
-            cut_out = int(mc.getAttr(f"{sequencer_node}.maxFrame"))
-        except Exception:
-            return self._timeline_range()
-        if cut_out < cut_in:
-            cut_out = cut_in
-        return cut_in, cut_out
-
     @staticmethod
-    def _active_camera() -> str:
-        focused_panel = str(mc.getPanel(withFocus=True) or "")
-        if focused_panel and mc.getPanel(typeOf=focused_panel) == "modelPanel":
-            try:
-                return str(mc.modelEditor(focused_panel, query=True, camera=True))
-            except Exception:
-                pass
-
-        sequencer_panel = str(mc.sequenceManager(query=True, modelPanel=True) or "")
-        if sequencer_panel and mc.modelPanel(sequencer_panel, exists=True):
-            try:
-                return str(mc.modelEditor(sequencer_panel, query=True, camera=True))
-            except Exception:
-                pass
-
-        visible_cameras = mc.ls(cameras=True, visible=True) or []
-        if visible_cameras:
-            return str(visible_cameras[0])
-        return "persp"
-
-    def _generate_config(self) -> MPlayblastConfig:
-        seq_node = str(mc.sequenceManager(query=True, writableSequencer=True) or "")
-        date = datetime.now().strftime("%m-%d-%y")
-        shot_name = self._scene_stem()
-
-        shots = [
-            MShotPlayblastConfig(
-                camera=str(mc.shot(config.id, query=True, currentCamera=True)),
-                shot=dummy_shot(
-                    clip_name := str(mc.shot(config.id, query=True, shotName=True)),
-                    int(mc.shot(config.id, query=True, startTime=True)),
-                    int(mc.shot(config.id, query=True, endTime=True)),
-                    int(mc.shot(config.id, query=True, clipDuration=True)),
-                ),
-                paths=self.save_locations_to_paths(
-                    config.id,
-                    (sl[0] for sl in config.save_locs),
-                    f"{clip_name}_{date}",
-                ),
+    def _available_custom_cameras() -> list[str]:
+        return [
+            str(c)
+            for c in (
+                mc.ls(cameras=True, visible=True) or mc.ls(cameras=True) or ["persp"]
             )
-            for config in self._shot_dialog_configs
-            if self.is_shot_enabled(config.id)
         ]
 
-        for config in self._sequence_dialog_configs:
-            if not self.is_shot_enabled(config.id):
-                continue
-            seq_in, seq_out = self._sequencer_range(seq_node)
-            shots.append(
-                MShotPlayblastConfig(
-                    camera=None,
-                    shot=dummy_shot(
-                        code=shot_name,
-                        cut_in=seq_in,
-                        cut_out=seq_out,
-                        cut_duration=seq_out - seq_in,
-                    ),
-                    paths=self.save_locations_to_paths(
-                        config.id,
-                        (sl[0] for sl in config.save_locs),
-                        f"{shot_name}_{date}",
-                    ),
-                    use_sequencer=True,
-                )
-            )
+    def _is_shot_mode_selected(self) -> bool:
+        return self._source_tabs.currentIndex() == self.SHOT_TAB_INDEX
 
-        for config in self._timeline_dialog_configs:
-            if not self.is_shot_enabled(config.id):
+    def _selected_destination_locations(self) -> list[SaveLocation]:
+        selected: list[SaveLocation] = []
+        for location in self._destination_locations():
+            toggle = self._destination_checkboxes.get(location.name)
+            if toggle and toggle.isChecked():
+                selected.append(location)
+        return selected
+
+    def _is_custom_destination_selected(self) -> bool:
+        custom_checkbox = self._destination_checkboxes.get(self.SAVE_LOCS.CUSTOM.name)
+        return bool(custom_checkbox and custom_checkbox.isChecked())
+
+    def _paths_for_filename(
+        self, filename: str
+    ) -> dict[Playblaster.PRESET, list[str | Path]]:
+        paths: dict[Playblaster.PRESET, list[str | Path]] = defaultdict(list)
+        for location in self._selected_destination_locations():
+            destination_dir = self._resolved_destination_path(location).strip()
+            if not destination_dir:
                 continue
-            timeline_in, timeline_out = self._timeline_range()
-            shots.append(
-                MShotPlayblastConfig(
-                    camera=self._active_camera(),
-                    shot=dummy_shot(
-                        code=shot_name,
-                        cut_in=timeline_in,
-                        cut_out=timeline_out,
-                        cut_duration=timeline_out - timeline_in,
-                    ),
-                    paths=self.save_locations_to_paths(
-                        config.id,
-                        (sl[0] for sl in config.save_locs),
-                        f"{shot_name}_{date}",
-                    ),
-                    use_sequencer=False,
+            paths[location.preset].append(str(Path(destination_dir) / filename))
+        return paths
+
+    def _resolved_destination_path(self, location: SaveLocation) -> str:
+        if location.name == self.SAVE_LOCS.CUSTOM.name:
+            return self._custom_folder_field.text().strip()
+        return str(location.path)
+
+    def _refresh_destination_path_labels(self) -> None:
+        for location_name, path_label in self._destination_path_labels.items():
+            location = self._save_locations_by_name[location_name]
+            path_label.setText(f"-> {self._resolved_destination_path(location)}")
+
+    def _refresh_context_banner(self) -> None:
+        shot_context = self._resolve_current_sequencer_shot_context()
+        if self._is_shot_mode_selected():
+            if shot_context is None:
+                current_frame = int(mc.currentTime(query=True))
+                banner_text = (
+                    "No current sequencer shot found at frame "
+                    f"{current_frame}. Move the timeline into a shot or switch to Custom Playblast."
                 )
+                self._shot_name_value.setText("-")
+                self._shot_camera_value.setText("-")
+                self._shot_range_value.setText("-")
+            else:
+                banner_text = (
+                    f"Detected shot: {shot_context.name} | "
+                    f"Camera: {shot_context.camera} | "
+                    f"Range: {shot_context.cut_in}-{shot_context.cut_out}"
+                )
+                self._shot_name_value.setText(shot_context.name)
+                self._shot_camera_value.setText(shot_context.camera)
+                self._shot_range_value.setText(
+                    f"{shot_context.cut_in} - {shot_context.cut_out}"
+                )
+        else:
+            if shot_context is None:
+                banner_text = "No shot context detected. Custom Playblast is active."
+            else:
+                banner_text = (
+                    f"Detected shot: {shot_context.name}. "
+                    "Custom Playblast is active and will use manual camera/range settings."
+                )
+        self._context_banner.setText(banner_text)
+
+    def _sync_custom_path_row_visibility(self) -> None:
+        is_visible = self._is_custom_destination_selected()
+        self._custom_folder_row.setVisible(is_visible)
+        self._custom_folder_field.setEnabled(is_visible)
+
+    def _validate_target_destination_state(self) -> str | None:
+        if self._is_shot_mode_selected():
+            shot_context = self._resolve_current_sequencer_shot_context()
+            if shot_context is None:
+                return "No current sequencer shot was found. Move timeline to a shot or use Custom Playblast."
+            if not shot_context.camera:
+                return "Current sequencer shot has no camera assigned."
+        else:
+            if self._custom_out.value() < self._custom_in.value():
+                return "Custom Out must be greater than or equal to Custom In."
+            if not str(self._custom_camera.currentText()).strip():
+                return "Choose a camera for Custom Playblast."
+
+        if not self._selected_destination_locations():
+            return "Select at least one save destination."
+
+        if (
+            self._is_custom_destination_selected()
+            and not self._custom_folder_field.text().strip()
+        ):
+            return "Custom Folder path is required when Custom Folder destination is enabled."
+
+        return None
+
+    def _update_action_state(self) -> None:
+        ok_button = self.buttons.button(QDialogButtonBox.Ok)
+        if ok_button is None:
+            return
+
+        ok_button.setText(
+            "Playblast Shot" if self._is_shot_mode_selected() else "Playblast Custom"
+        )
+        validation_error = self._validate_target_destination_state()
+        ok_button.setEnabled(validation_error is None)
+        self._validation_label.setText(validation_error or "")
+        self._validation_label.setVisible(validation_error is not None)
+
+    def _update_ui_state(self) -> None:
+        self._sync_custom_path_row_visibility()
+        self._refresh_destination_path_labels()
+        self._refresh_context_banner()
+        self._update_action_state()
+
+    def _on_source_mode_changed(self, _index: int) -> None:
+        self._update_ui_state()
+
+    def _on_destination_changed(self, _checked: bool) -> None:
+        self._update_ui_state()
+
+    def _on_custom_path_changed(self, _path: str) -> None:
+        self._update_ui_state()
+
+    def _on_custom_in_changed(self, in_frame: int) -> None:
+        self._custom_out.setMinimum(in_frame)
+        self._update_ui_state()
+
+    def _on_source_settings_changed(self, *_args) -> None:
+        self._update_ui_state()
+
+    def _refresh_summary(self, *_args) -> None:
+        self._update_ui_state()
+
+    def _resolve_current_sequencer_shot_context(self) -> SequencerShotContext | None:
+        shot_node = self._resolve_current_shot_node()
+        if not shot_node:
+            return None
+
+        try:
+            shot_name = str(mc.shot(shot_node, query=True, shotName=True) or shot_node)
+            shot_camera = str(mc.shot(shot_node, query=True, currentCamera=True) or "")
+            cut_in = int(mc.shot(shot_node, query=True, startTime=True))
+            cut_out = int(mc.shot(shot_node, query=True, endTime=True))
+            cut_duration = int(mc.shot(shot_node, query=True, clipDuration=True))
+        except Exception:
+            return None
+
+        if cut_out < cut_in:
+            cut_out = cut_in
+        if cut_duration < 0:
+            cut_duration = 0
+
+        return SequencerShotContext(
+            node=shot_node,
+            name=shot_name,
+            camera=shot_camera,
+            cut_in=cut_in,
+            cut_out=cut_out,
+            cut_duration=cut_duration,
+        )
+
+    def _resolve_current_shot_node(self) -> str | None:
+        if not self._sequencer_shot_nodes:
+            return None
+
+        current_frame = int(mc.currentTime(query=True))
+        for shot_node in self._sequencer_shot_nodes:
+            if not mc.objExists(shot_node):
+                continue
+            try:
+                shot_in = int(mc.shot(shot_node, query=True, startTime=True))
+                shot_out = int(mc.shot(shot_node, query=True, endTime=True))
+            except Exception:
+                continue
+            if shot_in <= current_frame <= shot_out:
+                return shot_node
+        return None
+
+    @staticmethod
+    def _scene_stem() -> str:
+        scene_name = Path(str(mc.file(query=True, sceneName=True) or "")).stem
+        return scene_name or "previs_playblast"
+
+    def _hud_shot_label(self) -> str:
+        shot_context = self._resolve_current_sequencer_shot_context()
+        if shot_context:
+            return shot_context.name
+        return "Custom"
+
+    def _validate_config(self, config: MPlayblastConfig) -> str | None:
+        validation_error = self._validate_target_destination_state()
+        if validation_error:
+            return validation_error
+        return super()._validate_config(config)
+
+    def _generate_config(self) -> MPlayblastConfig:
+        validation_error = self._validate_target_destination_state()
+        if validation_error:
+            raise ValueError(validation_error)
+
+        date_suffix = datetime.now().strftime("%m-%d-%y")
+        if self._is_shot_mode_selected():
+            shot_context = self._resolve_current_sequencer_shot_context()
+            if shot_context is None:
+                raise ValueError("No current sequencer shot was found.")
+
+            output_name = f"{shot_context.name}_{date_suffix}"
+            shot_config = MShotPlayblastConfig(
+                camera=shot_context.camera,
+                shot=dummy_shot(
+                    code=shot_context.name,
+                    cut_in=shot_context.cut_in,
+                    cut_out=shot_context.cut_out,
+                    cut_duration=shot_context.cut_duration,
+                ),
+                paths=self._paths_for_filename(output_name),
+                use_sequencer=False,
+            )
+        else:
+            custom_in = self._custom_in.value()
+            custom_out = self._custom_out.value()
+            custom_code = self._scene_stem()
+            output_name = f"{custom_code}_custom_{date_suffix}"
+            shot_config = MShotPlayblastConfig(
+                camera=str(self._custom_camera.currentText()),
+                shot=dummy_shot(
+                    code=custom_code,
+                    cut_in=custom_in,
+                    cut_out=custom_out,
+                    cut_duration=max(0, custom_out - custom_in),
+                ),
+                paths=self._paths_for_filename(output_name),
+                use_sequencer=False,
             )
 
         return MPlayblastConfig(
@@ -240,7 +540,7 @@ class PrevisPlayblastDialog(PlayblastDialog):
                 PlayblastDialog.CUSTOM_HUDS.ARTIST,
                 HudDefinition(
                     "Boboshot",
-                    command=self._do_camera_shot_lookup,
+                    command=self._hud_shot_label,
                     section=7,
                     idle_refresh=True,
                 ),
@@ -249,6 +549,6 @@ class PrevisPlayblastDialog(PlayblastDialog):
             hardware_fog=self.use_hardware_fog,
             lighting=self.use_lighting,
             shadows=self.use_shadows,
-            shots=shots,
+            shots=[shot_config],
             ssao=self.use_ssao,
         )

--- a/pipeline/pipe/m/playblast/previs.py
+++ b/pipeline/pipe/m/playblast/previs.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from collections import defaultdict
 from dataclasses import dataclass
-from datetime import datetime
 from pathlib import Path
 
 import maya.cmds as mc
@@ -24,6 +23,10 @@ from Qt.QtWidgets import (
 )
 from shared.util import get_edit_path
 
+from pipe.playblast_naming import (
+    playblast_date_folder,
+    resolve_versioned_playblast_basename,
+)
 from pipe.util import Playblaster
 
 from .struct import (
@@ -71,7 +74,7 @@ class PrevisPlayblastDialog(PlayblastDialog):
     class SAVE_LOCS(PlayblastDialog.SAVE_LOCS):
         EDIT = SaveLocation(
             "Send to Edit",
-            get_edit_path() / "previs" / datetime.now().strftime("%m-%d-%y"),
+            lambda: get_edit_path() / "previs" / playblast_date_folder(),
             Playblaster.PRESET.EDIT_SQ,
         )
 
@@ -387,6 +390,20 @@ class PrevisPlayblastDialog(PlayblastDialog):
             paths[location.preset].append(str(Path(destination_dir) / filename))
         return paths
 
+    def _selected_destination_directories(self) -> list[Path]:
+        directories: list[Path] = []
+        for location in self._selected_destination_locations():
+            destination_dir = self._resolved_destination_path(location).strip()
+            if destination_dir:
+                directories.append(Path(destination_dir))
+        return directories
+
+    def _resolve_output_name(self, prefix: str) -> str:
+        return resolve_versioned_playblast_basename(
+            prefix,
+            self._selected_destination_directories(),
+        )
+
     def _resolved_destination_path(self, location: SaveLocation) -> str:
         if location.name == self.SAVE_LOCS.CUSTOM.name:
             return self._custom_folder_field.text().strip()
@@ -564,13 +581,12 @@ class PrevisPlayblastDialog(PlayblastDialog):
         if validation_error:
             raise ValueError(validation_error)
 
-        date_suffix = datetime.now().strftime("%m-%d-%y")
         if self._is_shot_mode_selected():
             shot_context = self._resolve_current_sequencer_shot_context()
             if shot_context is None:
                 raise ValueError("No current sequencer shot was found.")
 
-            output_name = f"{shot_context.name}_{date_suffix}"
+            output_name = self._resolve_output_name(shot_context.name)
             shot_config = MShotPlayblastConfig(
                 camera=shot_context.camera,
                 shot=dummy_shot(
@@ -586,7 +602,7 @@ class PrevisPlayblastDialog(PlayblastDialog):
             custom_in = self._custom_in.value()
             custom_out = self._custom_out.value()
             custom_code = self._scene_stem()
-            output_name = f"{custom_code}_custom_{date_suffix}"
+            output_name = self._resolve_output_name(f"{custom_code}_custom")
             shot_config = MShotPlayblastConfig(
                 camera=str(self._custom_camera.currentText()),
                 shot=dummy_shot(

--- a/pipeline/pipe/m/playblast/previs.py
+++ b/pipeline/pipe/m/playblast/previs.py
@@ -31,7 +31,12 @@ from pipe.playblast_naming import (
     playblast_date_folder,
     resolve_versioned_playblast_basename,
 )
-from pipe.playblast_shotgrid import resolve_preferred_upload_movie_path
+from pipe.playblast_shotgrid import (
+    PlayblastVersionUploadRequest,
+    default_version_name_from_movie_path,
+    resolve_preferred_upload_movie_path,
+    upload_playblast_version,
+)
 from pipe.util import Playblaster
 
 from .struct import (
@@ -41,7 +46,7 @@ from .struct import (
     SaveLocation,
     dummy_shot,
 )
-from .ui import PlayblastDialog
+from .ui import PlayblastDialog, resolve_artist_display_name
 
 if TYPE_CHECKING:
     from pipe.struct.db import Shot
@@ -676,6 +681,66 @@ class PrevisPlayblastDialog(PlayblastDialog):
             preferred_paths=preferred_paths,
         )
 
+    def _should_upload_shot_playblast_to_shotgrid(self) -> bool:
+        return (
+            self._selected_source_mode() == "shot"
+            and self._is_shotgrid_upload_requested()
+        )
+
+    def _upload_shot_playblast_to_shotgrid(
+        self,
+        config: MPlayblastConfig,
+    ) -> list[str]:
+        if not config.shots:
+            return ["ShotGrid upload skipped: no shot output was generated."]
+
+        shot_code = str(config.shots[0].shot.code or "").strip()
+        if not shot_code:
+            return ["ShotGrid upload skipped: shot code is missing."]
+
+        movie_path = self._resolve_shotgrid_upload_movie_path(config)
+        if movie_path is None:
+            return ["ShotGrid upload skipped: no valid playblast movie file was found."]
+
+        version_name = default_version_name_from_movie_path(movie_path)
+        if not version_name:
+            version_name = f"{shot_code}_playblast"
+
+        artist_name = resolve_artist_display_name().strip() or None
+        upload_request = PlayblastVersionUploadRequest(
+            shot_code=shot_code,
+            movie_path=movie_path,
+            version_name=version_name,
+            description=self._shotgrid_upload_description() or None,
+            path_to_frames=str(movie_path),
+            artist_display_name=artist_name,
+        )
+
+        try:
+            upload_result = upload_playblast_version(upload_request)
+        except Exception as exc:
+            log.exception("ShotGrid upload failed for shot '%s'", shot_code)
+            return [f"ShotGrid upload failed: {exc}"]
+
+        message_lines: list[str] = []
+        if upload_result.ok:
+            success_message = (
+                f"ShotGrid upload successful: {upload_result.version_name}"
+                f" (shot {upload_result.shot_code})."
+            )
+            if upload_result.version_id is not None:
+                success_message = (
+                    f"{success_message} Version ID: {upload_result.version_id}."
+                )
+            message_lines.append(success_message)
+        else:
+            message_lines.append(f"ShotGrid upload failed: {upload_result.message}")
+
+        for warning in upload_result.warnings:
+            message_lines.append(f"ShotGrid warning: {warning}")
+
+        return message_lines
+
     def _selected_destination_directories(self) -> list[Path]:
         directories: list[Path] = []
         for location in self._selected_destination_locations():
@@ -897,6 +962,14 @@ class PrevisPlayblastDialog(PlayblastDialog):
         if validation_error:
             return validation_error
         return super()._validate_config(config)
+
+    def _after_local_playblast(
+        self,
+        config: MPlayblastConfig,
+    ) -> list[str]:
+        if not self._should_upload_shot_playblast_to_shotgrid():
+            return []
+        return self._upload_shot_playblast_to_shotgrid(config)
 
     def _build_shot_playblast_config(self) -> MShotPlayblastConfig:
         if self._shot is None:

--- a/pipeline/pipe/m/playblast/previs.py
+++ b/pipeline/pipe/m/playblast/previs.py
@@ -27,6 +27,7 @@ from Qt.QtWidgets import (
 from shared.util import get_edit_path
 
 from pipe.db import DB
+from pipe.playblast_artist import resolve_artist_display_name
 from pipe.playblast_naming import (
     playblast_date_folder,
     resolve_versioned_playblast_basename,
@@ -46,7 +47,7 @@ from .struct import (
     SaveLocation,
     dummy_shot,
 )
-from .ui import PlayblastDialog, resolve_artist_display_name
+from .ui import PlayblastDialog
 
 if TYPE_CHECKING:
     from pipe.struct.db import Shot

--- a/pipeline/pipe/m/playblast/previs.py
+++ b/pipeline/pipe/m/playblast/previs.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import logging
 from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING, Literal
 
 import maya.cmds as mc
+from env_sg import DB_Config
 from Qt import QtCore
 from Qt.QtWidgets import (
     QCheckBox,
@@ -23,6 +26,7 @@ from Qt.QtWidgets import (
 )
 from shared.util import get_edit_path
 
+from pipe.db import DB
 from pipe.playblast_naming import (
     playblast_date_folder,
     resolve_versioned_playblast_basename,
@@ -38,6 +42,11 @@ from .struct import (
 )
 from .ui import PlayblastDialog
 
+if TYPE_CHECKING:
+    from pipe.struct.db import Shot
+
+log = logging.getLogger(__name__)
+
 
 @dataclass(frozen=True)
 class SequencerShotContext:
@@ -50,7 +59,6 @@ class SequencerShotContext:
 
 
 class PrevisPlayblastDialog(PlayblastDialog):
-    _context_banner: QLabel
     _custom_camera: QComboBox
     _custom_folder_row: QWidget
     _custom_in: QSpinBox
@@ -58,18 +66,21 @@ class PrevisPlayblastDialog(PlayblastDialog):
     _destination_checkboxes: dict[str, QCheckBox]
     _destination_path_labels: dict[str, QLabel]
     _save_locations_by_name: dict[str, SaveLocation]
-    _sequencer_shot_nodes: list[str]
-    _source_tabs: QTabWidget
-    _shot_camera_value: QLabel
-    _shot_name_value: QLabel
+    _sequencer_camera_value: QLabel
+    _sequencer_name_value: QLabel
+    _sequencer_range_value: QLabel
+    _shot: Shot | None
+    _shot_camera: QComboBox
+    _shot_code_value: QLabel
     _shot_range_value: QLabel
+    _source_tabs: QTabWidget
     _validation_label: QLabel
 
     SHOT_TAB_INDEX = 0
-    CUSTOM_TAB_INDEX = 1
-    CONTEXT_BANNER_STYLE = (
-        "padding: 8px; border: 1px solid #c3cfdb; background: #e3ebf5; color: #666;"
-    )
+    SEQUENCER_TAB_INDEX = 1
+    CUSTOM_TAB_INDEX = 2
+
+    SOURCE_MODE = Literal["shot", "sequencer", "custom"]
 
     class SAVE_LOCS(PlayblastDialog.SAVE_LOCS):
         EDIT = SaveLocation(
@@ -79,12 +90,7 @@ class PrevisPlayblastDialog(PlayblastDialog):
         )
 
     def __init__(self, parent) -> None:
-        self._sequencer_shot_nodes = [
-            str(shot_node)
-            for shot_node in (mc.sequenceManager(listShots=True) or [])
-            if mc.objExists(shot_node)
-            and not bool(mc.shot(shot_node, query=True, mute=True))
-        ]
+        self._shot = self._resolve_pipeline_shot_context()
         self._destination_checkboxes = {}
         self._destination_path_labels = {}
         self._save_locations_by_name = {
@@ -110,10 +116,10 @@ class PrevisPlayblastDialog(PlayblastDialog):
         title.setStyleSheet("font-size: 24px; font-weight: 700;")
         title.setAlignment(QtCore.Qt.AlignCenter)
 
-        subtitle = QLabel("Choose source mode, choose destinations, then export.")
+        subtitle = QLabel("Choose source mode, choose destinations, then export")
         subtitle.setAlignment(QtCore.Qt.AlignCenter)
         subtitle.setToolTip(
-            "High-level workflow: choose source, choose destinations, then export."
+            "Playblast flow: choose the source mode, choose destinations, then export."
         )
 
         self._main_layout.addWidget(title)
@@ -123,21 +129,13 @@ class PrevisPlayblastDialog(PlayblastDialog):
         setup_group = QGroupBox("1. Export Setup")
         setup_layout = QVBoxLayout(setup_group)
 
-        self._context_banner = QLabel()
-        self._context_banner.setWordWrap(True)
-        self._context_banner.setStyleSheet(self.CONTEXT_BANNER_STYLE)
-        self._context_banner.setToolTip(
-            "Live context for the selected export mode: shot, camera, and frame range."
-        )
-        setup_layout.addWidget(self._context_banner)
-
         setup_layout.addWidget(self._build_export_source_section())
         setup_layout.addWidget(self._build_destination_section())
 
         self._validation_label = QLabel()
         self._validation_label.setStyleSheet("color: #b00020;")
         self._validation_label.setToolTip(
-            "Validation feedback. Export is disabled until this message is cleared."
+            "Validation feedback. Export stays disabled until all required inputs are valid."
         )
         self._validation_label.setVisible(False)
         setup_layout.addWidget(self._validation_label)
@@ -149,8 +147,10 @@ class PrevisPlayblastDialog(PlayblastDialog):
         source_layout = QVBoxLayout(source_group)
 
         self._source_tabs = QTabWidget()
+        self._source_tabs.addTab(self._build_shot_source_tab(), "Shot Playblast")
         self._source_tabs.addTab(
-            self._build_shot_source_tab(), "Shot Playblast (Current Sequencer Shot)"
+            self._build_sequencer_source_tab(),
+            "Sequencer Playblast",
         )
         self._source_tabs.addTab(
             self._build_custom_source_tab(),
@@ -158,17 +158,23 @@ class PrevisPlayblastDialog(PlayblastDialog):
         )
         self._source_tabs.currentChanged.connect(self._on_source_mode_changed)
         self._source_tabs.setToolTip(
-            "Choose whether to export the current sequencer shot or a custom range."
+            "Select how the playblast source is resolved: pipeline shot metadata, sequencer shot, or manual custom settings."
         )
+
         source_tab_bar = self._source_tabs.tabBar()
         source_tab_bar.setTabToolTip(
             self.SHOT_TAB_INDEX,
-            "Exports the shot under the current timeline frame in the camera sequencer.",
+            "Uses shot code metadata from the current Maya file (fileInfo 'code') and ShotGrid cut range.",
+        )
+        source_tab_bar.setTabToolTip(
+            self.SEQUENCER_TAB_INDEX,
+            "Uses the camera sequencer shot under the current timeline frame.",
         )
         source_tab_bar.setTabToolTip(
             self.CUSTOM_TAB_INDEX,
-            "Exports a manually selected camera and frame range.",
+            "Uses manual camera and manual frame range, independent of shot metadata.",
         )
+
         source_layout.addWidget(self._source_tabs)
         return source_group
 
@@ -177,31 +183,69 @@ class PrevisPlayblastDialog(PlayblastDialog):
         shot_layout = QGridLayout(shot_tab)
 
         shot_layout.addWidget(QLabel("Source"), 0, 0)
-        shot_source_value = QLabel("Current Sequencer Shot")
+        shot_source_value = QLabel("Pipeline Shot File")
         shot_source_value.setToolTip(
-            "This mode uses the sequencer shot at the current timeline frame."
+            "Source is derived from this Maya scene's pipeline shot metadata."
         )
         shot_layout.addWidget(shot_source_value, 0, 1)
 
         shot_layout.addWidget(QLabel("Shot"), 1, 0)
-        self._shot_name_value = QLabel("-")
-        self._shot_name_value.setToolTip("Resolved shot name for the current frame.")
-        shot_layout.addWidget(self._shot_name_value, 1, 1)
+        self._shot_code_value = QLabel("-")
+        self._shot_code_value.setToolTip("Resolved pipeline shot code.")
+        shot_layout.addWidget(self._shot_code_value, 1, 1)
 
         shot_layout.addWidget(QLabel("Camera"), 2, 0)
-        self._shot_camera_value = QLabel("-")
-        self._shot_camera_value.setToolTip(
-            "Resolved camera from the active sequencer shot."
+        self._shot_camera = QComboBox(self)
+        self._shot_camera.addItems(self._available_custom_cameras())
+        self._shot_camera.setToolTip(
+            "Camera used for shot playblast output in Shot mode."
         )
-        shot_layout.addWidget(self._shot_camera_value, 2, 1)
+        self._shot_camera.currentTextChanged.connect(self._on_source_settings_changed)
+        shot_layout.addWidget(self._shot_camera, 2, 1)
 
         shot_layout.addWidget(QLabel("Frame Range"), 3, 0)
         self._shot_range_value = QLabel("-")
         self._shot_range_value.setToolTip(
-            "Resolved frame range from the active sequencer shot."
+            "Resolved cut range from ShotGrid for the detected pipeline shot."
         )
         shot_layout.addWidget(self._shot_range_value, 3, 1)
+
+        self._set_default_shot_camera()
         return shot_tab
+
+    def _build_sequencer_source_tab(self) -> QWidget:
+        sequencer_tab = QWidget()
+        sequencer_layout = QGridLayout(sequencer_tab)
+
+        sequencer_layout.addWidget(QLabel("Source"), 0, 0)
+        sequencer_source_value = QLabel("Current Sequencer Shot")
+        sequencer_source_value.setToolTip(
+            "Uses the sequencer shot at the current timeline frame."
+        )
+        sequencer_layout.addWidget(sequencer_source_value, 0, 1)
+
+        sequencer_layout.addWidget(QLabel("Shot"), 1, 0)
+        self._sequencer_name_value = QLabel("-")
+        self._sequencer_name_value.setToolTip(
+            "Resolved sequencer shot name for the current frame."
+        )
+        sequencer_layout.addWidget(self._sequencer_name_value, 1, 1)
+
+        sequencer_layout.addWidget(QLabel("Camera"), 2, 0)
+        self._sequencer_camera_value = QLabel("-")
+        self._sequencer_camera_value.setToolTip(
+            "Resolved camera from the active sequencer shot."
+        )
+        sequencer_layout.addWidget(self._sequencer_camera_value, 2, 1)
+
+        sequencer_layout.addWidget(QLabel("Frame Range"), 3, 0)
+        self._sequencer_range_value = QLabel("-")
+        self._sequencer_range_value.setToolTip(
+            "Resolved frame range from the active sequencer shot."
+        )
+        sequencer_layout.addWidget(self._sequencer_range_value, 3, 1)
+
+        return sequencer_tab
 
     def _build_custom_source_tab(self) -> QWidget:
         custom_tab = QWidget()
@@ -221,9 +265,8 @@ class PrevisPlayblastDialog(PlayblastDialog):
         custom_layout.addWidget(QLabel("Custom Out"), 0, 2)
         custom_layout.addWidget(self._custom_out, 0, 3)
 
-        camera_list = self._available_custom_cameras()
         self._custom_camera = QComboBox(self)
-        self._custom_camera.addItems(camera_list)
+        self._custom_camera.addItems(self._available_custom_cameras())
         self._custom_camera.setToolTip("Camera used for custom playblast output.")
         self._custom_camera.currentTextChanged.connect(self._on_source_settings_changed)
         custom_layout.addWidget(QLabel("Custom Camera"), 1, 0)
@@ -307,14 +350,17 @@ class PrevisPlayblastDialog(PlayblastDialog):
         self._init_buttons(has_cancel_button=True, ok_name="Playblast Shot")
         self.buttons.rejected.connect(self.close)
         self.buttons.accepted.connect(self.do_export)
+
         ok_button = self.buttons.button(QDialogButtonBox.Ok)
         if ok_button is not None:
             ok_button.setToolTip(
-                "Start playblast with current source and destination selections."
+                "Start playblast with the current source and destination selections."
             )
+
         cancel_button = self.buttons.button(QDialogButtonBox.Cancel)
         if cancel_button is not None:
             cancel_button.setToolTip("Close without exporting.")
+
         self._main_layout.addWidget(self.buttons)
 
     def _apply_viewport_option_tooltips(self) -> None:
@@ -329,23 +375,55 @@ class PrevisPlayblastDialog(PlayblastDialog):
         self._use_dof.setToolTip("Include camera depth of field in playblast.")
 
     def _set_default_source_tab(self) -> None:
-        has_shot_context = bool(self._sequencer_shot_nodes)
+        self._refresh_source_tab_availability()
+
+        self._source_tabs.setCurrentIndex(self._default_source_tab_index())
+
+    def _refresh_source_tab_availability(self) -> None:
+        has_shot_context = self._shot is not None
+        has_sequencer_context = self._has_sequencer_shot_context()
+
         self._source_tabs.setTabEnabled(self.SHOT_TAB_INDEX, has_shot_context)
-        default_index = (
-            self.SHOT_TAB_INDEX if has_shot_context else self.CUSTOM_TAB_INDEX
+        self._source_tabs.setTabEnabled(
+            self.SEQUENCER_TAB_INDEX,
+            has_sequencer_context,
         )
-        self._source_tabs.setCurrentIndex(default_index)
+
+        selected_mode = self._selected_source_mode()
+        if selected_mode == "shot" and not has_shot_context:
+            self._source_tabs.setCurrentIndex(self._default_source_tab_index())
+        if selected_mode == "sequencer" and not has_sequencer_context:
+            self._source_tabs.setCurrentIndex(self._default_source_tab_index())
+
+    def _default_source_tab_index(self) -> int:
+        has_shot_context = self._shot is not None
+        has_sequencer_context = self._has_sequencer_shot_context()
+
+        if has_shot_context:
+            return self.SHOT_TAB_INDEX
+        if has_sequencer_context:
+            return self.SEQUENCER_TAB_INDEX
+        return self.CUSTOM_TAB_INDEX
 
     @staticmethod
-    def _destination_locations() -> list[SaveLocation]:
-        return [
-            PrevisPlayblastDialog.SAVE_LOCS.EDIT,
-            PrevisPlayblastDialog.SAVE_LOCS.CURRENT,
-            PrevisPlayblastDialog.SAVE_LOCS.CUSTOM,
-        ]
+    def _resolve_pipeline_shot_context() -> Shot | None:
+        try:
+            conn = DB.Get(DB_Config)
+        except Exception:
+            return None
 
-    def _default_destination_enabled(self, location: SaveLocation) -> bool:
-        return location.name == self.SAVE_LOCS.EDIT.name
+        try:
+            code = str(mc.fileInfo("code", query=True)[0]).strip()
+        except Exception:
+            return None
+
+        if not code:
+            return None
+
+        try:
+            return conn.get_shot_by_code(code)
+        except Exception:
+            return None
 
     @staticmethod
     def _timeline_range() -> tuple[int, int]:
@@ -364,8 +442,104 @@ class PrevisPlayblastDialog(PlayblastDialog):
             )
         ]
 
-    def _is_shot_mode_selected(self) -> bool:
-        return self._source_tabs.currentIndex() == self.SHOT_TAB_INDEX
+    @staticmethod
+    def _active_camera_name() -> str:
+        panel = PlayblastDialog._resolve_active_model_panel()
+        if not panel:
+            return ""
+
+        try:
+            camera = str(mc.modelEditor(panel, query=True, camera=True) or "")
+        except Exception:
+            return ""
+
+        return camera.strip()
+
+    @staticmethod
+    def _camera_name_variants(camera_name: str) -> set[str]:
+        if not camera_name:
+            return set()
+
+        variants = {camera_name, camera_name.split("|")[-1], camera_name.split(":")[-1]}
+
+        if not mc.objExists(camera_name):
+            return variants
+
+        node_type = str(mc.nodeType(camera_name) or "")
+        if node_type == "transform":
+            shapes = (
+                mc.listRelatives(
+                    camera_name,
+                    shapes=True,
+                    type="camera",
+                    fullPath=True,
+                )
+                or []
+            )
+            for shape in shapes:
+                shape_name = str(shape)
+                variants.add(shape_name)
+                variants.add(shape_name.split("|")[-1])
+                variants.add(shape_name.split(":")[-1])
+
+        if node_type == "camera":
+            parents = mc.listRelatives(camera_name, parent=True, fullPath=True) or []
+            for parent in parents:
+                parent_name = str(parent)
+                variants.add(parent_name)
+                variants.add(parent_name.split("|")[-1])
+                variants.add(parent_name.split(":")[-1])
+
+        return variants
+
+    @staticmethod
+    def _set_combo_to_camera(combo: QComboBox, camera_name: str) -> None:
+        variants = PrevisPlayblastDialog._camera_name_variants(camera_name)
+        if not variants:
+            return
+
+        for index in range(combo.count()):
+            item_text = combo.itemText(index)
+            if item_text in variants:
+                combo.setCurrentIndex(index)
+                return
+
+    def _set_default_shot_camera(self) -> None:
+        self._set_combo_to_camera(self._shot_camera, self._active_camera_name())
+
+    @staticmethod
+    def _list_sequencer_shot_nodes() -> list[str]:
+        return [
+            str(shot_node)
+            for shot_node in (mc.sequenceManager(listShots=True) or [])
+            if mc.objExists(shot_node)
+            and not bool(mc.shot(shot_node, query=True, mute=True))
+        ]
+
+    def _has_sequencer_shot_context(self) -> bool:
+        return bool(self._list_sequencer_shot_nodes())
+
+    @staticmethod
+    def _destination_locations() -> list[SaveLocation]:
+        return [
+            PrevisPlayblastDialog.SAVE_LOCS.EDIT,
+            PrevisPlayblastDialog.SAVE_LOCS.CURRENT,
+            PrevisPlayblastDialog.SAVE_LOCS.CUSTOM,
+        ]
+
+    def _default_destination_enabled(self, location: SaveLocation) -> bool:
+        return location.name == self.SAVE_LOCS.EDIT.name
+
+    def _selected_source_mode(self) -> SOURCE_MODE:
+        current_index = self._source_tabs.currentIndex()
+        if current_index == self.SHOT_TAB_INDEX:
+            return "shot"
+        if current_index == self.SEQUENCER_TAB_INDEX:
+            return "sequencer"
+        return "custom"
+
+    def _selected_shot_camera(self) -> str:
+        return str(self._shot_camera.currentText()).strip()
 
     def _selected_destination_locations(self) -> list[SaveLocation]:
         selected: list[SaveLocation] = []
@@ -414,38 +588,29 @@ class PrevisPlayblastDialog(PlayblastDialog):
             location = self._save_locations_by_name[location_name]
             path_label.setText(f"-> {self._resolved_destination_path(location)}")
 
-    def _refresh_context_banner(self) -> None:
+    def _refresh_shot_context_fields(self) -> None:
+        if self._shot is None:
+            self._shot_code_value.setText("-")
+            self._shot_range_value.setText("-")
+            return
+
+        self._shot_code_value.setText(self._shot.code)
+        self._shot_range_value.setText(f"{self._shot.cut_in} - {self._shot.cut_out}")
+
+    def _refresh_sequencer_context_fields(self) -> SequencerShotContext | None:
         shot_context = self._resolve_current_sequencer_shot_context()
-        if self._is_shot_mode_selected():
-            if shot_context is None:
-                current_frame = int(mc.currentTime(query=True))
-                banner_text = (
-                    "No current sequencer shot found at frame "
-                    f"{current_frame}. Move the timeline into a shot or switch to Custom Playblast."
-                )
-                self._shot_name_value.setText("-")
-                self._shot_camera_value.setText("-")
-                self._shot_range_value.setText("-")
-            else:
-                banner_text = (
-                    f"Detected shot: {shot_context.name} | "
-                    f"Camera: {shot_context.camera} | "
-                    f"Range: {shot_context.cut_in}-{shot_context.cut_out}"
-                )
-                self._shot_name_value.setText(shot_context.name)
-                self._shot_camera_value.setText(shot_context.camera)
-                self._shot_range_value.setText(
-                    f"{shot_context.cut_in} - {shot_context.cut_out}"
-                )
-        else:
-            if shot_context is None:
-                banner_text = "No shot context detected. Custom Playblast is active."
-            else:
-                banner_text = (
-                    f"Detected shot: {shot_context.name}. "
-                    "Custom Playblast is active and will use manual camera/range settings."
-                )
-        self._context_banner.setText(banner_text)
+        if shot_context is None:
+            self._sequencer_name_value.setText("-")
+            self._sequencer_camera_value.setText("-")
+            self._sequencer_range_value.setText("-")
+            return None
+
+        self._sequencer_name_value.setText(shot_context.name)
+        self._sequencer_camera_value.setText(shot_context.camera)
+        self._sequencer_range_value.setText(
+            f"{shot_context.cut_in} - {shot_context.cut_out}"
+        )
+        return shot_context
 
     def _sync_custom_path_row_visibility(self) -> None:
         is_visible = self._is_custom_destination_selected()
@@ -453,13 +618,27 @@ class PrevisPlayblastDialog(PlayblastDialog):
         self._custom_folder_field.setEnabled(is_visible)
 
     def _validate_target_destination_state(self) -> str | None:
-        if self._is_shot_mode_selected():
+        mode = self._selected_source_mode()
+
+        if mode == "shot":
+            if self._shot is None:
+                return (
+                    "No pipeline shot context was found. Open a pipeline shot file "
+                    "or switch to Sequencer or Custom Playblast."
+                )
+            if self._shot.cut_out < self._shot.cut_in:
+                return "Shot cut range is invalid (Cut Out must be >= Cut In)."
+            if not self._selected_shot_camera():
+                return "Choose a camera for Shot Playblast."
+
+        if mode == "sequencer":
             shot_context = self._resolve_current_sequencer_shot_context()
             if shot_context is None:
-                return "No current sequencer shot was found. Move timeline to a shot or use Custom Playblast."
+                return "No current sequencer shot was found. Move timeline to a shot or use another source mode."
             if not shot_context.camera:
                 return "Current sequencer shot has no camera assigned."
-        else:
+
+        if mode == "custom":
             if self._custom_out.value() < self._custom_in.value():
                 return "Custom Out must be greater than or equal to Custom In."
             if not str(self._custom_camera.currentText()).strip():
@@ -476,23 +655,31 @@ class PrevisPlayblastDialog(PlayblastDialog):
 
         return None
 
+    def _action_button_text(self) -> str:
+        mode = self._selected_source_mode()
+        if mode == "shot":
+            return "Playblast Shot"
+        if mode == "sequencer":
+            return "Playblast Sequencer"
+        return "Playblast Custom"
+
     def _update_action_state(self) -> None:
         ok_button = self.buttons.button(QDialogButtonBox.Ok)
         if ok_button is None:
             return
 
-        ok_button.setText(
-            "Playblast Shot" if self._is_shot_mode_selected() else "Playblast Custom"
-        )
+        ok_button.setText(self._action_button_text())
         validation_error = self._validate_target_destination_state()
         ok_button.setEnabled(validation_error is None)
         self._validation_label.setText(validation_error or "")
         self._validation_label.setVisible(validation_error is not None)
 
     def _update_ui_state(self) -> None:
+        self._refresh_source_tab_availability()
+        self._refresh_shot_context_fields()
+        self._refresh_sequencer_context_fields()
         self._sync_custom_path_row_visibility()
         self._refresh_destination_path_labels()
-        self._refresh_context_banner()
         self._update_action_state()
 
     def _on_source_mode_changed(self, _index: int) -> None:
@@ -543,11 +730,9 @@ class PrevisPlayblastDialog(PlayblastDialog):
         )
 
     def _resolve_current_shot_node(self) -> str | None:
-        if not self._sequencer_shot_nodes:
-            return None
-
         current_frame = int(mc.currentTime(query=True))
-        for shot_node in self._sequencer_shot_nodes:
+
+        for shot_node in self._list_sequencer_shot_nodes():
             if not mc.objExists(shot_node):
                 continue
             try:
@@ -565,9 +750,19 @@ class PrevisPlayblastDialog(PlayblastDialog):
         return scene_name or "previs_playblast"
 
     def _hud_shot_label(self) -> str:
-        shot_context = self._resolve_current_sequencer_shot_context()
-        if shot_context:
-            return shot_context.name
+        mode = self._selected_source_mode()
+
+        if mode == "shot" and self._shot is not None:
+            return self._shot.code
+
+        if mode == "sequencer":
+            shot_context = self._resolve_current_sequencer_shot_context()
+            if shot_context is not None:
+                return shot_context.name
+
+        if self._shot is not None:
+            return self._shot.code
+
         return "Custom"
 
     def _validate_config(self, config: MPlayblastConfig) -> str | None:
@@ -576,44 +771,70 @@ class PrevisPlayblastDialog(PlayblastDialog):
             return validation_error
         return super()._validate_config(config)
 
+    def _build_shot_playblast_config(self) -> MShotPlayblastConfig:
+        if self._shot is None:
+            raise ValueError("No pipeline shot context was found.")
+
+        shot_camera = self._selected_shot_camera()
+        if not shot_camera:
+            raise ValueError("Choose a camera for Shot Playblast.")
+
+        output_name = self._resolve_output_name(self._shot.code)
+        return MShotPlayblastConfig(
+            camera=shot_camera,
+            shot=self._shot,
+            paths=self._paths_for_filename(output_name),
+            use_sequencer=False,
+        )
+
+    def _build_sequencer_playblast_config(self) -> MShotPlayblastConfig:
+        shot_context = self._resolve_current_sequencer_shot_context()
+        if shot_context is None:
+            raise ValueError("No current sequencer shot was found.")
+
+        output_name = self._resolve_output_name(shot_context.name)
+        return MShotPlayblastConfig(
+            camera=shot_context.camera,
+            shot=dummy_shot(
+                code=shot_context.name,
+                cut_in=shot_context.cut_in,
+                cut_out=shot_context.cut_out,
+                cut_duration=shot_context.cut_duration,
+            ),
+            paths=self._paths_for_filename(output_name),
+            use_sequencer=False,
+        )
+
+    def _build_custom_playblast_config(self) -> MShotPlayblastConfig:
+        custom_in = self._custom_in.value()
+        custom_out = self._custom_out.value()
+        custom_code = self._scene_stem()
+        output_name = self._resolve_output_name(f"{custom_code}_custom")
+
+        return MShotPlayblastConfig(
+            camera=str(self._custom_camera.currentText()),
+            shot=dummy_shot(
+                code=custom_code,
+                cut_in=custom_in,
+                cut_out=custom_out,
+                cut_duration=max(0, custom_out - custom_in),
+            ),
+            paths=self._paths_for_filename(output_name),
+            use_sequencer=False,
+        )
+
     def _generate_config(self) -> MPlayblastConfig:
         validation_error = self._validate_target_destination_state()
         if validation_error:
             raise ValueError(validation_error)
 
-        if self._is_shot_mode_selected():
-            shot_context = self._resolve_current_sequencer_shot_context()
-            if shot_context is None:
-                raise ValueError("No current sequencer shot was found.")
-
-            output_name = self._resolve_output_name(shot_context.name)
-            shot_config = MShotPlayblastConfig(
-                camera=shot_context.camera,
-                shot=dummy_shot(
-                    code=shot_context.name,
-                    cut_in=shot_context.cut_in,
-                    cut_out=shot_context.cut_out,
-                    cut_duration=shot_context.cut_duration,
-                ),
-                paths=self._paths_for_filename(output_name),
-                use_sequencer=False,
-            )
+        mode = self._selected_source_mode()
+        if mode == "shot":
+            shot_config = self._build_shot_playblast_config()
+        elif mode == "sequencer":
+            shot_config = self._build_sequencer_playblast_config()
         else:
-            custom_in = self._custom_in.value()
-            custom_out = self._custom_out.value()
-            custom_code = self._scene_stem()
-            output_name = self._resolve_output_name(f"{custom_code}_custom")
-            shot_config = MShotPlayblastConfig(
-                camera=str(self._custom_camera.currentText()),
-                shot=dummy_shot(
-                    code=custom_code,
-                    cut_in=custom_in,
-                    cut_out=custom_out,
-                    cut_duration=max(0, custom_out - custom_in),
-                ),
-                paths=self._paths_for_filename(output_name),
-                use_sequencer=False,
-            )
+            shot_config = self._build_custom_playblast_config()
 
         return MPlayblastConfig(
             builtin_huds=[

--- a/pipeline/pipe/m/playblast/previs.py
+++ b/pipeline/pipe/m/playblast/previs.py
@@ -72,6 +72,9 @@ class PrevisPlayblastDialog(PlayblastDialog):
     _shot: Shot | None
     _shot_camera: QComboBox
     _shot_code_value: QLabel
+    _shotgrid_description_field: QLineEdit
+    _shotgrid_description_row: QWidget
+    _shotgrid_upload_checkbox: QCheckBox
     _shot_range_value: QLabel
     _source_tabs: QTabWidget
     _validation_label: QLabel
@@ -210,7 +213,31 @@ class PrevisPlayblastDialog(PlayblastDialog):
         )
         shot_layout.addWidget(self._shot_range_value, 3, 1)
 
+        shot_layout.addWidget(QLabel("ShotGrid"), 4, 0)
+        self._shotgrid_upload_checkbox = QCheckBox("Upload to ShotGrid")
+        self._shotgrid_upload_checkbox.setChecked(False)
+        self._shotgrid_upload_checkbox.setToolTip(
+            "When enabled, this Shot playblast will also create a ShotGrid Version and upload the movie."
+        )
+        self._shotgrid_upload_checkbox.toggled.connect(self._on_shotgrid_upload_toggled)
+        shot_layout.addWidget(self._shotgrid_upload_checkbox, 4, 1)
+
+        self._shotgrid_description_row = QWidget()
+        shotgrid_description_layout = QHBoxLayout(self._shotgrid_description_row)
+        shotgrid_description_layout.setContentsMargins(0, 0, 0, 0)
+        shotgrid_description_layout.addWidget(QLabel("Description"))
+        self._shotgrid_description_field = QLineEdit()
+        self._shotgrid_description_field.setPlaceholderText(
+            "Optional ShotGrid version description"
+        )
+        self._shotgrid_description_field.setToolTip(
+            "Optional notes saved to the ShotGrid Version description when upload is enabled."
+        )
+        shotgrid_description_layout.addWidget(self._shotgrid_description_field)
+        shot_layout.addWidget(self._shotgrid_description_row, 5, 0, 1, 2)
+
         self._set_default_shot_camera()
+        self._sync_shotgrid_description_visibility()
         return shot_tab
 
     def _build_sequencer_source_tab(self) -> QWidget:
@@ -617,6 +644,17 @@ class PrevisPlayblastDialog(PlayblastDialog):
         self._custom_folder_row.setVisible(is_visible)
         self._custom_folder_field.setEnabled(is_visible)
 
+    def _sync_shotgrid_description_visibility(self) -> None:
+        show_description = self._is_shotgrid_upload_requested()
+        self._shotgrid_description_row.setVisible(show_description)
+        self._shotgrid_description_field.setEnabled(show_description)
+
+    def _is_shotgrid_upload_requested(self) -> bool:
+        return self._shotgrid_upload_checkbox.isChecked()
+
+    def _shotgrid_upload_description(self) -> str:
+        return self._shotgrid_description_field.text().strip()
+
     def _validate_target_destination_state(self) -> str | None:
         mode = self._selected_source_mode()
 
@@ -679,6 +717,7 @@ class PrevisPlayblastDialog(PlayblastDialog):
         self._refresh_shot_context_fields()
         self._refresh_sequencer_context_fields()
         self._sync_custom_path_row_visibility()
+        self._sync_shotgrid_description_visibility()
         self._refresh_destination_path_labels()
         self._update_action_state()
 
@@ -696,6 +735,9 @@ class PrevisPlayblastDialog(PlayblastDialog):
         self._update_ui_state()
 
     def _on_source_settings_changed(self, *_args) -> None:
+        self._update_ui_state()
+
+    def _on_shotgrid_upload_toggled(self, _enabled: bool) -> None:
         self._update_ui_state()
 
     def _refresh_summary(self, *_args) -> None:

--- a/pipeline/pipe/m/playblast/previs.py
+++ b/pipeline/pipe/m/playblast/previs.py
@@ -64,6 +64,9 @@ class PrevisPlayblastDialog(PlayblastDialog):
 
     SHOT_TAB_INDEX = 0
     CUSTOM_TAB_INDEX = 1
+    CONTEXT_BANNER_STYLE = (
+        "padding: 8px; border: 1px solid #c3cfdb; background: #e3ebf5; color: #666;"
+    )
 
     class SAVE_LOCS(PlayblastDialog.SAVE_LOCS):
         EDIT = SaveLocation(
@@ -84,7 +87,7 @@ class PrevisPlayblastDialog(PlayblastDialog):
         self._save_locations_by_name = {
             location.name: location for location in self._destination_locations()
         }
-        super().__init__(parent, [], "Bobo Previs Playblast")
+        super().__init__(parent, [], "SKD Previs Playblast")
 
     def _setup_ui(self) -> None:
         self._central_widget = QWidget()
@@ -100,13 +103,15 @@ class PrevisPlayblastDialog(PlayblastDialog):
         self._update_ui_state()
 
     def _build_header_section(self) -> None:
-        title = QLabel("Bobo Previs Playblast")
+        title = QLabel("SKD Previs Playblast")
         title.setStyleSheet("font-size: 24px; font-weight: 700;")
         title.setAlignment(QtCore.Qt.AlignCenter)
 
         subtitle = QLabel("Choose source mode, choose destinations, then export.")
-        subtitle.setStyleSheet("color: #666;")
         subtitle.setAlignment(QtCore.Qt.AlignCenter)
+        subtitle.setToolTip(
+            "High-level workflow: choose source, choose destinations, then export."
+        )
 
         self._main_layout.addWidget(title)
         self._main_layout.addWidget(subtitle)
@@ -117,8 +122,9 @@ class PrevisPlayblastDialog(PlayblastDialog):
 
         self._context_banner = QLabel()
         self._context_banner.setWordWrap(True)
-        self._context_banner.setStyleSheet(
-            "padding: 6px; border: 1px solid #dcdcdc; background: #f7f7f7;"
+        self._context_banner.setStyleSheet(self.CONTEXT_BANNER_STYLE)
+        self._context_banner.setToolTip(
+            "Live context for the selected export mode: shot, camera, and frame range."
         )
         setup_layout.addWidget(self._context_banner)
 
@@ -127,13 +133,16 @@ class PrevisPlayblastDialog(PlayblastDialog):
 
         self._validation_label = QLabel()
         self._validation_label.setStyleSheet("color: #b00020;")
+        self._validation_label.setToolTip(
+            "Validation feedback. Export is disabled until this message is cleared."
+        )
         self._validation_label.setVisible(False)
         setup_layout.addWidget(self._validation_label)
 
         self._main_layout.addWidget(setup_group)
 
     def _build_export_source_section(self) -> QGroupBox:
-        source_group = QGroupBox("Export Source")
+        source_group = QGroupBox("")
         source_layout = QVBoxLayout(source_group)
 
         self._source_tabs = QTabWidget()
@@ -142,9 +151,21 @@ class PrevisPlayblastDialog(PlayblastDialog):
         )
         self._source_tabs.addTab(
             self._build_custom_source_tab(),
-            "Custom Playblast (Testing / Non-shot File)",
+            "Custom Playblast",
         )
         self._source_tabs.currentChanged.connect(self._on_source_mode_changed)
+        self._source_tabs.setToolTip(
+            "Choose whether to export the current sequencer shot or a custom range."
+        )
+        source_tab_bar = self._source_tabs.tabBar()
+        source_tab_bar.setTabToolTip(
+            self.SHOT_TAB_INDEX,
+            "Exports the shot under the current timeline frame in the camera sequencer.",
+        )
+        source_tab_bar.setTabToolTip(
+            self.CUSTOM_TAB_INDEX,
+            "Exports a manually selected camera and frame range.",
+        )
         source_layout.addWidget(self._source_tabs)
         return source_group
 
@@ -153,18 +174,29 @@ class PrevisPlayblastDialog(PlayblastDialog):
         shot_layout = QGridLayout(shot_tab)
 
         shot_layout.addWidget(QLabel("Source"), 0, 0)
-        shot_layout.addWidget(QLabel("Current Sequencer Shot"), 0, 1)
+        shot_source_value = QLabel("Current Sequencer Shot")
+        shot_source_value.setToolTip(
+            "This mode uses the sequencer shot at the current timeline frame."
+        )
+        shot_layout.addWidget(shot_source_value, 0, 1)
 
         shot_layout.addWidget(QLabel("Shot"), 1, 0)
         self._shot_name_value = QLabel("-")
+        self._shot_name_value.setToolTip("Resolved shot name for the current frame.")
         shot_layout.addWidget(self._shot_name_value, 1, 1)
 
         shot_layout.addWidget(QLabel("Camera"), 2, 0)
         self._shot_camera_value = QLabel("-")
+        self._shot_camera_value.setToolTip(
+            "Resolved camera from the active sequencer shot."
+        )
         shot_layout.addWidget(self._shot_camera_value, 2, 1)
 
         shot_layout.addWidget(QLabel("Frame Range"), 3, 0)
         self._shot_range_value = QLabel("-")
+        self._shot_range_value.setToolTip(
+            "Resolved frame range from the active sequencer shot."
+        )
         shot_layout.addWidget(self._shot_range_value, 3, 1)
         return shot_tab
 
@@ -176,6 +208,8 @@ class PrevisPlayblastDialog(PlayblastDialog):
         self._custom_in = QSpinBox(self, minimum=0, maximum=10000, value=timeline_in)
         self._custom_out = QSpinBox(self, minimum=0, maximum=10000, value=timeline_out)
         self._custom_out.setMinimum(self._custom_in.value())
+        self._custom_in.setToolTip("Start frame for custom playblast.")
+        self._custom_out.setToolTip("End frame for custom playblast.")
         self._custom_in.valueChanged.connect(self._on_custom_in_changed)
         self._custom_out.valueChanged.connect(self._on_source_settings_changed)
 
@@ -187,6 +221,7 @@ class PrevisPlayblastDialog(PlayblastDialog):
         camera_list = self._available_custom_cameras()
         self._custom_camera = QComboBox(self)
         self._custom_camera.addItems(camera_list)
+        self._custom_camera.setToolTip("Camera used for custom playblast output.")
         self._custom_camera.currentTextChanged.connect(self._on_source_settings_changed)
         custom_layout.addWidget(QLabel("Custom Camera"), 1, 0)
         custom_layout.addWidget(self._custom_camera, 1, 1, 1, 3)
@@ -195,10 +230,6 @@ class PrevisPlayblastDialog(PlayblastDialog):
     def _build_destination_section(self) -> QGroupBox:
         destination_group = QGroupBox("Save Destinations")
         destination_layout = QVBoxLayout(destination_group)
-
-        help_label = QLabel("Select one or more destinations.")
-        help_label.setStyleSheet("color: #666;")
-        destination_layout.addWidget(help_label)
 
         for save_location in self._destination_locations():
             row_widget = QWidget()
@@ -209,20 +240,35 @@ class PrevisPlayblastDialog(PlayblastDialog):
             destination_toggle.setChecked(
                 self._default_destination_enabled(save_location)
             )
+            destination_toggle.setToolTip(f"Enable export to {save_location.name}.")
             destination_toggle.toggled.connect(self._on_destination_changed)
             self._destination_checkboxes[save_location.name] = destination_toggle
             row_layout.addWidget(destination_toggle)
 
             path_label = QLabel("")
-            path_label.setStyleSheet("color: #666;")
+            path_label.setToolTip(
+                f"Resolved output directory for {save_location.name}."
+            )
             self._destination_path_labels[save_location.name] = path_label
             row_layout.addWidget(path_label)
             row_layout.addStretch()
             destination_layout.addWidget(row_widget)
 
+        self._align_destination_path_columns()
         self._custom_folder_row = self._build_destination_path_row()
         destination_layout.addWidget(self._custom_folder_row)
         return destination_group
+
+    def _align_destination_path_columns(self) -> None:
+        destination_column_width = max(
+            (
+                checkbox.sizeHint().width()
+                for checkbox in self._destination_checkboxes.values()
+            ),
+            default=0,
+        )
+        for checkbox in self._destination_checkboxes.values():
+            checkbox.setFixedWidth(destination_column_width)
 
     def _build_destination_path_row(self) -> QWidget:
         custom_path_row = QWidget()
@@ -233,10 +279,14 @@ class PrevisPlayblastDialog(PlayblastDialog):
 
         self._custom_folder_field = QLineEdit()
         self._custom_folder_field.setText(self._default_custom_folder_path())
+        self._custom_folder_field.setToolTip(
+            "Directory used when Custom Folder destination is enabled."
+        )
         self._custom_folder_field.textChanged.connect(self._on_custom_path_changed)
         custom_path_layout.addWidget(self._custom_folder_field)
 
         browse_button = QPushButton("Browse")
+        browse_button.setToolTip("Choose a custom output directory.")
         browse_button.clicked.connect(self._set_custom_folder)
         custom_path_layout.addWidget(browse_button)
         return custom_path_row
@@ -247,13 +297,33 @@ class PrevisPlayblastDialog(PlayblastDialog):
         options_layout.addWidget(
             self._build_viewport_options_widget(self._resolve_active_model_panel())
         )
+        self._apply_viewport_option_tooltips()
         self._main_layout.addWidget(options_group)
 
     def _build_buttons(self) -> None:
         self._init_buttons(has_cancel_button=True, ok_name="Playblast Shot")
         self.buttons.rejected.connect(self.close)
         self.buttons.accepted.connect(self.do_export)
+        ok_button = self.buttons.button(QDialogButtonBox.Ok)
+        if ok_button is not None:
+            ok_button.setToolTip(
+                "Start playblast with current source and destination selections."
+            )
+        cancel_button = self.buttons.button(QDialogButtonBox.Cancel)
+        if cancel_button is not None:
+            cancel_button.setToolTip("Close without exporting.")
         self._main_layout.addWidget(self.buttons)
+
+    def _apply_viewport_option_tooltips(self) -> None:
+        self._use_lighting.setToolTip("Use viewport lighting for playblast capture.")
+        self._use_shadows.setToolTip("Render viewport shadows in playblast.")
+        self._use_ssao.setToolTip(
+            "Enable viewport anti-aliasing (SSAO/multi-sample setting)."
+        )
+        self._use_hardware_fog.setToolTip(
+            "Include hardware fog from viewport settings."
+        )
+        self._use_dof.setToolTip("Include camera depth of field in playblast.")
 
     def _set_default_source_tab(self) -> None:
         has_shot_context = bool(self._sequencer_shot_nodes)
@@ -539,7 +609,7 @@ class PrevisPlayblastDialog(PlayblastDialog):
                 PlayblastDialog.CUSTOM_HUDS.FILENAME,
                 PlayblastDialog.CUSTOM_HUDS.ARTIST,
                 HudDefinition(
-                    "Boboshot",
+                    "SKD_shot",
                     command=self._hud_shot_label,
                     section=7,
                     idle_refresh=True,

--- a/pipeline/pipe/m/playblast/previs.py
+++ b/pipeline/pipe/m/playblast/previs.py
@@ -1,43 +1,20 @@
 from __future__ import annotations
 
 import logging
-from collections import defaultdict
 from dataclasses import dataclass
-from pathlib import Path
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 import maya.cmds as mc
-from env_sg import DB_Config
-from Qt import QtCore
 from Qt.QtWidgets import (
-    QCheckBox,
     QComboBox,
-    QDialogButtonBox,
     QGridLayout,
-    QGroupBox,
-    QHBoxLayout,
     QLabel,
-    QLineEdit,
-    QPushButton,
-    QSpinBox,
     QTabWidget,
-    QVBoxLayout,
     QWidget,
 )
 from shared.util import get_edit_path
 
-from pipe.db import DB
-from pipe.playblast_artist import resolve_artist_display_name
-from pipe.playblast_naming import (
-    playblast_date_folder,
-    resolve_versioned_playblast_basename,
-)
-from pipe.playblast_shotgrid import (
-    PlayblastVersionUploadRequest,
-    default_version_name_from_movie_path,
-    resolve_preferred_upload_movie_path,
-    upload_playblast_version,
-)
+from pipe.playblast_naming import playblast_date_folder
 from pipe.util import Playblaster
 
 from .struct import (
@@ -48,9 +25,6 @@ from .struct import (
     dummy_shot,
 )
 from .ui import PlayblastDialog
-
-if TYPE_CHECKING:
-    from pipe.struct.db import Shot
 
 log = logging.getLogger(__name__)
 
@@ -66,31 +40,12 @@ class SequencerShotContext:
 
 
 class PrevisPlayblastDialog(PlayblastDialog):
-    _custom_camera: QComboBox
-    _custom_folder_row: QWidget
-    _custom_in: QSpinBox
-    _custom_out: QSpinBox
-    _destination_checkboxes: dict[str, QCheckBox]
-    _destination_path_labels: dict[str, QLabel]
-    _save_locations_by_name: dict[str, SaveLocation]
     _sequencer_camera_value: QLabel
     _sequencer_name_value: QLabel
     _sequencer_range_value: QLabel
-    _shot: Shot | None
     _shot_camera: QComboBox
-    _shot_code_value: QLabel
-    _shotgrid_description_field: QLineEdit
-    _shotgrid_description_row: QWidget
-    _shotgrid_upload_checkbox: QCheckBox
-    _shot_range_value: QLabel
-    _source_tabs: QTabWidget
-    _validation_label: QLabel
 
-    SHOT_TAB_INDEX = 0
-    SEQUENCER_TAB_INDEX = 1
-    CUSTOM_TAB_INDEX = 2
-
-    SOURCE_MODE = Literal["shot", "sequencer", "custom"]
+    SEQUENCER_TAB_INDEX: int
 
     class SAVE_LOCS(PlayblastDialog.SAVE_LOCS):
         EDIT = SaveLocation(
@@ -100,152 +55,21 @@ class PrevisPlayblastDialog(PlayblastDialog):
         )
 
     def __init__(self, parent) -> None:
-        self._shot = self._resolve_pipeline_shot_context()
-        self._destination_checkboxes = {}
-        self._destination_path_labels = {}
-        self._save_locations_by_name = {
-            location.name: location for location in self._destination_locations()
-        }
-        super().__init__(parent, [], "SKD Previs Playblast")
+        super().__init__(parent, windowTitle="SKD Previs Playblast")
 
-    def _setup_ui(self) -> None:
-        self._central_widget = QWidget()
-        self.setCentralWidget(self._central_widget)
-        self._main_layout = QVBoxLayout()
-        self._central_widget.setLayout(self._main_layout)
+    def _default_destination_enabled(self, location: SaveLocation) -> bool:
+        return location.name == self.SAVE_LOCS.EDIT.name
 
-        self._build_header_section()
-        self._build_targets_section()
-        self._build_render_options_section()
-        self._build_buttons()
-        self._set_default_source_tab()
-        self._update_ui_state()
-
-    def _build_header_section(self) -> None:
-        title = QLabel("SKD Previs Playblast")
-        title.setStyleSheet("font-size: 24px; font-weight: 700;")
-        title.setAlignment(QtCore.Qt.AlignCenter)
-
-        subtitle = QLabel("Choose source mode, choose destinations, then export")
-        subtitle.setAlignment(QtCore.Qt.AlignCenter)
-        subtitle.setToolTip(
-            "Playblast flow: choose the source mode, choose destinations, then export."
-        )
-
-        self._main_layout.addWidget(title)
-        self._main_layout.addWidget(subtitle)
-
-    def _build_targets_section(self) -> None:
-        setup_group = QGroupBox("1. Export Setup")
-        setup_layout = QVBoxLayout(setup_group)
-
-        setup_layout.addWidget(self._build_export_source_section())
-        setup_layout.addWidget(self._build_destination_section())
-
-        self._validation_label = QLabel()
-        self._validation_label.setStyleSheet("color: #b00020;")
-        self._validation_label.setToolTip(
-            "Validation feedback. Export stays disabled until all required inputs are valid."
-        )
-        self._validation_label.setVisible(False)
-        setup_layout.addWidget(self._validation_label)
-
-        self._main_layout.addWidget(setup_group)
-
-    def _build_export_source_section(self) -> QGroupBox:
-        source_group = QGroupBox("")
-        source_layout = QVBoxLayout(source_group)
-
-        self._source_tabs = QTabWidget()
-        self._source_tabs.addTab(self._build_shot_source_tab(), "Shot Playblast")
-        self._source_tabs.addTab(
+    def _add_custom_tabs(self, tabs: QTabWidget) -> None:
+        self.SEQUENCER_TAB_INDEX = tabs.count()
+        tabs.addTab(
             self._build_sequencer_source_tab(),
             "Sequencer Playblast",
         )
-        self._source_tabs.addTab(
-            self._build_custom_source_tab(),
-            "Custom Playblast",
-        )
-        self._source_tabs.currentChanged.connect(self._on_source_mode_changed)
-        self._source_tabs.setToolTip(
-            "Select how the playblast source is resolved: pipeline shot metadata, sequencer shot, or manual custom settings."
-        )
-
-        source_tab_bar = self._source_tabs.tabBar()
-        source_tab_bar.setTabToolTip(
-            self.SHOT_TAB_INDEX,
-            "Uses shot code metadata from the current Maya file (fileInfo 'code') and ShotGrid cut range.",
-        )
-        source_tab_bar.setTabToolTip(
+        tabs.tabBar().setTabToolTip(
             self.SEQUENCER_TAB_INDEX,
             "Uses the camera sequencer shot under the current timeline frame.",
         )
-        source_tab_bar.setTabToolTip(
-            self.CUSTOM_TAB_INDEX,
-            "Uses manual camera and manual frame range, independent of shot metadata.",
-        )
-
-        source_layout.addWidget(self._source_tabs)
-        return source_group
-
-    def _build_shot_source_tab(self) -> QWidget:
-        shot_tab = QWidget()
-        shot_layout = QGridLayout(shot_tab)
-
-        shot_layout.addWidget(QLabel("Source"), 0, 0)
-        shot_source_value = QLabel("Pipeline Shot File")
-        shot_source_value.setToolTip(
-            "Source is derived from this Maya scene's pipeline shot metadata."
-        )
-        shot_layout.addWidget(shot_source_value, 0, 1)
-
-        shot_layout.addWidget(QLabel("Shot"), 1, 0)
-        self._shot_code_value = QLabel("-")
-        self._shot_code_value.setToolTip("Resolved pipeline shot code.")
-        shot_layout.addWidget(self._shot_code_value, 1, 1)
-
-        shot_layout.addWidget(QLabel("Camera"), 2, 0)
-        self._shot_camera = QComboBox(self)
-        self._shot_camera.addItems(self._available_custom_cameras())
-        self._shot_camera.setToolTip(
-            "Camera used for shot playblast output in Shot mode."
-        )
-        self._shot_camera.currentTextChanged.connect(self._on_source_settings_changed)
-        shot_layout.addWidget(self._shot_camera, 2, 1)
-
-        shot_layout.addWidget(QLabel("Frame Range"), 3, 0)
-        self._shot_range_value = QLabel("-")
-        self._shot_range_value.setToolTip(
-            "Resolved cut range from ShotGrid for the detected pipeline shot."
-        )
-        shot_layout.addWidget(self._shot_range_value, 3, 1)
-
-        shot_layout.addWidget(QLabel("ShotGrid"), 4, 0)
-        self._shotgrid_upload_checkbox = QCheckBox("Upload to ShotGrid")
-        self._shotgrid_upload_checkbox.setChecked(False)
-        self._shotgrid_upload_checkbox.setToolTip(
-            "When enabled, this Shot playblast will also create a ShotGrid Version and upload the movie."
-        )
-        self._shotgrid_upload_checkbox.toggled.connect(self._on_shotgrid_upload_toggled)
-        shot_layout.addWidget(self._shotgrid_upload_checkbox, 4, 1)
-
-        self._shotgrid_description_row = QWidget()
-        shotgrid_description_layout = QHBoxLayout(self._shotgrid_description_row)
-        shotgrid_description_layout.setContentsMargins(0, 0, 0, 0)
-        shotgrid_description_layout.addWidget(QLabel("Description"))
-        self._shotgrid_description_field = QLineEdit()
-        self._shotgrid_description_field.setPlaceholderText(
-            "Optional ShotGrid version description"
-        )
-        self._shotgrid_description_field.setToolTip(
-            "Optional notes saved to the ShotGrid Version description when upload is enabled."
-        )
-        shotgrid_description_layout.addWidget(self._shotgrid_description_field)
-        shot_layout.addWidget(self._shotgrid_description_row, 5, 0, 1, 2)
-
-        self._set_default_shot_camera()
-        self._sync_shotgrid_description_visibility()
-        return shot_tab
 
     def _build_sequencer_source_tab(self) -> QWidget:
         sequencer_tab = QWidget()
@@ -281,501 +105,39 @@ class PrevisPlayblastDialog(PlayblastDialog):
 
         return sequencer_tab
 
-    def _build_custom_source_tab(self) -> QWidget:
-        custom_tab = QWidget()
-        custom_layout = QGridLayout(custom_tab)
-
-        timeline_in, timeline_out = self._timeline_range()
-        self._custom_in = QSpinBox(self, minimum=0, maximum=10000, value=timeline_in)
-        self._custom_out = QSpinBox(self, minimum=0, maximum=10000, value=timeline_out)
-        self._custom_out.setMinimum(self._custom_in.value())
-        self._custom_in.setToolTip("Start frame for custom playblast.")
-        self._custom_out.setToolTip("End frame for custom playblast.")
-        self._custom_in.valueChanged.connect(self._on_custom_in_changed)
-        self._custom_out.valueChanged.connect(self._on_source_settings_changed)
-
-        custom_layout.addWidget(QLabel("Custom In"), 0, 0)
-        custom_layout.addWidget(self._custom_in, 0, 1)
-        custom_layout.addWidget(QLabel("Custom Out"), 0, 2)
-        custom_layout.addWidget(self._custom_out, 0, 3)
-
-        self._custom_camera = QComboBox(self)
-        self._custom_camera.addItems(self._available_custom_cameras())
-        self._custom_camera.setToolTip("Camera used for custom playblast output.")
-        self._custom_camera.currentTextChanged.connect(self._on_source_settings_changed)
-        custom_layout.addWidget(QLabel("Custom Camera"), 1, 0)
-        custom_layout.addWidget(self._custom_camera, 1, 1, 1, 3)
-        return custom_tab
-
-    def _build_destination_section(self) -> QGroupBox:
-        destination_group = QGroupBox("Save Destinations")
-        destination_layout = QVBoxLayout(destination_group)
-
-        for save_location in self._destination_locations():
-            row_widget = QWidget()
-            row_layout = QHBoxLayout(row_widget)
-            row_layout.setContentsMargins(0, 0, 0, 0)
-
-            destination_toggle = QCheckBox(save_location.name)
-            destination_toggle.setChecked(
-                self._default_destination_enabled(save_location)
-            )
-            destination_toggle.setToolTip(f"Enable export to {save_location.name}.")
-            destination_toggle.toggled.connect(self._on_destination_changed)
-            self._destination_checkboxes[save_location.name] = destination_toggle
-            row_layout.addWidget(destination_toggle)
-
-            path_label = QLabel("")
-            path_label.setToolTip(
-                f"Resolved output directory for {save_location.name}."
-            )
-            self._destination_path_labels[save_location.name] = path_label
-            row_layout.addWidget(path_label)
-            row_layout.addStretch()
-            destination_layout.addWidget(row_widget)
-
-        self._align_destination_path_columns()
-        self._custom_folder_row = self._build_destination_path_row()
-        destination_layout.addWidget(self._custom_folder_row)
-        return destination_group
-
-    def _align_destination_path_columns(self) -> None:
-        destination_column_width = max(
-            (
-                checkbox.sizeHint().width()
-                for checkbox in self._destination_checkboxes.values()
-            ),
-            default=0,
+    def _build_shot_camera_widget(self) -> QWidget:
+        self._shot_camera = QComboBox(self)
+        self._shot_camera.addItems(self._available_custom_cameras())
+        self._shot_camera.setToolTip(
+            "Camera used for shot playblast output in Shot mode."
         )
-        for checkbox in self._destination_checkboxes.values():
-            checkbox.setFixedWidth(destination_column_width)
+        self._shot_camera.currentTextChanged.connect(self._on_source_settings_changed)
+        self._set_default_shot_camera()
+        return self._shot_camera
 
-    def _build_destination_path_row(self) -> QWidget:
-        custom_path_row = QWidget()
-        custom_path_layout = QHBoxLayout(custom_path_row)
-        custom_path_layout.setContentsMargins(24, 0, 0, 0)
+    def _validate_source_state(self, mode: str) -> str | None:
+        if mode == "shot":
+            if self._shot and self._shot.cut_out < self._shot.cut_in:
+                return "Shot cut range is invalid (Cut Out must be >= Cut In)."
+            if not str(self._shot_camera.currentText()).strip():
+                return "Choose a camera for Shot Playblast."
 
-        custom_path_layout.addWidget(QLabel("Custom Folder Path"))
+        if mode == "sequencer":
+            shot_context = self._resolve_current_sequencer_shot_context()
+            if shot_context is None:
+                return "No current sequencer shot was found. Move timeline to a shot or use another source mode."
+            if not shot_context.camera:
+                return "Current sequencer shot has no camera assigned."
 
-        self._custom_folder_field = QLineEdit()
-        self._custom_folder_field.setText(self._default_custom_folder_path())
-        self._custom_folder_field.setToolTip(
-            "Directory used when Custom Folder destination is enabled."
-        )
-        self._custom_folder_field.textChanged.connect(self._on_custom_path_changed)
-        custom_path_layout.addWidget(self._custom_folder_field)
+        return None
 
-        browse_button = QPushButton("Browse")
-        browse_button.setToolTip("Choose a custom output directory.")
-        browse_button.clicked.connect(self._set_custom_folder)
-        custom_path_layout.addWidget(browse_button)
-        return custom_path_row
-
-    def _build_render_options_section(self) -> None:
-        options_group = QGroupBox("2. Viewport Options")
-        options_layout = QVBoxLayout(options_group)
-        options_layout.addWidget(
-            self._build_viewport_options_widget(self._resolve_active_model_panel())
-        )
-        self._apply_viewport_option_tooltips()
-        self._main_layout.addWidget(options_group)
-
-    def _build_buttons(self) -> None:
-        self._init_buttons(has_cancel_button=True, ok_name="Playblast Shot")
-        self.buttons.rejected.connect(self.close)
-        self.buttons.accepted.connect(self.do_export)
-
-        ok_button = self.buttons.button(QDialogButtonBox.Ok)
-        if ok_button is not None:
-            ok_button.setToolTip(
-                "Start playblast with the current source and destination selections."
-            )
-
-        cancel_button = self.buttons.button(QDialogButtonBox.Cancel)
-        if cancel_button is not None:
-            cancel_button.setToolTip("Close without exporting.")
-
-        self._main_layout.addWidget(self.buttons)
-
-    def _apply_viewport_option_tooltips(self) -> None:
-        self._use_lighting.setToolTip("Use viewport lighting for playblast capture.")
-        self._use_shadows.setToolTip("Render viewport shadows in playblast.")
-        self._use_ssao.setToolTip(
-            "Enable viewport anti-aliasing (SSAO/multi-sample setting)."
-        )
-        self._use_hardware_fog.setToolTip(
-            "Include hardware fog from viewport settings."
-        )
-        self._use_dof.setToolTip("Include camera depth of field in playblast.")
-
-    def _set_default_source_tab(self) -> None:
-        self._refresh_source_tab_availability()
-
-        self._source_tabs.setCurrentIndex(self._default_source_tab_index())
-
-    def _refresh_source_tab_availability(self) -> None:
-        has_shot_context = self._shot is not None
+    def _refresh_custom_ui_state(self) -> None:
+        self._refresh_sequencer_context_fields()
         has_sequencer_context = self._has_sequencer_shot_context()
-
-        self._source_tabs.setTabEnabled(self.SHOT_TAB_INDEX, has_shot_context)
         self._source_tabs.setTabEnabled(
             self.SEQUENCER_TAB_INDEX,
             has_sequencer_context,
         )
-
-        selected_mode = self._selected_source_mode()
-        if selected_mode == "shot" and not has_shot_context:
-            self._source_tabs.setCurrentIndex(self._default_source_tab_index())
-        if selected_mode == "sequencer" and not has_sequencer_context:
-            self._source_tabs.setCurrentIndex(self._default_source_tab_index())
-
-    def _default_source_tab_index(self) -> int:
-        has_shot_context = self._shot is not None
-        has_sequencer_context = self._has_sequencer_shot_context()
-
-        if has_shot_context:
-            return self.SHOT_TAB_INDEX
-        if has_sequencer_context:
-            return self.SEQUENCER_TAB_INDEX
-        return self.CUSTOM_TAB_INDEX
-
-    @staticmethod
-    def _resolve_pipeline_shot_context() -> Shot | None:
-        try:
-            conn = DB.Get(DB_Config)
-        except Exception:
-            return None
-
-        try:
-            code = str(mc.fileInfo("code", query=True)[0]).strip()
-        except Exception:
-            return None
-
-        if not code:
-            return None
-
-        try:
-            return conn.get_shot_by_code(code)
-        except Exception:
-            return None
-
-    @staticmethod
-    def _timeline_range() -> tuple[int, int]:
-        cut_in = int(mc.playbackOptions(minTime=True, query=True))
-        cut_out = int(mc.playbackOptions(maxTime=True, query=True))
-        if cut_out < cut_in:
-            cut_out = cut_in
-        return cut_in, cut_out
-
-    @staticmethod
-    def _available_custom_cameras() -> list[str]:
-        return [
-            str(c)
-            for c in (
-                mc.ls(cameras=True, visible=True) or mc.ls(cameras=True) or ["persp"]
-            )
-        ]
-
-    @staticmethod
-    def _active_camera_name() -> str:
-        panel = PlayblastDialog._resolve_active_model_panel()
-        if not panel:
-            return ""
-
-        try:
-            camera = str(mc.modelEditor(panel, query=True, camera=True) or "")
-        except Exception:
-            return ""
-
-        return camera.strip()
-
-    @staticmethod
-    def _camera_name_variants(camera_name: str) -> set[str]:
-        if not camera_name:
-            return set()
-
-        variants = {camera_name, camera_name.split("|")[-1], camera_name.split(":")[-1]}
-
-        if not mc.objExists(camera_name):
-            return variants
-
-        node_type = str(mc.nodeType(camera_name) or "")
-        if node_type == "transform":
-            shapes = (
-                mc.listRelatives(
-                    camera_name,
-                    shapes=True,
-                    type="camera",
-                    fullPath=True,
-                )
-                or []
-            )
-            for shape in shapes:
-                shape_name = str(shape)
-                variants.add(shape_name)
-                variants.add(shape_name.split("|")[-1])
-                variants.add(shape_name.split(":")[-1])
-
-        if node_type == "camera":
-            parents = mc.listRelatives(camera_name, parent=True, fullPath=True) or []
-            for parent in parents:
-                parent_name = str(parent)
-                variants.add(parent_name)
-                variants.add(parent_name.split("|")[-1])
-                variants.add(parent_name.split(":")[-1])
-
-        return variants
-
-    @staticmethod
-    def _set_combo_to_camera(combo: QComboBox, camera_name: str) -> None:
-        variants = PrevisPlayblastDialog._camera_name_variants(camera_name)
-        if not variants:
-            return
-
-        for index in range(combo.count()):
-            item_text = combo.itemText(index)
-            if item_text in variants:
-                combo.setCurrentIndex(index)
-                return
-
-    def _set_default_shot_camera(self) -> None:
-        self._set_combo_to_camera(self._shot_camera, self._active_camera_name())
-
-    @staticmethod
-    def _list_sequencer_shot_nodes() -> list[str]:
-        return [
-            str(shot_node)
-            for shot_node in (mc.sequenceManager(listShots=True) or [])
-            if mc.objExists(shot_node)
-            and not bool(mc.shot(shot_node, query=True, mute=True))
-        ]
-
-    def _has_sequencer_shot_context(self) -> bool:
-        return bool(self._list_sequencer_shot_nodes())
-
-    @staticmethod
-    def _destination_locations() -> list[SaveLocation]:
-        return [
-            PrevisPlayblastDialog.SAVE_LOCS.EDIT,
-            PrevisPlayblastDialog.SAVE_LOCS.CURRENT,
-            PrevisPlayblastDialog.SAVE_LOCS.CUSTOM,
-        ]
-
-    def _default_destination_enabled(self, location: SaveLocation) -> bool:
-        return location.name == self.SAVE_LOCS.EDIT.name
-
-    def _selected_source_mode(self) -> SOURCE_MODE:
-        current_index = self._source_tabs.currentIndex()
-        if current_index == self.SHOT_TAB_INDEX:
-            return "shot"
-        if current_index == self.SEQUENCER_TAB_INDEX:
-            return "sequencer"
-        return "custom"
-
-    def _selected_shot_camera(self) -> str:
-        return str(self._shot_camera.currentText()).strip()
-
-    def _selected_destination_locations(self) -> list[SaveLocation]:
-        selected: list[SaveLocation] = []
-        for location in self._destination_locations():
-            toggle = self._destination_checkboxes.get(location.name)
-            if toggle and toggle.isChecked():
-                selected.append(location)
-        return selected
-
-    def _is_custom_destination_selected(self) -> bool:
-        custom_checkbox = self._destination_checkboxes.get(self.SAVE_LOCS.CUSTOM.name)
-        return bool(custom_checkbox and custom_checkbox.isChecked())
-
-    def _paths_for_filename(
-        self, filename: str
-    ) -> dict[Playblaster.PRESET, list[str | Path]]:
-        paths: dict[Playblaster.PRESET, list[str | Path]] = defaultdict(list)
-        for location in self._selected_destination_locations():
-            destination_dir = self._resolved_destination_path(location).strip()
-            if not destination_dir:
-                continue
-            paths[location.preset].append(str(Path(destination_dir) / filename))
-        return paths
-
-    @staticmethod
-    def _final_movie_path_for_base(
-        output_base: str | Path,
-        preset: Playblaster.PRESET,
-    ) -> Path:
-        return Path(str(output_base) + f".{preset.ext}")
-
-    def _final_movie_paths_for_location(
-        self,
-        shot_config: MShotPlayblastConfig,
-        location: SaveLocation,
-    ) -> list[Path]:
-        destination_dir = Path(self._resolved_destination_path(location)).expanduser()
-        resolved_destination_dir = destination_dir.resolve()
-
-        matching_paths: list[Path] = []
-        for output_base in shot_config.paths.get(location.preset, []):
-            resolved_output_base = Path(str(output_base)).expanduser().resolve()
-            if resolved_output_base.parent != resolved_destination_dir:
-                continue
-            matching_paths.append(
-                self._final_movie_path_for_base(resolved_output_base, location.preset)
-            )
-        return matching_paths
-
-    def _ordered_final_movie_paths_for_upload(
-        self,
-        shot_config: MShotPlayblastConfig,
-    ) -> list[Path]:
-        """Return deterministic output path order for upload path resolution."""
-
-        ordered_paths: list[Path] = []
-        seen_paths: set[Path] = set()
-
-        for location in self._destination_locations():
-            for output_path in self._final_movie_paths_for_location(
-                shot_config, location
-            ):
-                if output_path in seen_paths:
-                    continue
-                seen_paths.add(output_path)
-                ordered_paths.append(output_path)
-
-        for preset, output_bases in shot_config.paths.items():
-            for output_base in output_bases:
-                output_path = self._final_movie_path_for_base(output_base, preset)
-                resolved_output_path = output_path.expanduser().resolve()
-                if resolved_output_path in seen_paths:
-                    continue
-                seen_paths.add(resolved_output_path)
-                ordered_paths.append(resolved_output_path)
-
-        return ordered_paths
-
-    def _preferred_edit_movie_paths_for_upload(
-        self,
-        shot_config: MShotPlayblastConfig,
-    ) -> list[Path]:
-        edit_location = self._save_locations_by_name.get(self.SAVE_LOCS.EDIT.name)
-        if edit_location is None:
-            return []
-        return self._final_movie_paths_for_location(shot_config, edit_location)
-
-    def _resolve_shotgrid_upload_movie_path(
-        self,
-        config: MPlayblastConfig,
-    ) -> Path | None:
-        """Resolve upload movie path with stable preference ordering.
-
-        Preference order:
-        1) valid `Send to Edit` output
-        2) first valid output from the deterministic export order
-        """
-        if not config.shots:
-            return None
-
-        shot_config = config.shots[0]
-        preferred_paths = self._preferred_edit_movie_paths_for_upload(shot_config)
-        output_paths = self._ordered_final_movie_paths_for_upload(shot_config)
-        return resolve_preferred_upload_movie_path(
-            output_paths,
-            preferred_paths=preferred_paths,
-        )
-
-    def _should_upload_shot_playblast_to_shotgrid(self) -> bool:
-        return (
-            self._selected_source_mode() == "shot"
-            and self._is_shotgrid_upload_requested()
-        )
-
-    def _upload_shot_playblast_to_shotgrid(
-        self,
-        config: MPlayblastConfig,
-    ) -> list[str]:
-        if not config.shots:
-            return ["ShotGrid Upload: Skipped - no shot output was generated."]
-
-        shot_code = str(config.shots[0].shot.code or "").strip()
-        if not shot_code:
-            return ["ShotGrid Upload: Skipped - shot code is missing."]
-
-        movie_path = self._resolve_shotgrid_upload_movie_path(config)
-        if movie_path is None:
-            return [
-                "ShotGrid Upload: Skipped - no valid playblast movie file was found."
-            ]
-
-        version_name = default_version_name_from_movie_path(movie_path)
-        if not version_name:
-            version_name = f"{shot_code}_playblast"
-
-        artist_name = resolve_artist_display_name().strip() or None
-        upload_request = PlayblastVersionUploadRequest(
-            shot_code=shot_code,
-            movie_path=movie_path,
-            version_name=version_name,
-            description=self._shotgrid_upload_description() or None,
-            path_to_frames=str(movie_path),
-            artist_display_name=artist_name,
-        )
-
-        try:
-            upload_result = upload_playblast_version(upload_request)
-        except Exception as exc:
-            log.exception("ShotGrid upload failed for shot '%s'", shot_code)
-            return [f"ShotGrid Upload: Failed - {exc}"]
-
-        message_lines: list[str] = []
-        if upload_result.ok:
-            success_message = (
-                f"ShotGrid Upload: Success - {upload_result.version_name}"
-                f" (shot {upload_result.shot_code})."
-            )
-            if upload_result.version_id is not None:
-                success_message = (
-                    f"{success_message} Version ID: {upload_result.version_id}."
-                )
-            message_lines.append(success_message)
-        else:
-            message_lines.append(f"ShotGrid Upload: Failed - {upload_result.message}")
-
-        for warning in upload_result.warnings:
-            message_lines.append(f"ShotGrid Warning: {warning}")
-
-        return message_lines
-
-    def _selected_destination_directories(self) -> list[Path]:
-        directories: list[Path] = []
-        for location in self._selected_destination_locations():
-            destination_dir = self._resolved_destination_path(location).strip()
-            if destination_dir:
-                directories.append(Path(destination_dir))
-        return directories
-
-    def _resolve_output_name(self, prefix: str) -> str:
-        return resolve_versioned_playblast_basename(
-            prefix,
-            self._selected_destination_directories(),
-        )
-
-    def _resolved_destination_path(self, location: SaveLocation) -> str:
-        if location.name == self.SAVE_LOCS.CUSTOM.name:
-            return self._custom_folder_field.text().strip()
-        return str(location.path)
-
-    def _refresh_destination_path_labels(self) -> None:
-        for location_name, path_label in self._destination_path_labels.items():
-            location = self._save_locations_by_name[location_name]
-            path_label.setText(f"-> {self._resolved_destination_path(location)}")
-
-    def _refresh_shot_context_fields(self) -> None:
-        if self._shot is None:
-            self._shot_code_value.setText("-")
-            self._shot_range_value.setText("-")
-            return
-
-        self._shot_code_value.setText(self._shot.code)
-        self._shot_range_value.setText(f"{self._shot.cut_in} - {self._shot.cut_out}")
 
     def _refresh_sequencer_context_fields(self) -> SequencerShotContext | None:
         shot_context = self._resolve_current_sequencer_shot_context()
@@ -792,109 +154,71 @@ class PrevisPlayblastDialog(PlayblastDialog):
         )
         return shot_context
 
-    def _sync_custom_path_row_visibility(self) -> None:
-        is_visible = self._is_custom_destination_selected()
-        self._custom_folder_row.setVisible(is_visible)
-        self._custom_folder_field.setEnabled(is_visible)
+    @staticmethod
+    def _active_camera_name() -> str:
+        panel = PlayblastDialog._resolve_active_model_panel()
+        if not panel:
+            return ""
+        try:
+            camera = str(mc.modelEditor(panel, query=True, camera=True) or "")
+        except Exception:
+            return ""
+        return camera.strip()
 
-    def _sync_shotgrid_description_visibility(self) -> None:
-        show_description = self._is_shotgrid_upload_requested()
-        self._shotgrid_description_row.setVisible(show_description)
-        self._shotgrid_description_field.setEnabled(show_description)
-
-    def _is_shotgrid_upload_requested(self) -> bool:
-        return self._shotgrid_upload_checkbox.isChecked()
-
-    def _shotgrid_upload_description(self) -> str:
-        return self._shotgrid_description_field.text().strip()
-
-    def _validate_target_destination_state(self) -> str | None:
-        mode = self._selected_source_mode()
-
-        if mode == "shot":
-            if self._shot is None:
-                return (
-                    "No pipeline shot context was found. Open a pipeline shot file "
-                    "or switch to Sequencer or Custom Playblast."
+    @staticmethod
+    def _camera_name_variants(camera_name: str) -> set[str]:
+        if not camera_name:
+            return set()
+        variants = {camera_name, camera_name.split("|")[-1], camera_name.split(":")[-1]}
+        if not mc.objExists(camera_name):
+            return variants
+        node_type = str(mc.nodeType(camera_name) or "")
+        if node_type == "transform":
+            shapes = (
+                mc.listRelatives(
+                    camera_name,
+                    shapes=True,
+                    type="camera",
+                    fullPath=True,
                 )
-            if self._shot.cut_out < self._shot.cut_in:
-                return "Shot cut range is invalid (Cut Out must be >= Cut In)."
-            if not self._selected_shot_camera():
-                return "Choose a camera for Shot Playblast."
+                or []
+            )
+            for shape in shapes:
+                shape_name = str(shape)
+                variants.add(shape_name)
+                variants.add(shape_name.split("|")[-1])
+                variants.add(shape_name.split(":")[-1])
+        if node_type == "camera":
+            parents = mc.listRelatives(camera_name, parent=True, fullPath=True) or []
+            for parent in parents:
+                parent_name = str(parent)
+                variants.add(parent_name)
+                variants.add(parent_name.split("|")[-1])
+                variants.add(parent_name.split(":")[-1])
+        return variants
 
-        if mode == "sequencer":
-            shot_context = self._resolve_current_sequencer_shot_context()
-            if shot_context is None:
-                return "No current sequencer shot was found. Move timeline to a shot or use another source mode."
-            if not shot_context.camera:
-                return "Current sequencer shot has no camera assigned."
-
-        if mode == "custom":
-            if self._custom_out.value() < self._custom_in.value():
-                return "Custom Out must be greater than or equal to Custom In."
-            if not str(self._custom_camera.currentText()).strip():
-                return "Choose a camera for Custom Playblast."
-
-        if not self._selected_destination_locations():
-            return "Select at least one save destination."
-
-        if (
-            self._is_custom_destination_selected()
-            and not self._custom_folder_field.text().strip()
-        ):
-            return "Custom Folder path is required when Custom Folder destination is enabled."
-
-        return None
-
-    def _action_button_text(self) -> str:
-        mode = self._selected_source_mode()
-        if mode == "shot":
-            return "Playblast Shot"
-        if mode == "sequencer":
-            return "Playblast Sequencer"
-        return "Playblast Custom"
-
-    def _update_action_state(self) -> None:
-        ok_button = self.buttons.button(QDialogButtonBox.Ok)
-        if ok_button is None:
+    def _set_default_shot_camera(self) -> None:
+        camera_name = self._active_camera_name()
+        variants = self._camera_name_variants(camera_name)
+        if not variants:
             return
+        for index in range(self._shot_camera.count()):
+            item_text = self._shot_camera.itemText(index)
+            if item_text in variants:
+                self._shot_camera.setCurrentIndex(index)
+                return
 
-        ok_button.setText(self._action_button_text())
-        validation_error = self._validate_target_destination_state()
-        ok_button.setEnabled(validation_error is None)
-        self._validation_label.setText(validation_error or "")
-        self._validation_label.setVisible(validation_error is not None)
+    @staticmethod
+    def _list_sequencer_shot_nodes() -> list[str]:
+        return [
+            str(shot_node)
+            for shot_node in (mc.sequenceManager(listShots=True) or [])
+            if mc.objExists(shot_node)
+            and not bool(mc.shot(shot_node, query=True, mute=True))
+        ]
 
-    def _update_ui_state(self) -> None:
-        self._refresh_source_tab_availability()
-        self._refresh_shot_context_fields()
-        self._refresh_sequencer_context_fields()
-        self._sync_custom_path_row_visibility()
-        self._sync_shotgrid_description_visibility()
-        self._refresh_destination_path_labels()
-        self._update_action_state()
-
-    def _on_source_mode_changed(self, _index: int) -> None:
-        self._update_ui_state()
-
-    def _on_destination_changed(self, _checked: bool) -> None:
-        self._update_ui_state()
-
-    def _on_custom_path_changed(self, _path: str) -> None:
-        self._update_ui_state()
-
-    def _on_custom_in_changed(self, in_frame: int) -> None:
-        self._custom_out.setMinimum(in_frame)
-        self._update_ui_state()
-
-    def _on_source_settings_changed(self, *_args) -> None:
-        self._update_ui_state()
-
-    def _on_shotgrid_upload_toggled(self, _enabled: bool) -> None:
-        self._update_ui_state()
-
-    def _refresh_summary(self, *_args) -> None:
-        self._update_ui_state()
+    def _has_sequencer_shot_context(self) -> bool:
+        return bool(self._list_sequencer_shot_nodes())
 
     def _resolve_current_sequencer_shot_context(self) -> SequencerShotContext | None:
         shot_node = self._resolve_current_shot_node()
@@ -939,11 +263,6 @@ class PrevisPlayblastDialog(PlayblastDialog):
                 return shot_node
         return None
 
-    @staticmethod
-    def _scene_stem() -> str:
-        scene_name = Path(str(mc.file(query=True, sceneName=True) or "")).stem
-        return scene_name or "previs_playblast"
-
     def _hud_shot_label(self) -> str:
         mode = self._selected_source_mode()
 
@@ -960,28 +279,11 @@ class PrevisPlayblastDialog(PlayblastDialog):
 
         return "Custom"
 
-    def _validate_config(self, config: MPlayblastConfig) -> str | None:
-        validation_error = self._validate_target_destination_state()
-        if validation_error:
-            return validation_error
-        return super()._validate_config(config)
-
-    def _after_local_playblast(
-        self,
-        config: MPlayblastConfig,
-    ) -> list[str]:
-        if not self._should_upload_shot_playblast_to_shotgrid():
-            return []
-        return self._upload_shot_playblast_to_shotgrid(config)
-
     def _build_shot_playblast_config(self) -> MShotPlayblastConfig:
         if self._shot is None:
             raise ValueError("No pipeline shot context was found.")
 
-        shot_camera = self._selected_shot_camera()
-        if not shot_camera:
-            raise ValueError("Choose a camera for Shot Playblast.")
-
+        shot_camera = str(self._shot_camera.currentText()).strip()
         output_name = self._resolve_output_name(self._shot.code)
         return MShotPlayblastConfig(
             camera=shot_camera,
@@ -1008,29 +310,7 @@ class PrevisPlayblastDialog(PlayblastDialog):
             use_sequencer=False,
         )
 
-    def _build_custom_playblast_config(self) -> MShotPlayblastConfig:
-        custom_in = self._custom_in.value()
-        custom_out = self._custom_out.value()
-        custom_code = self._scene_stem()
-        output_name = self._resolve_output_name(f"{custom_code}_custom")
-
-        return MShotPlayblastConfig(
-            camera=str(self._custom_camera.currentText()),
-            shot=dummy_shot(
-                code=custom_code,
-                cut_in=custom_in,
-                cut_out=custom_out,
-                cut_duration=max(0, custom_out - custom_in),
-            ),
-            paths=self._paths_for_filename(output_name),
-            use_sequencer=False,
-        )
-
     def _generate_config(self) -> MPlayblastConfig:
-        validation_error = self._validate_target_destination_state()
-        if validation_error:
-            raise ValueError(validation_error)
-
         mode = self._selected_source_mode()
         if mode == "shot":
             shot_config = self._build_shot_playblast_config()

--- a/pipeline/pipe/m/playblast/previs.py
+++ b/pipeline/pipe/m/playblast/previs.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import logging
-import maya.cmds as mc
-
 from datetime import datetime
 from pathlib import Path
 
-from pipe.util import Playblaster
+import maya.cmds as mc
 from shared.util import get_edit_path
+
+from pipe.util import Playblaster
 
 from .struct import (
     HudDefinition,
@@ -24,6 +24,7 @@ log = logging.getLogger(__name__)
 
 class PrevisPlayblastDialog(PlayblastDialog):
     _camera_shot_lookup: dict[str, str]
+    _timeline_dialog_configs: list[MShotDialogConfig]
     _sequence_dialog_configs: list[MShotDialogConfig]
     _shot_dialog_configs: list[MShotDialogConfig]
 
@@ -36,6 +37,9 @@ class PrevisPlayblastDialog(PlayblastDialog):
 
     def __init__(self, parent) -> None:
         shot_node_list: list[str] = mc.sequenceManager(listShots=True) or []  # type: ignore[assignment]
+        sequencer_node = str(
+            mc.sequenceManager(query=True, writableSequencer=True) or ""
+        )
 
         # generate lookup table for matching cameras to shots
         self._camera_shot_lookup = {
@@ -57,26 +61,49 @@ class PrevisPlayblastDialog(PlayblastDialog):
             )
             for shot_node in shot_node_list
         ]
-        self._sequence_dialog_configs = [
-            MShotDialogConfig(
-                id=str(mc.sequenceManager(query=True, writableSequencer=True)),
-                name="Camera Sequencer",
-                save_locs=[
-                    (self.SAVE_LOCS.EDIT, True),
-                    (self.SAVE_LOCS.CURRENT, True),
-                    (self.SAVE_LOCS.CUSTOM, False),
-                ],
+        self._sequence_dialog_configs = []
+        if shot_node_list and sequencer_node and mc.objExists(sequencer_node):
+            self._sequence_dialog_configs = [
+                MShotDialogConfig(
+                    id=sequencer_node,
+                    name="Camera Sequencer",
+                    save_locs=[
+                        (self.SAVE_LOCS.EDIT, True),
+                        (self.SAVE_LOCS.CURRENT, True),
+                        (self.SAVE_LOCS.CUSTOM, False),
+                    ],
+                )
+            ]
+
+        self._timeline_dialog_configs = []
+        if not shot_node_list:
+            log.warning(
+                "No camera sequencer shots detected. Falling back to active timeline export."
             )
-        ]
+            self._timeline_dialog_configs = [
+                MShotDialogConfig(
+                    id="timeline_fallback",
+                    name="Active Camera Timeline",
+                    save_locs=[
+                        (self.SAVE_LOCS.EDIT, True),
+                        (self.SAVE_LOCS.CURRENT, True),
+                        (self.SAVE_LOCS.CUSTOM, False),
+                    ],
+                )
+            ]
 
         super().__init__(
             parent,
-            self._shot_dialog_configs + self._sequence_dialog_configs,
+            self._shot_dialog_configs
+            + self._sequence_dialog_configs
+            + self._timeline_dialog_configs,
             "Bobo Previs Playblast",
         )
 
     def _do_camera_shot_lookup(self) -> str:
         """Look up the current shot based off of the camera"""
+        if not self._camera_shot_lookup:
+            return "No shot data"
         panel: str = mc.getPanel(withLabel="CapturePanel")  # type: ignore[assignment]
         try:
             if panel:
@@ -88,9 +115,120 @@ class PrevisPlayblastDialog(PlayblastDialog):
             pass
         return "No shot data"
 
+    @staticmethod
+    def _scene_stem() -> str:
+        scene_name = Path(mc.file(query=True, sceneName=True)).stem  # type: ignore[arg-type]
+        return scene_name or "previs_playblast"
+
+    @staticmethod
+    def _timeline_range() -> tuple[int, int]:
+        cut_in = int(mc.playbackOptions(minTime=True, query=True))
+        cut_out = int(mc.playbackOptions(maxTime=True, query=True))
+        if cut_out < cut_in:
+            cut_out = cut_in
+        return cut_in, cut_out
+
+    def _sequencer_range(self, sequencer_node: str) -> tuple[int, int]:
+        if not sequencer_node or not mc.objExists(sequencer_node):
+            return self._timeline_range()
+        try:
+            cut_in = int(mc.getAttr(f"{sequencer_node}.minFrame"))
+            cut_out = int(mc.getAttr(f"{sequencer_node}.maxFrame"))
+        except Exception:
+            return self._timeline_range()
+        if cut_out < cut_in:
+            cut_out = cut_in
+        return cut_in, cut_out
+
+    @staticmethod
+    def _active_camera() -> str:
+        focused_panel = str(mc.getPanel(withFocus=True) or "")
+        if focused_panel and mc.getPanel(typeOf=focused_panel) == "modelPanel":
+            try:
+                return str(mc.modelEditor(focused_panel, query=True, camera=True))
+            except Exception:
+                pass
+
+        sequencer_panel = str(mc.sequenceManager(query=True, modelPanel=True) or "")
+        if sequencer_panel and mc.modelPanel(sequencer_panel, exists=True):
+            try:
+                return str(mc.modelEditor(sequencer_panel, query=True, camera=True))
+            except Exception:
+                pass
+
+        visible_cameras = mc.ls(cameras=True, visible=True) or []
+        if visible_cameras:
+            return str(visible_cameras[0])
+        return "persp"
+
     def _generate_config(self) -> MPlayblastConfig:
-        seq_node = str(mc.sequenceManager(query=True, writableSequencer=True))
+        seq_node = str(mc.sequenceManager(query=True, writableSequencer=True) or "")
         date = datetime.now().strftime("%m-%d-%y")
+        shot_name = self._scene_stem()
+
+        shots = [
+            MShotPlayblastConfig(
+                camera=str(mc.shot(config.id, query=True, currentCamera=True)),
+                shot=dummy_shot(
+                    clip_name := str(mc.shot(config.id, query=True, shotName=True)),
+                    int(mc.shot(config.id, query=True, startTime=True)),
+                    int(mc.shot(config.id, query=True, endTime=True)),
+                    int(mc.shot(config.id, query=True, clipDuration=True)),
+                ),
+                paths=self.save_locations_to_paths(
+                    config.id,
+                    (sl[0] for sl in config.save_locs),
+                    f"{clip_name}_{date}",
+                ),
+            )
+            for config in self._shot_dialog_configs
+            if self.is_shot_enabled(config.id)
+        ]
+
+        for config in self._sequence_dialog_configs:
+            if not self.is_shot_enabled(config.id):
+                continue
+            seq_in, seq_out = self._sequencer_range(seq_node)
+            shots.append(
+                MShotPlayblastConfig(
+                    camera=None,
+                    shot=dummy_shot(
+                        code=shot_name,
+                        cut_in=seq_in,
+                        cut_out=seq_out,
+                        cut_duration=seq_out - seq_in,
+                    ),
+                    paths=self.save_locations_to_paths(
+                        config.id,
+                        (sl[0] for sl in config.save_locs),
+                        f"{shot_name}_{date}",
+                    ),
+                    use_sequencer=True,
+                )
+            )
+
+        for config in self._timeline_dialog_configs:
+            if not self.is_shot_enabled(config.id):
+                continue
+            timeline_in, timeline_out = self._timeline_range()
+            shots.append(
+                MShotPlayblastConfig(
+                    camera=self._active_camera(),
+                    shot=dummy_shot(
+                        code=shot_name,
+                        cut_in=timeline_in,
+                        cut_out=timeline_out,
+                        cut_duration=timeline_out - timeline_in,
+                    ),
+                    paths=self.save_locations_to_paths(
+                        config.id,
+                        (sl[0] for sl in config.save_locs),
+                        f"{shot_name}_{date}",
+                    ),
+                    use_sequencer=False,
+                )
+            )
+
         return MPlayblastConfig(
             builtin_huds=[
                 PlayblastDialog.MAYA_HUDS.CAM_NAME,
@@ -111,40 +249,6 @@ class PrevisPlayblastDialog(PlayblastDialog):
             hardware_fog=self.use_hardware_fog,
             lighting=self.use_lighting,
             shadows=self.use_shadows,
-            shots=[
-                MShotPlayblastConfig(
-                    camera=str(mc.shot(config.id, query=True, currentCamera=True)),
-                    shot=dummy_shot(
-                        shot_name := str(mc.shot(config.id, query=True, shotName=True)),
-                        int(mc.shot(config.id, query=True, startTime=True)),
-                        int(mc.shot(config.id, query=True, endTime=True)),
-                        int(mc.shot(config.id, query=True, clipDuration=True)),
-                    ),
-                    paths=self.save_locations_to_paths(
-                        config.id,
-                        (sl[0] for sl in config.save_locs),
-                        f"{shot_name}_{date}",
-                    ),
-                )
-                for config in self._shot_dialog_configs
-                if self.is_shot_enabled(config.id)
-            ]
-            + [
-                MShotPlayblastConfig(
-                    camera=None,
-                    shot=dummy_shot(
-                        code=(name := Path(mc.file(query=True, sceneName=True)).stem),  # type: ignore[arg-type]
-                        cut_in=(ci := mc.getAttr(f"{seq_node}.minFrame")),
-                        cut_out=(co := mc.getAttr(f"{seq_node}.maxFrame")),
-                        cut_duration=co - ci,
-                    ),
-                    paths=self.save_locations_to_paths(
-                        config.id, (sl[0] for sl in config.save_locs), f"{name}_{date}"
-                    ),
-                    use_sequencer=True,
-                )
-                for config in self._sequence_dialog_configs
-                if self.is_shot_enabled(config.id)
-            ],
+            shots=shots,
             ssao=self.use_ssao,
         )

--- a/pipeline/pipe/m/playblast/previs.py
+++ b/pipeline/pipe/m/playblast/previs.py
@@ -692,15 +692,17 @@ class PrevisPlayblastDialog(PlayblastDialog):
         config: MPlayblastConfig,
     ) -> list[str]:
         if not config.shots:
-            return ["ShotGrid upload skipped: no shot output was generated."]
+            return ["ShotGrid Upload: Skipped - no shot output was generated."]
 
         shot_code = str(config.shots[0].shot.code or "").strip()
         if not shot_code:
-            return ["ShotGrid upload skipped: shot code is missing."]
+            return ["ShotGrid Upload: Skipped - shot code is missing."]
 
         movie_path = self._resolve_shotgrid_upload_movie_path(config)
         if movie_path is None:
-            return ["ShotGrid upload skipped: no valid playblast movie file was found."]
+            return [
+                "ShotGrid Upload: Skipped - no valid playblast movie file was found."
+            ]
 
         version_name = default_version_name_from_movie_path(movie_path)
         if not version_name:
@@ -720,12 +722,12 @@ class PrevisPlayblastDialog(PlayblastDialog):
             upload_result = upload_playblast_version(upload_request)
         except Exception as exc:
             log.exception("ShotGrid upload failed for shot '%s'", shot_code)
-            return [f"ShotGrid upload failed: {exc}"]
+            return [f"ShotGrid Upload: Failed - {exc}"]
 
         message_lines: list[str] = []
         if upload_result.ok:
             success_message = (
-                f"ShotGrid upload successful: {upload_result.version_name}"
+                f"ShotGrid Upload: Success - {upload_result.version_name}"
                 f" (shot {upload_result.shot_code})."
             )
             if upload_result.version_id is not None:
@@ -734,10 +736,10 @@ class PrevisPlayblastDialog(PlayblastDialog):
                 )
             message_lines.append(success_message)
         else:
-            message_lines.append(f"ShotGrid upload failed: {upload_result.message}")
+            message_lines.append(f"ShotGrid Upload: Failed - {upload_result.message}")
 
         for warning in upload_result.warnings:
-            message_lines.append(f"ShotGrid warning: {warning}")
+            message_lines.append(f"ShotGrid Warning: {warning}")
 
         return message_lines
 

--- a/pipeline/pipe/m/playblast/ui.py
+++ b/pipeline/pipe/m/playblast/ui.py
@@ -30,7 +30,7 @@ from .playblaster import MPlayblaster
 from .struct import HudDefinition, SaveLocation
 
 if TYPE_CHECKING:
-    from typing import Iterable
+    from typing import Callable, Iterable
 
     from .struct import (
         MPlayblastConfig,
@@ -44,12 +44,21 @@ log = logging.getLogger(__name__)
 class ClickableQLabel(QLabel):
     clicked = QtCore.Signal()
 
-    def mousePressEvent(self, _event):  # type: ignore[override]
+    def mousePressEvent(self, event):  # type: ignore[override]
         self.clicked.emit()
+        super().mousePressEvent(event)
 
 
 class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
-    """Shared Maya playblast dialog with clear target selection and export summary."""
+    """Shared Maya playblast dialog.
+
+    The dialog is intentionally organized into linear sections so artists can
+    understand and configure exports quickly:
+    1) choose export targets + destinations
+    2) configure shot-specific options (subclass provided)
+    3) configure viewport and folder options
+    4) review a live export summary
+    """
 
     _central_widget: QWidget
     _context_group: QGroupBox
@@ -125,7 +134,7 @@ class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
         self._central_widget.setLayout(self._main_layout)
 
         self._build_header_section()
-        self._build_target_section()
+        self._build_targets_section()
         self._build_context_section()
         self._build_render_options_section()
         self._build_summary_section()
@@ -145,22 +154,41 @@ class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
         self._main_layout.addWidget(title)
         self._main_layout.addWidget(subtitle)
 
-    def _build_target_section(self) -> None:
+    def _build_targets_section(self) -> None:
         target_group = QGroupBox("1. Targets and Destinations")
         target_layout = QVBoxLayout(target_group)
 
         description = QLabel(
-            "Enable each target you want to export, then select one or more destinations."
+            "Enable each target you want to export, then choose one or more destinations."
         )
         description.setStyleSheet("color: #666;")
         target_layout.addWidget(description)
 
+        location_order = self._collect_location_order()
+        targets_grid = self._build_targets_grid(location_order)
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
+        scroll.setWidget(targets_grid)
+        target_layout.addWidget(scroll)
+
+        self._main_layout.addWidget(target_group)
+
+    def _build_targets_grid(self, location_order: list[SaveLocation]) -> QWidget:
         grid_container = QWidget()
         grid = QGridLayout(grid_container)
         grid.setHorizontalSpacing(12)
         grid.setVerticalSpacing(8)
 
-        location_order = self._collect_location_order()
+        self._add_targets_grid_header(grid, location_order)
+        self._add_targets_grid_bulk_controls(grid, location_order)
+        self._add_targets_grid_rows(grid, location_order)
+        return grid_container
+
+    def _add_targets_grid_header(
+        self, grid: QGridLayout, location_order: list[SaveLocation]
+    ) -> None:
         grid.addWidget(QLabel("Export"), 0, 0)
         grid.addWidget(QLabel("Target"), 0, 1)
 
@@ -169,82 +197,124 @@ class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
             header.setAlignment(QtCore.Qt.AlignCenter)
             grid.addWidget(header, 0, column)
 
+    def _add_targets_grid_bulk_controls(
+        self, grid: QGridLayout, location_order: list[SaveLocation]
+    ) -> None:
         select_all_targets = QPushButton("All Targets")
-        select_all_targets.clicked.connect(lambda: self._set_all_targets(True))
+        select_all_targets.clicked.connect(self._make_set_all_targets_callback(True))
         grid.addWidget(select_all_targets, 1, 0)
 
         select_no_targets = QPushButton("No Targets")
-        select_no_targets.clicked.connect(lambda: self._set_all_targets(False))
+        select_no_targets.clicked.connect(self._make_set_all_targets_callback(False))
         grid.addWidget(select_no_targets, 1, 1)
 
         for column, location in enumerate(location_order, start=2):
-            toggle_widget = QWidget()
-            toggle_layout = QHBoxLayout(toggle_widget)
-            toggle_layout.setContentsMargins(0, 0, 0, 0)
+            location_controls = self._build_location_bulk_controls(location.name)
+            grid.addWidget(location_controls, 1, column)
 
-            loc_all = QPushButton("All")
-            loc_all.clicked.connect(
-                lambda _checked=False, loc_name=location.name: (
-                    self._set_location_for_all(loc_name, True)
-                )
-            )
-            toggle_layout.addWidget(loc_all)
+    def _build_location_bulk_controls(self, location_name: str) -> QWidget:
+        controls_widget = QWidget()
+        controls_layout = QHBoxLayout(controls_widget)
+        controls_layout.setContentsMargins(0, 0, 0, 0)
 
-            loc_none = QPushButton("None")
-            loc_none.clicked.connect(
-                lambda _checked=False, loc_name=location.name: (
-                    self._set_location_for_all(loc_name, False)
-                )
-            )
-            toggle_layout.addWidget(loc_none)
+        enable_all = QPushButton("All")
+        enable_all.clicked.connect(
+            self._make_set_all_location_destinations_callback(location_name, True)
+        )
+        controls_layout.addWidget(enable_all)
 
-            grid.addWidget(toggle_widget, 1, column)
+        enable_none = QPushButton("None")
+        enable_none.clicked.connect(
+            self._make_set_all_location_destinations_callback(location_name, False)
+        )
+        controls_layout.addWidget(enable_none)
+        return controls_widget
 
+    def _add_targets_grid_rows(
+        self, grid: QGridLayout, location_order: list[SaveLocation]
+    ) -> None:
         for row, config in enumerate(self.shot_configs, start=2):
-            shot_toggle = QCheckBox()
-            shot_toggle.setChecked(True)
-            shot_toggle.toggled.connect(
-                lambda enabled, shot_id=config.id: self._set_shot_locations_enabled(
-                    shot_id, enabled
-                )
+            self._add_target_row(grid, row, config, location_order)
+
+    def _add_target_row(
+        self,
+        grid: QGridLayout,
+        row: int,
+        config: MShotDialogConfig,
+        location_order: list[SaveLocation],
+    ) -> None:
+        target_toggle = self._build_target_toggle(config.id)
+        self._enabled_shot_cbs[config.id] = target_toggle
+        grid.addWidget(target_toggle, row, 0, alignment=QtCore.Qt.AlignCenter)
+
+        target_label = ClickableQLabel(f"<b>{config.name}</b>", target_toggle)
+        target_label.clicked.connect(lambda cb=target_toggle: cb.click())
+        grid.addWidget(target_label, row, 1)
+
+        config_locations = {
+            location.name: (location, enabled) for location, enabled in config.save_locs
+        }
+        for column, location in enumerate(location_order, start=2):
+            location_data = config_locations.get(location.name)
+            if location_data is None:
+                placeholder = self._build_destination_placeholder()
+                grid.addWidget(placeholder, row, column)
+                continue
+
+            _, enabled_by_default = location_data
+            destination_toggle = self._build_destination_toggle(
+                config.id, location.name
             )
-            shot_toggle.toggled.connect(self._refresh_summary)
-            self._enabled_shot_cbs[config.id] = shot_toggle
-            grid.addWidget(shot_toggle, row, 0, alignment=QtCore.Qt.AlignCenter)
+            destination_toggle.setChecked(enabled_by_default)
+            grid.addWidget(
+                destination_toggle, row, column, alignment=QtCore.Qt.AlignCenter
+            )
 
-            shot_label = ClickableQLabel(f"<b>{config.name}</b>", shot_toggle)
-            shot_label.clicked.connect(lambda cb=shot_toggle: cb.click())
-            grid.addWidget(shot_label, row, 1)
+        self._set_shot_locations_enabled(config.id, target_toggle.isChecked())
 
-            config_locations = {
-                loc.name: (loc, enabled) for loc, enabled in config.save_locs
-            }
-            for column, location in enumerate(location_order, start=2):
-                location_config = config_locations.get(location.name)
-                if location_config is None:
-                    placeholder = QLabel("-")
-                    placeholder.setAlignment(QtCore.Qt.AlignCenter)
-                    placeholder.setEnabled(False)
-                    grid.addWidget(placeholder, row, column)
-                    continue
+    def _build_target_toggle(self, shot_id: str) -> QCheckBox:
+        target_toggle = QCheckBox()
+        target_toggle.setChecked(True)
+        target_toggle.toggled.connect(
+            self._make_set_shot_locations_enabled_callback(shot_id)
+        )
+        target_toggle.toggled.connect(self._refresh_summary)
+        return target_toggle
 
-                _, enabled_by_default = location_config
-                location_toggle = QCheckBox()
-                location_toggle.setChecked(enabled_by_default)
-                location_toggle.toggled.connect(self._refresh_summary)
-                self._enabled_loc_cbs[config.id][location.name] = location_toggle
-                grid.addWidget(
-                    location_toggle, row, column, alignment=QtCore.Qt.AlignCenter
-                )
+    def _build_destination_toggle(self, shot_id: str, location_name: str) -> QCheckBox:
+        destination_toggle = QCheckBox()
+        destination_toggle.toggled.connect(self._refresh_summary)
+        self._enabled_loc_cbs[shot_id][location_name] = destination_toggle
+        return destination_toggle
 
-            self._set_shot_locations_enabled(config.id, shot_toggle.isChecked())
+    @staticmethod
+    def _build_destination_placeholder() -> QLabel:
+        placeholder = QLabel("-")
+        placeholder.setAlignment(QtCore.Qt.AlignCenter)
+        placeholder.setEnabled(False)
+        return placeholder
 
-        scroll = QScrollArea()
-        scroll.setWidgetResizable(True)
-        scroll.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
-        scroll.setWidget(grid_container)
-        target_layout.addWidget(scroll)
-        self._main_layout.addWidget(target_group)
+    def _make_set_all_targets_callback(self, enabled: bool) -> Callable[[], None]:
+        def callback() -> None:
+            self._set_all_targets(enabled)
+
+        return callback
+
+    def _make_set_all_location_destinations_callback(
+        self, location_name: str, enabled: bool
+    ) -> Callable[[], None]:
+        def callback() -> None:
+            self._set_location_for_all(location_name, enabled)
+
+        return callback
+
+    def _make_set_shot_locations_enabled_callback(
+        self, shot_id: str
+    ) -> Callable[[bool], None]:
+        def callback(enabled: bool) -> None:
+            self._set_shot_locations_enabled(shot_id, enabled)
+
+        return callback
 
     def _build_context_section(self) -> None:
         self._context_group = QGroupBox("2. Shot Settings")
@@ -263,54 +333,71 @@ class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
         options_layout = QVBoxLayout(options_group)
 
         active_panel = self._resolve_active_model_panel()
+        options_layout.addWidget(self._build_viewport_options_widget(active_panel))
+        options_layout.addWidget(self._build_custom_folder_widget())
+        self._main_layout.addWidget(options_group)
 
+    def _build_viewport_options_widget(self, active_panel: str) -> QWidget:
         viewport_widget = QWidget()
         viewport_layout = QHBoxLayout(viewport_widget)
         viewport_layout.setContentsMargins(0, 0, 0, 0)
 
-        self._use_lighting = QCheckBox("Use Lighting")
-        self._use_lighting.setChecked(self._query_lighting(active_panel))
-        self._use_lighting.toggled.connect(self._refresh_summary)
+        self._use_lighting = self._build_option_checkbox(
+            "Use Lighting",
+            self._query_lighting(active_panel),
+        )
         viewport_layout.addWidget(self._use_lighting)
 
-        self._use_shadows = QCheckBox("Use Shadows")
-        self._use_shadows.setChecked(self._query_shadows(active_panel))
-        self._use_shadows.toggled.connect(self._refresh_summary)
+        self._use_shadows = self._build_option_checkbox(
+            "Use Shadows",
+            self._query_shadows(active_panel),
+        )
         viewport_layout.addWidget(self._use_shadows)
 
-        self._use_ssao = QCheckBox("Use Anti-aliasing")
-        self._use_ssao.setChecked(self._query_ssao())
-        self._use_ssao.toggled.connect(self._refresh_summary)
+        self._use_ssao = self._build_option_checkbox(
+            "Use Anti-aliasing",
+            self._query_ssao(),
+        )
         viewport_layout.addWidget(self._use_ssao)
 
-        self._use_hardware_fog = QCheckBox("Use Hardware Fog")
-        self._use_hardware_fog.setChecked(self._query_hardware_fog(active_panel))
-        self._use_hardware_fog.toggled.connect(self._refresh_summary)
+        self._use_hardware_fog = self._build_option_checkbox(
+            "Use Hardware Fog",
+            self._query_hardware_fog(active_panel),
+        )
         viewport_layout.addWidget(self._use_hardware_fog)
 
-        self._use_dof = QCheckBox("Use DoF")
-        self._use_dof.setChecked(self._query_dof(active_panel))
-        self._use_dof.toggled.connect(self._refresh_summary)
+        self._use_dof = self._build_option_checkbox(
+            "Use DoF",
+            self._query_dof(active_panel),
+        )
         viewport_layout.addWidget(self._use_dof)
+        return viewport_widget
 
-        options_layout.addWidget(viewport_widget)
-
+    def _build_custom_folder_widget(self) -> QWidget:
         custom_folder_widget = QWidget()
         custom_folder_layout = QHBoxLayout(custom_folder_widget)
         custom_folder_layout.setContentsMargins(0, 0, 0, 0)
 
         self._custom_folder_field = QLineEdit()
         self._custom_folder_field.setReadOnly(True)
-        self._custom_folder_field.setText(os.getenv("TMPDIR", os.getenv("TEMP", "tmp")))
+        self._custom_folder_field.setText(self._default_custom_folder_path())
         self._custom_folder_field.textChanged.connect(self._refresh_summary)
         custom_folder_layout.addWidget(self._custom_folder_field)
 
         browse_button = QPushButton("Browse Custom Folder")
         browse_button.clicked.connect(self._set_custom_folder)
         custom_folder_layout.addWidget(browse_button)
+        return custom_folder_widget
 
-        options_layout.addWidget(custom_folder_widget)
-        self._main_layout.addWidget(options_group)
+    def _build_option_checkbox(self, label: str, enabled_by_default: bool) -> QCheckBox:
+        option_toggle = QCheckBox(label)
+        option_toggle.setChecked(enabled_by_default)
+        option_toggle.toggled.connect(self._refresh_summary)
+        return option_toggle
+
+    @staticmethod
+    def _default_custom_folder_path() -> str:
+        return os.getenv("TMPDIR", os.getenv("TEMP", "tmp"))
 
     def _build_summary_section(self) -> None:
         summary_group = QGroupBox("4. Export Summary")
@@ -433,38 +520,45 @@ class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
 
     def _refresh_summary(self, *_args) -> None:
         lines: list[str] = []
+        lines.extend(self._summary_target_lines())
+        lines.append("")
+        lines.extend(self._summary_render_option_lines())
+        self._summary_field.setPlainText("\n".join(lines))
 
+    def _summary_target_lines(self) -> list[str]:
+        lines: list[str] = []
         enabled_configs = [
-            cfg for cfg in self.shot_configs if self.is_shot_enabled(cfg.id)
+            config for config in self.shot_configs if self.is_shot_enabled(config.id)
         ]
         if not enabled_configs:
             lines.append("No targets selected.")
-        else:
-            lines.append("Selected targets:")
-            for config in enabled_configs:
-                lines.append(f"- {config.name}")
+            return lines
 
-                enabled_locations = [
-                    location
-                    for location in self._save_locs_by_shot[config.id]
-                    if self.is_location_enabled(config.id, location.name)
-                ]
-                if not enabled_locations:
-                    lines.append("  (no destination selected)")
-                    continue
+        lines.append("Selected targets:")
+        for config in enabled_configs:
+            lines.append(f"- {config.name}")
+            enabled_locations = [
+                location
+                for location in self._save_locs_by_shot[config.id]
+                if self.is_location_enabled(config.id, location.name)
+            ]
+            if not enabled_locations:
+                lines.append("  (no destination selected)")
+                continue
 
-                for location in enabled_locations:
-                    lines.append(f"  -> {location.name}: {location.path}")
+            for location in enabled_locations:
+                lines.append(f"  -> {location.name}: {location.path}")
+        return lines
 
-        lines.append("")
-        lines.append("Viewport options:")
-        lines.append(f"- Lighting: {'On' if self.use_lighting else 'Off'}")
-        lines.append(f"- Shadows: {'On' if self.use_shadows else 'Off'}")
-        lines.append(f"- Anti-aliasing: {'On' if self.use_ssao else 'Off'}")
-        lines.append(f"- Hardware Fog: {'On' if self.use_hardware_fog else 'Off'}")
-        lines.append(f"- Depth of Field: {'On' if self.use_dof else 'Off'}")
-
-        self._summary_field.setPlainText("\n".join(lines))
+    def _summary_render_option_lines(self) -> list[str]:
+        return [
+            "Viewport options:",
+            f"- Lighting: {'On' if self.use_lighting else 'Off'}",
+            f"- Shadows: {'On' if self.use_shadows else 'Off'}",
+            f"- Anti-aliasing: {'On' if self.use_ssao else 'Off'}",
+            f"- Hardware Fog: {'On' if self.use_hardware_fog else 'Off'}",
+            f"- Depth of Field: {'On' if self.use_dof else 'Off'}",
+        ]
 
     def save_locations_to_paths(
         self, dialog_id: str, locs: Iterable[SaveLocation], filename: str

--- a/pipeline/pipe/m/playblast/ui.py
+++ b/pipeline/pipe/m/playblast/ui.py
@@ -693,6 +693,17 @@ class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
                 )
         return None
 
+    def _after_local_playblast(
+        self,
+        config: MPlayblastConfig,
+    ) -> list[str]:
+        """Run optional tool-specific actions after local playblast succeeds.
+
+        Returned lines are appended to the success dialog.
+        """
+        del config
+        return []
+
     def do_export(self) -> None:
         try:
             config = self._generate_config()
@@ -721,9 +732,18 @@ class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
             ).exec_()
             return
 
+        post_playblast_messages: list[str] = []
+        try:
+            post_playblast_messages = self._after_local_playblast(config)
+        except Exception as exc:
+            log.exception("Post-playblast actions failed")
+            post_playblast_messages = [f"Post-playblast actions failed: {exc}"]
+
         output_paths = self._collect_output_paths(config)
         success_msg = "Playblast(s) successful!"
         if output_paths:
             success_msg += "\n\nOutputs:\n" + "\n".join(output_paths)
+        if post_playblast_messages:
+            success_msg += "\n\n" + "\n".join(post_playblast_messages)
         MessageDialog(self.parent(), success_msg).exec_()
         self.close()

--- a/pipeline/pipe/m/playblast/ui.py
+++ b/pipeline/pipe/m/playblast/ui.py
@@ -9,18 +9,34 @@ from typing import TYPE_CHECKING
 
 import maya.cmds as mc
 from Qt import QtCore, QtWidgets
-from Qt.QtWidgets import QCheckBox, QHBoxLayout, QLabel, QWidget
+from Qt.QtWidgets import (
+    QCheckBox,
+    QGridLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPlainTextEdit,
+    QPushButton,
+    QScrollArea,
+    QVBoxLayout,
+    QWidget,
+)
 
 from pipe.glui.dialogs import ButtonPair, MessageDialog
-from pipe.util import Playblaster, checkbox_callback_helper
+from pipe.util import Playblaster
 
 from .playblaster import MPlayblaster
 from .struct import HudDefinition, SaveLocation
 
 if TYPE_CHECKING:
-    from typing import Callable, Iterable
+    from typing import Iterable
 
-    from .struct import MPlayblastConfig, MShotDialogConfig, MShotPlayblastConfig
+    from .struct import (
+        MPlayblastConfig,
+        MShotDialogConfig,
+        MShotPlayblastConfig,
+    )
 
 log = logging.getLogger(__name__)
 
@@ -28,21 +44,22 @@ log = logging.getLogger(__name__)
 class ClickableQLabel(QLabel):
     clicked = QtCore.Signal()
 
-    def mousePressEvent(self, ev):
+    def mousePressEvent(self, _event):  # type: ignore[override]
         self.clicked.emit()
 
 
 class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
-    """Dialog for a generic Maya playblaster. To subclass:
-    - subclass SAVE_LOCS as necessary to add more locations
-    - define a `_generate_config` function
-    """
+    """Shared Maya playblast dialog with clear target selection and export summary."""
 
     _central_widget: QWidget
-    _custom_folder_text: QLabel
+    _context_group: QGroupBox
+    _context_layout: QVBoxLayout
+    _custom_folder_field: QLineEdit
     _enabled_loc_cbs: dict[str, dict[str, QCheckBox]]
     _enabled_shot_cbs: dict[str, QCheckBox]
-    _main_layout: QtWidgets.QLayout
+    _main_layout: QVBoxLayout
+    _save_locs_by_shot: dict[str, list[SaveLocation]]
+    _summary_field: QPlainTextEdit
     _use_dof: QCheckBox
     _use_hardware_fog: QCheckBox
     _use_lighting: QCheckBox
@@ -56,7 +73,7 @@ class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
         CUSTOM = SaveLocation("Custom Folder", "", Playblaster.PRESET.WEB)
         CURRENT = SaveLocation(
             "Current Folder",
-            Path(mc.file(query=True, sceneName=True)).parent,  # type: ignore[arg-type]
+            lambda: Path(str(mc.file(query=True, sceneName=True) or ".")).parent,
             Playblaster.PRESET.WEB,
         )
 
@@ -90,177 +107,309 @@ class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
         windowTitle: str = "LnD Playblast",
     ) -> None:
         super().__init__(parent, windowTitle=windowTitle)
-        # initialize SAVE_LOCS custom path
-        self.SAVE_LOCS.CUSTOM._path = lambda: self._custom_folder_text.text()
-
-        # initialize other values
         self.shot_configs = shot_configs
-        self._enabled_shot_cbs = dict()
+        self._enabled_shot_cbs = {}
         self._enabled_loc_cbs = defaultdict(dict)
+        self._save_locs_by_shot = {
+            cfg.id: [loc for loc, _ in cfg.save_locs] for cfg in self.shot_configs
+        }
+
         self._setup_ui()
+        self.SAVE_LOCS.CUSTOM._path = lambda: self._custom_folder_field.text()
+        self._refresh_summary()
 
     def _setup_ui(self) -> None:
-        # set up main layout
         self._central_widget = QWidget()
         self.setCentralWidget(self._central_widget)
-        self._main_layout = QtWidgets.QVBoxLayout()
+        self._main_layout = QVBoxLayout()
         self._central_widget.setLayout(self._main_layout)
 
-        # title
-        title = QLabel("Playblast")
+        self._build_header_section()
+        self._build_target_section()
+        self._build_context_section()
+        self._build_render_options_section()
+        self._build_summary_section()
+        self._build_buttons()
+
+    def _build_header_section(self) -> None:
+        title = QLabel("Playblast Export")
         title.setAlignment(QtCore.Qt.AlignCenter)
-        title.setStyleSheet("font-size: 30px; font-weight: bold;")
-        self._main_layout.addWidget(title, 0)
+        title.setStyleSheet("font-size: 24px; font-weight: 700;")
 
-        # iterate over shot configs and add them to the table
-        playblasts_layout = QtWidgets.QGridLayout()
-        for idx, pb in enumerate(self.shot_configs):
-            # create shot enable checkbox
-            shot_enable_cb_widget = QWidget()
-            shot_enable_cb_layout = QHBoxLayout(shot_enable_cb_widget)
-            self._enabled_shot_cbs[pb.id] = QCheckBox()
-            cb = self._enabled_shot_cbs[pb.id]
-            cb.setChecked(True)
-            shot_enable_cb_layout.addWidget(cb)
-
-            shot_label = ClickableQLabel(f"<b>{pb.name}</b>", cb)
-            shot_label.clicked.connect(self._click_checkbox(cb))
-            shot_enable_cb_layout.addWidget(shot_label)
-            playblasts_layout.addWidget(shot_enable_cb_widget, idx + 1, 0, 1, 1)
-
-            # disable the output checkboxes when the shot is disabled
-            outputs_container = QWidget()
-            cb.toggled.connect(checkbox_callback_helper(cb, outputs_container))
-            outputs_layout = QHBoxLayout(outputs_container)
-            playblasts_layout.addWidget(outputs_container, idx + 1, 1, 1, 1)
-
-            # create the location checkboxes
-            for location, enabled_by_default in pb.save_locs:
-                loc_cb = QCheckBox(location.name)
-                loc_cb.setChecked(enabled_by_default)
-                self._enabled_loc_cbs[pb.id][location.name] = loc_cb
-                outputs_layout.addWidget(loc_cb)
-
-            playblasts_layout.addWidget(outputs_container, idx + 1, 2, 1, 1)
-
-        # Create check all/none buttons
-        shots_toggle_container = QWidget()
-        shots_toggle_container.setStyleSheet("margin: 0; padding: 0;")
-        shots_toggle_layout = QHBoxLayout(shots_toggle_container)
-        shots_all = QtWidgets.QPushButton("All", self)
-        shots_all.clicked.connect(
-            lambda: [
-                cb.setChecked(True)  # type: ignore[func-returns-value]
-                for cb in self._enabled_shot_cbs.values()
-                if cb.isEnabled()
-            ]
+        subtitle = QLabel(
+            "Select targets, choose destinations, and verify outputs before exporting."
         )
-        shots_toggle_layout.addWidget(shots_all)
-        shots_none = QtWidgets.QPushButton("None", self)
-        shots_none.clicked.connect(
-            lambda: [
-                cb.setChecked(False)  # type: ignore[func-returns-value]
-                for cb in self._enabled_shot_cbs.values()
-                if cb.isEnabled()
-            ]
-        )
-        shots_toggle_layout.addWidget(shots_none)
+        subtitle.setAlignment(QtCore.Qt.AlignCenter)
+        subtitle.setStyleSheet("color: #666;")
 
-        outputs_toggle_container = QWidget()
-        outputs_toggle_layout = QHBoxLayout(outputs_toggle_container)
-        for loc, _ in pb.save_locs:
-            loc_toggle_container = QWidget()
-            loc_toggle_container.setStyleSheet("margin: 0; padding: 0;")
-            loc_toggle_layout = QHBoxLayout(loc_toggle_container)
-            loc_all = QtWidgets.QPushButton("All", self)
+        self._main_layout.addWidget(title)
+        self._main_layout.addWidget(subtitle)
+
+    def _build_target_section(self) -> None:
+        target_group = QGroupBox("1. Targets and Destinations")
+        target_layout = QVBoxLayout(target_group)
+
+        description = QLabel(
+            "Enable each target you want to export, then select one or more destinations."
+        )
+        description.setStyleSheet("color: #666;")
+        target_layout.addWidget(description)
+
+        grid_container = QWidget()
+        grid = QGridLayout(grid_container)
+        grid.setHorizontalSpacing(12)
+        grid.setVerticalSpacing(8)
+
+        location_order = self._collect_location_order()
+        grid.addWidget(QLabel("Export"), 0, 0)
+        grid.addWidget(QLabel("Target"), 0, 1)
+
+        for column, location in enumerate(location_order, start=2):
+            header = QLabel(f"{location.name}\n(*.{location.preset.ext})")
+            header.setAlignment(QtCore.Qt.AlignCenter)
+            grid.addWidget(header, 0, column)
+
+        select_all_targets = QPushButton("All Targets")
+        select_all_targets.clicked.connect(lambda: self._set_all_targets(True))
+        grid.addWidget(select_all_targets, 1, 0)
+
+        select_no_targets = QPushButton("No Targets")
+        select_no_targets.clicked.connect(lambda: self._set_all_targets(False))
+        grid.addWidget(select_no_targets, 1, 1)
+
+        for column, location in enumerate(location_order, start=2):
+            toggle_widget = QWidget()
+            toggle_layout = QHBoxLayout(toggle_widget)
+            toggle_layout.setContentsMargins(0, 0, 0, 0)
+
+            loc_all = QPushButton("All")
             loc_all.clicked.connect(
-                self._set_checkboxes(self._enabled_loc_cbs.values(), loc.name, True)
+                lambda _checked=False, loc_name=location.name: (
+                    self._set_location_for_all(loc_name, True)
+                )
             )
-            loc_toggle_layout.addWidget(loc_all)
-            loc_none = QtWidgets.QPushButton("None", self)
+            toggle_layout.addWidget(loc_all)
+
+            loc_none = QPushButton("None")
             loc_none.clicked.connect(
-                self._set_checkboxes(self._enabled_loc_cbs.values(), loc.name, False)
+                lambda _checked=False, loc_name=location.name: (
+                    self._set_location_for_all(loc_name, False)
+                )
             )
-            loc_toggle_layout.addWidget(loc_none)
-            outputs_toggle_layout.addWidget(loc_toggle_container)
+            toggle_layout.addWidget(loc_none)
 
-        playblasts_layout.addWidget(shots_toggle_container, 0, 0, 1, 1)
-        playblasts_layout.addWidget(outputs_toggle_container, 0, 1)
+            grid.addWidget(toggle_widget, 1, column)
 
-        # configure playblast widget group
-        playblasts_widget = QWidget()
-        playblasts_widget.setLayout(playblasts_layout)
-        playblasts_scroll_area = QtWidgets.QScrollArea()
-        playblasts_scroll_area.setHorizontalScrollBarPolicy(
-            QtCore.Qt.ScrollBarAlwaysOff
-        )
-        playblasts_scroll_area.setWidget(playblasts_widget)
-        playblasts_scroll_area.setWidgetResizable(True)
-        self._main_layout.addWidget(playblasts_scroll_area)
+        for row, config in enumerate(self.shot_configs, start=2):
+            shot_toggle = QCheckBox()
+            shot_toggle.setChecked(True)
+            shot_toggle.toggled.connect(
+                lambda enabled, shot_id=config.id: self._set_shot_locations_enabled(
+                    shot_id, enabled
+                )
+            )
+            shot_toggle.toggled.connect(self._refresh_summary)
+            self._enabled_shot_cbs[config.id] = shot_toggle
+            grid.addWidget(shot_toggle, row, 0, alignment=QtCore.Qt.AlignCenter)
 
-        # create lighting, shadow, ssao toggles
-        active_editor = str(mc.sequenceManager(query=True, modelPanel=True))
-        toggles_layout = QHBoxLayout()
-        toggles_widget = QWidget()
-        toggles_widget.setLayout(toggles_layout)
+            shot_label = ClickableQLabel(f"<b>{config.name}</b>", shot_toggle)
+            shot_label.clicked.connect(lambda cb=shot_toggle: cb.click())
+            grid.addWidget(shot_label, row, 1)
+
+            config_locations = {
+                loc.name: (loc, enabled) for loc, enabled in config.save_locs
+            }
+            for column, location in enumerate(location_order, start=2):
+                location_config = config_locations.get(location.name)
+                if location_config is None:
+                    placeholder = QLabel("-")
+                    placeholder.setAlignment(QtCore.Qt.AlignCenter)
+                    placeholder.setEnabled(False)
+                    grid.addWidget(placeholder, row, column)
+                    continue
+
+                _, enabled_by_default = location_config
+                location_toggle = QCheckBox()
+                location_toggle.setChecked(enabled_by_default)
+                location_toggle.toggled.connect(self._refresh_summary)
+                self._enabled_loc_cbs[config.id][location.name] = location_toggle
+                grid.addWidget(
+                    location_toggle, row, column, alignment=QtCore.Qt.AlignCenter
+                )
+
+            self._set_shot_locations_enabled(config.id, shot_toggle.isChecked())
+
+        scroll = QScrollArea()
+        scroll.setWidgetResizable(True)
+        scroll.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
+        scroll.setWidget(grid_container)
+        target_layout.addWidget(scroll)
+        self._main_layout.addWidget(target_group)
+
+    def _build_context_section(self) -> None:
+        self._context_group = QGroupBox("2. Shot Settings")
+        self._context_layout = QVBoxLayout()
+        self._context_layout.setContentsMargins(8, 8, 8, 8)
+        self._context_group.setLayout(self._context_layout)
+        self._context_group.setVisible(False)
+        self._main_layout.addWidget(self._context_group)
+
+    def add_context_widget(self, widget: QWidget) -> None:
+        self._context_group.setVisible(True)
+        self._context_layout.addWidget(widget)
+
+    def _build_render_options_section(self) -> None:
+        options_group = QGroupBox("3. Render Options")
+        options_layout = QVBoxLayout(options_group)
+
+        active_panel = self._resolve_active_model_panel()
+
+        viewport_widget = QWidget()
+        viewport_layout = QHBoxLayout(viewport_widget)
+        viewport_layout.setContentsMargins(0, 0, 0, 0)
+
         self._use_lighting = QCheckBox("Use Lighting")
-        self._use_lighting.setChecked(
-            mc.modelEditor(active_editor, query=True, displayLights=True) == "all"
-        )
-        toggles_layout.addWidget(self._use_lighting)
+        self._use_lighting.setChecked(self._query_lighting(active_panel))
+        self._use_lighting.toggled.connect(self._refresh_summary)
+        viewport_layout.addWidget(self._use_lighting)
+
         self._use_shadows = QCheckBox("Use Shadows")
-        self._use_shadows.setChecked(
-            bool(mc.modelEditor(active_editor, query=True, shadows=True))
-        )
-        toggles_layout.addWidget(self._use_shadows)
+        self._use_shadows.setChecked(self._query_shadows(active_panel))
+        self._use_shadows.toggled.connect(self._refresh_summary)
+        viewport_layout.addWidget(self._use_shadows)
+
         self._use_ssao = QCheckBox("Use Anti-aliasing")
-        self._use_ssao.setChecked(
-            bool(mc.getAttr("hardwareRenderingGlobals.ssaoEnable"))
-        )
-        toggles_layout.addWidget(self._use_ssao)
+        self._use_ssao.setChecked(self._query_ssao())
+        self._use_ssao.toggled.connect(self._refresh_summary)
+        viewport_layout.addWidget(self._use_ssao)
+
         self._use_hardware_fog = QCheckBox("Use Hardware Fog")
-        self._use_hardware_fog.setChecked(
-            bool(mc.modelEditor(active_editor, query=True, fogging=True))
-        )
-        toggles_layout.addWidget(self._use_hardware_fog)
+        self._use_hardware_fog.setChecked(self._query_hardware_fog(active_panel))
+        self._use_hardware_fog.toggled.connect(self._refresh_summary)
+        viewport_layout.addWidget(self._use_hardware_fog)
+
         self._use_dof = QCheckBox("Use DoF")
-        camera = str(
-            mc.modelEditor(active_editor, query=True, activeView=True, camera=True)
-        )
-        self._use_dof.setChecked(bool(mc.camera(camera, query=True, depthOfField=True)))
-        toggles_layout.addWidget(self._use_dof)
-        self._main_layout.addWidget(toggles_widget)
+        self._use_dof.setChecked(self._query_dof(active_panel))
+        self._use_dof.toggled.connect(self._refresh_summary)
+        viewport_layout.addWidget(self._use_dof)
 
-        # custom folder prompt
-        custom_folder_layout = QHBoxLayout()
-        self._custom_folder_text = QLabel(os.getenv("TMPDIR", os.getenv("TEMP", "tmp")))
-        custom_folder_button = QtWidgets.QPushButton(text="Set Custom Folder")
-        custom_folder_button.clicked.connect(self._set_custom_folder)
-        custom_folder_layout.addWidget(self._custom_folder_text)
-        custom_folder_layout.addWidget(custom_folder_button)
-        self._main_layout.addLayout(custom_folder_layout)
+        options_layout.addWidget(viewport_widget)
 
+        custom_folder_widget = QWidget()
+        custom_folder_layout = QHBoxLayout(custom_folder_widget)
+        custom_folder_layout.setContentsMargins(0, 0, 0, 0)
+
+        self._custom_folder_field = QLineEdit()
+        self._custom_folder_field.setReadOnly(True)
+        self._custom_folder_field.setText(os.getenv("TMPDIR", os.getenv("TEMP", "tmp")))
+        self._custom_folder_field.textChanged.connect(self._refresh_summary)
+        custom_folder_layout.addWidget(self._custom_folder_field)
+
+        browse_button = QPushButton("Browse Custom Folder")
+        browse_button.clicked.connect(self._set_custom_folder)
+        custom_folder_layout.addWidget(browse_button)
+
+        options_layout.addWidget(custom_folder_widget)
+        self._main_layout.addWidget(options_group)
+
+    def _build_summary_section(self) -> None:
+        summary_group = QGroupBox("4. Export Summary")
+        summary_layout = QVBoxLayout(summary_group)
+
+        self._summary_field = QPlainTextEdit()
+        self._summary_field.setReadOnly(True)
+        self._summary_field.setMinimumHeight(150)
+        summary_layout.addWidget(self._summary_field)
+
+        self._main_layout.addWidget(summary_group)
+
+    def _build_buttons(self) -> None:
         self._init_buttons(has_cancel_button=True, ok_name="Playblast")
         self.buttons.rejected.connect(self.close)
         self.buttons.accepted.connect(self.do_export)
         self._main_layout.addWidget(self.buttons)
 
+    def _collect_location_order(self) -> list[SaveLocation]:
+        ordered_locations: list[SaveLocation] = []
+        seen_names: set[str] = set()
+
+        for config in self.shot_configs:
+            for location, _enabled in config.save_locs:
+                if location.name in seen_names:
+                    continue
+                seen_names.add(location.name)
+                ordered_locations.append(location)
+        return ordered_locations
+
+    def _set_all_targets(self, enabled: bool) -> None:
+        for checkbox in self._enabled_shot_cbs.values():
+            if checkbox.isEnabled():
+                checkbox.setChecked(enabled)
+
+    def _set_location_for_all(self, location_name: str, enabled: bool) -> None:
+        for location_map in self._enabled_loc_cbs.values():
+            checkbox = location_map.get(location_name)
+            if checkbox is not None:
+                checkbox.setChecked(enabled)
+
+    def _set_shot_locations_enabled(self, shot_id: str, enabled: bool) -> None:
+        for checkbox in self._enabled_loc_cbs.get(shot_id, {}).values():
+            checkbox.setEnabled(enabled)
+
     @staticmethod
-    def _click_checkbox(checkbox: QCheckBox) -> Callable[[], None]:
-        def inner() -> None:
-            checkbox.click()
+    def _resolve_active_model_panel() -> str:
+        panel = str(mc.sequenceManager(query=True, modelPanel=True) or "")
+        if panel and mc.modelPanel(panel, exists=True):
+            return panel
 
-        return inner
+        model_panels = mc.getPanel(type="modelPanel") or []
+        if model_panels:
+            return str(model_panels[0])
+        return ""
 
     @staticmethod
-    def _set_checkboxes(
-        checkboxes_index: Iterable[dict[str, QCheckBox]], loc: str, val: bool
-    ) -> Callable[[], None]:
-        def inner() -> None:
-            for cbi in checkboxes_index:
-                cbi[loc].setChecked(val)
+    def _query_lighting(panel: str) -> bool:
+        if not panel:
+            return False
+        try:
+            return mc.modelEditor(panel, query=True, displayLights=True) == "all"
+        except Exception:
+            return False
 
-        return inner
+    @staticmethod
+    def _query_shadows(panel: str) -> bool:
+        if not panel:
+            return False
+        try:
+            return bool(mc.modelEditor(panel, query=True, shadows=True))
+        except Exception:
+            return False
+
+    @staticmethod
+    def _query_ssao() -> bool:
+        try:
+            return bool(mc.getAttr("hardwareRenderingGlobals.ssaoEnable"))
+        except Exception:
+            return False
+
+    @staticmethod
+    def _query_hardware_fog(panel: str) -> bool:
+        if not panel:
+            return False
+        try:
+            return bool(mc.modelEditor(panel, query=True, fogging=True))
+        except Exception:
+            return False
+
+    @staticmethod
+    def _query_dof(panel: str) -> bool:
+        if not panel:
+            return False
+        try:
+            camera = str(mc.modelEditor(panel, query=True, camera=True))
+            return bool(mc.camera(camera, query=True, depthOfField=True))
+        except Exception:
+            return False
 
     @property
     def use_dof(self) -> bool:
@@ -282,19 +431,58 @@ class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
     def use_ssao(self) -> bool:
         return self._use_ssao.isChecked()
 
+    def _refresh_summary(self, *_args) -> None:
+        lines: list[str] = []
+
+        enabled_configs = [
+            cfg for cfg in self.shot_configs if self.is_shot_enabled(cfg.id)
+        ]
+        if not enabled_configs:
+            lines.append("No targets selected.")
+        else:
+            lines.append("Selected targets:")
+            for config in enabled_configs:
+                lines.append(f"- {config.name}")
+
+                enabled_locations = [
+                    location
+                    for location in self._save_locs_by_shot[config.id]
+                    if self.is_location_enabled(config.id, location.name)
+                ]
+                if not enabled_locations:
+                    lines.append("  (no destination selected)")
+                    continue
+
+                for location in enabled_locations:
+                    lines.append(f"  -> {location.name}: {location.path}")
+
+        lines.append("")
+        lines.append("Viewport options:")
+        lines.append(f"- Lighting: {'On' if self.use_lighting else 'Off'}")
+        lines.append(f"- Shadows: {'On' if self.use_shadows else 'Off'}")
+        lines.append(f"- Anti-aliasing: {'On' if self.use_ssao else 'Off'}")
+        lines.append(f"- Hardware Fog: {'On' if self.use_hardware_fog else 'Off'}")
+        lines.append(f"- Depth of Field: {'On' if self.use_dof else 'Off'}")
+
+        self._summary_field.setPlainText("\n".join(lines))
+
     def save_locations_to_paths(
         self, dialog_id: str, locs: Iterable[SaveLocation], filename: str
     ) -> dict[Playblaster.PRESET, list[str | Path]]:
         paths: dict[Playblaster.PRESET, list[str | Path]] = defaultdict(list)
-        for loc in locs:
-            if self.is_location_enabled(dialog_id, loc.name):
-                output_base = Path(str(loc.path)) / filename
-                paths[loc.preset].append(str(output_base))
+        for location in locs:
+            if not self.is_location_enabled(dialog_id, location.name):
+                continue
 
+            destination_dir = str(location.path).strip()
+            if not destination_dir:
+                continue
+
+            output_base = Path(destination_dir) / filename
+            paths[location.preset].append(str(output_base))
         return paths
 
     def _set_custom_folder(self) -> None:
-        """Prompt user to select a custom folder for saving"""
         path_list = mc.fileDialog2(
             caption="Select a custom playblast folder",
             fileMode=2,
@@ -303,19 +491,22 @@ class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
             setProjectBtnEnabled=False,
         )
         if path_list:
-            path = path_list[0]
-            self._custom_folder_text.setText(path)
+            self._custom_folder_field.setText(path_list[0])
 
     @abstractmethod
     def _generate_config(self) -> MPlayblastConfig:
-        pass
+        raise NotImplementedError
 
     def is_shot_enabled(self, dialog_id: str) -> bool:
-        """Takes an MShotDialogConfig id and returns if it's enabled"""
-        return self._enabled_shot_cbs[dialog_id].isChecked()
+        checkbox = self._enabled_shot_cbs.get(dialog_id)
+        return bool(checkbox and checkbox.isChecked())
 
     def is_location_enabled(self, dialog_id: str, loc_name: str) -> bool:
-        return self._enabled_loc_cbs[dialog_id][loc_name].isChecked()
+        location_map = self._enabled_loc_cbs.get(dialog_id)
+        if not location_map:
+            return False
+        checkbox = location_map.get(loc_name)
+        return bool(checkbox and checkbox.isChecked())
 
     @staticmethod
     def _output_count_for_shot(shot_cfg: MShotPlayblastConfig) -> int:
@@ -342,7 +533,7 @@ class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
                 )
         return None
 
-    def do_export(self):
+    def do_export(self) -> None:
         try:
             config = self._generate_config()
         except Exception as exc:

--- a/pipeline/pipe/m/playblast/ui.py
+++ b/pipeline/pipe/m/playblast/ui.py
@@ -5,12 +5,15 @@ import os
 from abc import abstractmethod
 from collections import defaultdict
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import maya.cmds as mc
+from env_sg import DB_Config
 from Qt import QtCore, QtWidgets
 from Qt.QtWidgets import (
     QCheckBox,
+    QComboBox,
+    QDialogButtonBox,
     QGridLayout,
     QGroupBox,
     QHBoxLayout,
@@ -18,24 +21,36 @@ from Qt.QtWidgets import (
     QLineEdit,
     QPlainTextEdit,
     QPushButton,
-    QScrollArea,
+    QSpinBox,
+    QTabWidget,
     QVBoxLayout,
     QWidget,
 )
 
+from pipe.db import DB
 from pipe.glui.dialogs import ButtonPair, MessageDialog
 from pipe.playblast_artist import resolve_artist_display_name
+from pipe.playblast_naming import (
+    resolve_versioned_playblast_basename,
+)
+from pipe.playblast_shotgrid import (
+    PlayblastVersionUploadRequest,
+    default_version_name_from_movie_path,
+    resolve_preferred_upload_movie_path,
+    upload_playblast_version,
+)
 from pipe.util import Playblaster
 
 from .playblaster import MPlayblaster
-from .struct import HudDefinition, SaveLocation
+from .struct import HudDefinition, SaveLocation, dummy_shot
 
 if TYPE_CHECKING:
     from typing import Callable, Iterable
 
+    from pipe.struct.db import Shot
+
     from .struct import (
         MPlayblastConfig,
-        MShotDialogConfig,
         MShotPlayblastConfig,
     )
 
@@ -51,7 +66,7 @@ class ClickableQLabel(QLabel):
 
 
 class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
-    """Shared Maya playblast dialog.
+    """Shared Maya playblast dialog using a Tabbed interface.
 
     The dialog is intentionally organized into linear sections so artists can
     understand and configure exports quickly:
@@ -62,22 +77,34 @@ class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
     """
 
     _central_widget: QWidget
-    _context_group: QGroupBox
-    _context_layout: QVBoxLayout
-    _custom_folder_field: QLineEdit
-    _enabled_loc_cbs: dict[str, dict[str, QCheckBox]]
-    _enabled_shot_cbs: dict[str, QCheckBox]
     _main_layout: QVBoxLayout
-    _save_locs_by_shot: dict[str, list[SaveLocation]]
-    _summary_field: QPlainTextEdit
+    _custom_camera: QComboBox
+    _custom_folder_row: QWidget
+    _custom_in: QSpinBox
+    _custom_out: QSpinBox
+    _destination_checkboxes: dict[str, QCheckBox]
+    _destination_path_labels: dict[str, QLabel]
+    _save_locations_by_name: dict[str, SaveLocation]
+    _shot_camera_widget: QWidget
+    _shot_code_value: QLabel
+    _shotgrid_description_field: QLineEdit
+    _shotgrid_description_row: QWidget
+    _shotgrid_upload_checkbox: QCheckBox
+    _shot_range_value: QLabel
+    _source_tabs: QTabWidget
+    _validation_label: QLabel
     _use_dof: QCheckBox
     _use_hardware_fog: QCheckBox
     _use_lighting: QCheckBox
     _use_shadows: QCheckBox
     _use_ssao: QCheckBox
+    _shot: Shot | None
+    _custom_folder_field: QLineEdit
+
+    SHOT_TAB_INDEX = 0
+    CUSTOM_TAB_INDEX: int
 
     playblaster = MPlayblaster()
-    shot_configs: list[MShotDialogConfig]
 
     class SAVE_LOCS:
         CUSTOM = SaveLocation("Custom Folder", "", Playblaster.PRESET.WEB)
@@ -113,20 +140,20 @@ class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
     def __init__(
         self,
         parent: QWidget | None,
-        shot_configs: list[MShotDialogConfig],
-        windowTitle: str = "LnD Playblast",
+        shot_configs: list[Any] = None,  # Used by legacy UI, kept for sig compat
+        windowTitle: str = "Playblast",
     ) -> None:
         super().__init__(parent, windowTitle=windowTitle)
-        self.shot_configs = shot_configs
-        self._enabled_shot_cbs = {}
-        self._enabled_loc_cbs = defaultdict(dict)
-        self._save_locs_by_shot = {
-            cfg.id: [loc for loc, _ in cfg.save_locs] for cfg in self.shot_configs
+        self._shot = self._resolve_pipeline_shot_context()
+        self._destination_checkboxes = {}
+        self._destination_path_labels = {}
+        self._save_locations_by_name = {
+            location.name: location for location in self._destination_locations()
         }
 
         self._setup_ui()
         self.SAVE_LOCS.CUSTOM._path = lambda: self._custom_folder_field.text()
-        self._refresh_summary()
+        self._update_ui_state()
 
     def _setup_ui(self) -> None:
         self._central_widget = QWidget()
@@ -136,206 +163,247 @@ class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
 
         self._build_header_section()
         self._build_targets_section()
-        self._build_context_section()
         self._build_render_options_section()
-        self._build_summary_section()
         self._build_buttons()
+        self._set_default_source_tab()
 
     def _build_header_section(self) -> None:
-        title = QLabel("Playblast Export")
-        title.setAlignment(QtCore.Qt.AlignCenter)
+        title = QLabel(self.windowTitle())
         title.setStyleSheet("font-size: 24px; font-weight: 700;")
+        title.setAlignment(QtCore.Qt.AlignCenter)
 
-        subtitle = QLabel(
-            "Select targets, choose destinations, and verify outputs before exporting."
-        )
+        subtitle = QLabel("Choose source mode, choose destinations, then export")
         subtitle.setAlignment(QtCore.Qt.AlignCenter)
-        subtitle.setStyleSheet("color: #666;")
+        subtitle.setToolTip(
+            "High-level workflow: choose source, choose destinations, then export."
+        )
 
         self._main_layout.addWidget(title)
         self._main_layout.addWidget(subtitle)
 
     def _build_targets_section(self) -> None:
-        target_group = QGroupBox("1. Targets and Destinations")
-        target_layout = QVBoxLayout(target_group)
+        setup_group = QGroupBox("1. Export Setup")
+        setup_layout = QVBoxLayout(setup_group)
 
-        description = QLabel(
-            "Enable each target you want to export, then choose one or more destinations."
+        setup_layout.addWidget(self._build_export_source_section())
+        setup_layout.addWidget(self._build_destination_section())
+
+        self._validation_label = QLabel()
+        self._validation_label.setStyleSheet("color: #b00020;")
+        self._validation_label.setToolTip(
+            "Validation feedback. Export is disabled until this message is cleared."
         )
-        description.setStyleSheet("color: #666;")
-        target_layout.addWidget(description)
+        self._validation_label.setVisible(False)
+        setup_layout.addWidget(self._validation_label)
 
-        location_order = self._collect_location_order()
-        targets_grid = self._build_targets_grid(location_order)
+        self._main_layout.addWidget(setup_group)
 
-        scroll = QScrollArea()
-        scroll.setWidgetResizable(True)
-        scroll.setHorizontalScrollBarPolicy(QtCore.Qt.ScrollBarAsNeeded)
-        scroll.setWidget(targets_grid)
-        target_layout.addWidget(scroll)
+    def _build_export_source_section(self) -> QGroupBox:
+        source_group = QGroupBox("")
+        source_layout = QVBoxLayout(source_group)
 
-        self._main_layout.addWidget(target_group)
+        self._source_tabs = QTabWidget()
 
-    def _build_targets_grid(self, location_order: list[SaveLocation]) -> QWidget:
-        grid_container = QWidget()
-        grid = QGridLayout(grid_container)
-        grid.setHorizontalSpacing(12)
-        grid.setVerticalSpacing(8)
-
-        self._add_targets_grid_header(grid, location_order)
-        self._add_targets_grid_bulk_controls(grid, location_order)
-        self._add_targets_grid_rows(grid, location_order)
-        return grid_container
-
-    def _add_targets_grid_header(
-        self, grid: QGridLayout, location_order: list[SaveLocation]
-    ) -> None:
-        grid.addWidget(QLabel("Export"), 0, 0)
-        grid.addWidget(QLabel("Target"), 0, 1)
-
-        for column, location in enumerate(location_order, start=2):
-            header = QLabel(f"{location.name}\n(*.{location.preset.ext})")
-            header.setAlignment(QtCore.Qt.AlignCenter)
-            grid.addWidget(header, 0, column)
-
-    def _add_targets_grid_bulk_controls(
-        self, grid: QGridLayout, location_order: list[SaveLocation]
-    ) -> None:
-        select_all_targets = QPushButton("All Targets")
-        select_all_targets.clicked.connect(self._make_set_all_targets_callback(True))
-        grid.addWidget(select_all_targets, 1, 0)
-
-        select_no_targets = QPushButton("No Targets")
-        select_no_targets.clicked.connect(self._make_set_all_targets_callback(False))
-        grid.addWidget(select_no_targets, 1, 1)
-
-        for column, location in enumerate(location_order, start=2):
-            location_controls = self._build_location_bulk_controls(location.name)
-            grid.addWidget(location_controls, 1, column)
-
-    def _build_location_bulk_controls(self, location_name: str) -> QWidget:
-        controls_widget = QWidget()
-        controls_layout = QHBoxLayout(controls_widget)
-        controls_layout.setContentsMargins(0, 0, 0, 0)
-
-        enable_all = QPushButton("All")
-        enable_all.clicked.connect(
-            self._make_set_all_location_destinations_callback(location_name, True)
+        # 1. Standard Shot Tab
+        self._source_tabs.addTab(self._build_shot_source_tab(), "Shot Playblast")
+        source_tab_bar = self._source_tabs.tabBar()
+        source_tab_bar.setTabToolTip(
+            self.SHOT_TAB_INDEX,
+            "Uses shot code metadata from this Maya scene and resolved shot camera/range.",
         )
-        controls_layout.addWidget(enable_all)
 
-        enable_none = QPushButton("None")
-        enable_none.clicked.connect(
-            self._make_set_all_location_destinations_callback(location_name, False)
+        # 2. Hook: Subclasses can inject extra tabs here (e.g. Sequencer)
+        self._add_custom_tabs(self._source_tabs)
+
+        # 3. Standard Custom Tab
+        self.CUSTOM_TAB_INDEX = self._source_tabs.count()
+        self._source_tabs.addTab(self._build_custom_source_tab(), "Custom Playblast")
+        source_tab_bar.setTabToolTip(
+            self.CUSTOM_TAB_INDEX,
+            "Uses manual camera and manual frame range.",
         )
-        controls_layout.addWidget(enable_none)
-        return controls_widget
 
-    def _add_targets_grid_rows(
-        self, grid: QGridLayout, location_order: list[SaveLocation]
-    ) -> None:
-        for row, config in enumerate(self.shot_configs, start=2):
-            self._add_target_row(grid, row, config, location_order)
-
-    def _add_target_row(
-        self,
-        grid: QGridLayout,
-        row: int,
-        config: MShotDialogConfig,
-        location_order: list[SaveLocation],
-    ) -> None:
-        target_toggle = self._build_target_toggle(config.id)
-        self._enabled_shot_cbs[config.id] = target_toggle
-        grid.addWidget(target_toggle, row, 0, alignment=QtCore.Qt.AlignCenter)
-
-        target_label = ClickableQLabel(f"<b>{config.name}</b>", target_toggle)
-        target_label.clicked.connect(lambda cb=target_toggle: cb.click())
-        grid.addWidget(target_label, row, 1)
-
-        config_locations = {
-            location.name: (location, enabled) for location, enabled in config.save_locs
-        }
-        for column, location in enumerate(location_order, start=2):
-            location_data = config_locations.get(location.name)
-            if location_data is None:
-                placeholder = self._build_destination_placeholder()
-                grid.addWidget(placeholder, row, column)
-                continue
-
-            _, enabled_by_default = location_data
-            destination_toggle = self._build_destination_toggle(
-                config.id, location.name
-            )
-            destination_toggle.setChecked(enabled_by_default)
-            grid.addWidget(
-                destination_toggle, row, column, alignment=QtCore.Qt.AlignCenter
-            )
-
-        self._set_shot_locations_enabled(config.id, target_toggle.isChecked())
-
-    def _build_target_toggle(self, shot_id: str) -> QCheckBox:
-        target_toggle = QCheckBox()
-        target_toggle.setChecked(True)
-        target_toggle.toggled.connect(
-            self._make_set_shot_locations_enabled_callback(shot_id)
+        self._source_tabs.currentChanged.connect(self._on_source_mode_changed)
+        self._source_tabs.setToolTip(
+            "Select how exports are generated: shot context or manual custom range."
         )
-        target_toggle.toggled.connect(self._refresh_summary)
-        return target_toggle
 
-    def _build_destination_toggle(self, shot_id: str, location_name: str) -> QCheckBox:
-        destination_toggle = QCheckBox()
-        destination_toggle.toggled.connect(self._refresh_summary)
-        self._enabled_loc_cbs[shot_id][location_name] = destination_toggle
-        return destination_toggle
+        source_layout.addWidget(self._source_tabs)
 
-    @staticmethod
-    def _build_destination_placeholder() -> QLabel:
-        placeholder = QLabel("-")
-        placeholder.setAlignment(QtCore.Qt.AlignCenter)
-        placeholder.setEnabled(False)
-        return placeholder
+        # 4. Hook: Subclasses can inject widgets below the tabs (e.g. Anim Pass)
+        extra_options = self._build_extra_source_options()
+        if extra_options:
+            source_layout.addWidget(extra_options)
 
-    def _make_set_all_targets_callback(self, enabled: bool) -> Callable[[], None]:
-        def callback() -> None:
-            self._set_all_targets(enabled)
+        return source_group
 
-        return callback
+    def _add_custom_tabs(self, tabs: QTabWidget) -> None:
+        """Override to inject tabs between Shot and Custom."""
+        pass
 
-    def _make_set_all_location_destinations_callback(
-        self, location_name: str, enabled: bool
-    ) -> Callable[[], None]:
-        def callback() -> None:
-            self._set_location_for_all(location_name, enabled)
+    def _build_extra_source_options(self) -> QWidget | None:
+        """Override to add options below the tabs."""
+        return None
 
-        return callback
+    @abstractmethod
+    def _build_shot_camera_widget(self) -> QWidget:
+        """Return the camera widget for the Shot tab (QLabel or QComboBox)."""
+        pass
 
-    def _make_set_shot_locations_enabled_callback(
-        self, shot_id: str
-    ) -> Callable[[bool], None]:
-        def callback(enabled: bool) -> None:
-            self._set_shot_locations_enabled(shot_id, enabled)
+    @abstractmethod
+    def _validate_source_state(self, mode: str) -> str | None:
+        """Return a validation error string for the currently selected source mode, or None."""
+        pass
 
-        return callback
+    def _build_shot_source_tab(self) -> QWidget:
+        shot_tab = QWidget()
+        shot_layout = QGridLayout(shot_tab)
 
-    def _build_context_section(self) -> None:
-        self._context_group = QGroupBox("2. Shot Settings")
-        self._context_layout = QVBoxLayout()
-        self._context_layout.setContentsMargins(8, 8, 8, 8)
-        self._context_group.setLayout(self._context_layout)
-        self._context_group.setVisible(False)
-        self._main_layout.addWidget(self._context_group)
+        shot_layout.addWidget(QLabel("Source"), 0, 0)
+        source_value = QLabel("Pipeline Shot File")
+        source_value.setToolTip(
+            "Source is resolved from this scene's pipeline shot metadata."
+        )
+        shot_layout.addWidget(source_value, 0, 1)
 
-    def add_context_widget(self, widget: QWidget) -> None:
-        self._context_group.setVisible(True)
-        self._context_layout.addWidget(widget)
+        shot_layout.addWidget(QLabel("Shot"), 1, 0)
+        self._shot_code_value = QLabel("-")
+        self._shot_code_value.setToolTip("Resolved pipeline shot code.")
+        shot_layout.addWidget(self._shot_code_value, 1, 1)
+
+        shot_layout.addWidget(QLabel("Camera"), 2, 0)
+        self._shot_camera_widget = self._build_shot_camera_widget()
+        shot_layout.addWidget(self._shot_camera_widget, 2, 1)
+
+        shot_layout.addWidget(QLabel("Frame Range"), 3, 0)
+        self._shot_range_value = QLabel("-")
+        self._shot_range_value.setToolTip(
+            "Resolved cut range from the detected pipeline shot."
+        )
+        shot_layout.addWidget(self._shot_range_value, 3, 1)
+
+        shot_layout.addWidget(QLabel("ShotGrid"), 4, 0)
+        self._shotgrid_upload_checkbox = QCheckBox("Upload to ShotGrid")
+        self._shotgrid_upload_checkbox.setChecked(False)
+        self._shotgrid_upload_checkbox.setToolTip(
+            "When enabled, this Shot playblast will also create a ShotGrid Version and upload the movie."
+        )
+        self._shotgrid_upload_checkbox.toggled.connect(self._on_shotgrid_upload_toggled)
+        shot_layout.addWidget(self._shotgrid_upload_checkbox, 4, 1)
+
+        self._shotgrid_description_row = QWidget()
+        shotgrid_description_layout = QHBoxLayout(self._shotgrid_description_row)
+        shotgrid_description_layout.setContentsMargins(0, 0, 0, 0)
+        shotgrid_description_layout.addWidget(QLabel("Description"))
+        self._shotgrid_description_field = QLineEdit()
+        self._shotgrid_description_field.setPlaceholderText(
+            "Optional ShotGrid version description"
+        )
+        self._shotgrid_description_field.setToolTip(
+            "Optional notes saved to the ShotGrid Version description when upload is enabled."
+        )
+        shotgrid_description_layout.addWidget(self._shotgrid_description_field)
+        shot_layout.addWidget(self._shotgrid_description_row, 5, 0, 1, 2)
+
+        self._sync_shotgrid_description_visibility()
+
+        return shot_tab
+
+    def _build_custom_source_tab(self) -> QWidget:
+        custom_tab = QWidget()
+        custom_layout = QGridLayout(custom_tab)
+
+        timeline_in, timeline_out = self._timeline_range()
+        self._custom_in = QSpinBox(self, minimum=0, maximum=10000, value=timeline_in)
+        self._custom_out = QSpinBox(self, minimum=0, maximum=10000, value=timeline_out)
+        self._custom_out.setMinimum(self._custom_in.value())
+        self._custom_in.setToolTip("Start frame for custom playblast.")
+        self._custom_out.setToolTip("End frame for custom playblast.")
+        self._custom_in.valueChanged.connect(self._on_custom_in_changed)
+        self._custom_out.valueChanged.connect(self._on_source_settings_changed)
+
+        custom_layout.addWidget(QLabel("Custom In"), 0, 0)
+        custom_layout.addWidget(self._custom_in, 0, 1)
+        custom_layout.addWidget(QLabel("Custom Out"), 0, 2)
+        custom_layout.addWidget(self._custom_out, 0, 3)
+
+        self._custom_camera = QComboBox(self)
+        self._custom_camera.addItems(self._available_custom_cameras())
+        self._custom_camera.setToolTip("Camera used for custom playblast output.")
+        self._custom_camera.currentTextChanged.connect(self._on_source_settings_changed)
+        custom_layout.addWidget(QLabel("Custom Camera"), 1, 0)
+        custom_layout.addWidget(self._custom_camera, 1, 1, 1, 3)
+
+        return custom_tab
+
+    def _build_destination_section(self) -> QGroupBox:
+        destination_group = QGroupBox("Save Destinations")
+        destination_layout = QVBoxLayout(destination_group)
+
+        for location in self._destination_locations():
+            row_widget = QWidget()
+            row_layout = QHBoxLayout(row_widget)
+            row_layout.setContentsMargins(0, 0, 0, 0)
+
+            toggle = QCheckBox(location.name)
+            toggle.setChecked(self._default_destination_enabled(location))
+            toggle.setToolTip(f"Enable export to {location.name}.")
+            toggle.toggled.connect(self._on_destination_changed)
+            self._destination_checkboxes[location.name] = toggle
+            row_layout.addWidget(toggle)
+
+            path_label = QLabel("")
+            path_label.setToolTip(f"Resolved output directory for {location.name}.")
+            self._destination_path_labels[location.name] = path_label
+            row_layout.addWidget(path_label)
+            row_layout.addStretch()
+            destination_layout.addWidget(row_widget)
+
+        self._align_destination_path_columns()
+
+        self._custom_folder_row = self._build_destination_path_row()
+        destination_layout.addWidget(self._custom_folder_row)
+        return destination_group
+
+    def _align_destination_path_columns(self) -> None:
+        destination_column_width = max(
+            (
+                checkbox.sizeHint().width()
+                for checkbox in self._destination_checkboxes.values()
+            ),
+            default=0,
+        )
+        for checkbox in self._destination_checkboxes.values():
+            checkbox.setFixedWidth(destination_column_width)
+
+    def _build_destination_path_row(self) -> QWidget:
+        custom_path_row = QWidget()
+        custom_path_layout = QHBoxLayout(custom_path_row)
+        custom_path_layout.setContentsMargins(24, 0, 0, 0)
+
+        custom_path_layout.addWidget(QLabel("Custom Folder Path"))
+
+        self._custom_folder_field = QLineEdit()
+        self._custom_folder_field.setText(self._default_custom_folder_path())
+        self._custom_folder_field.setToolTip(
+            "Directory used when Custom Folder destination is enabled."
+        )
+        self._custom_folder_field.textChanged.connect(self._on_custom_path_changed)
+        custom_path_layout.addWidget(self._custom_folder_field)
+
+        browse_button = QPushButton("Browse")
+        browse_button.setToolTip("Choose a custom output directory.")
+        browse_button.clicked.connect(self._set_custom_folder)
+        custom_path_layout.addWidget(browse_button)
+        return custom_path_row
 
     def _build_render_options_section(self) -> None:
-        options_group = QGroupBox("3. Render Options")
+        options_group = QGroupBox("2. Viewport Options")
         options_layout = QVBoxLayout(options_group)
-
-        active_panel = self._resolve_active_model_panel()
-        options_layout.addWidget(self._build_viewport_options_widget(active_panel))
-        options_layout.addWidget(self._build_custom_folder_widget())
+        options_layout.addWidget(
+            self._build_viewport_options_widget(self._resolve_active_model_panel())
+        )
+        self._apply_viewport_option_tooltips()
         self._main_layout.addWidget(options_group)
 
     def _build_viewport_options_widget(self, active_panel: str) -> QWidget:
@@ -374,75 +442,428 @@ class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
         viewport_layout.addWidget(self._use_dof)
         return viewport_widget
 
-    def _build_custom_folder_widget(self) -> QWidget:
-        custom_folder_widget = QWidget()
-        custom_folder_layout = QHBoxLayout(custom_folder_widget)
-        custom_folder_layout.setContentsMargins(0, 0, 0, 0)
-
-        self._custom_folder_field = QLineEdit()
-        self._custom_folder_field.setReadOnly(True)
-        self._custom_folder_field.setText(self._default_custom_folder_path())
-        self._custom_folder_field.textChanged.connect(self._refresh_summary)
-        custom_folder_layout.addWidget(self._custom_folder_field)
-
-        browse_button = QPushButton("Browse Custom Folder")
-        browse_button.clicked.connect(self._set_custom_folder)
-        custom_folder_layout.addWidget(browse_button)
-        return custom_folder_widget
-
     def _build_option_checkbox(self, label: str, enabled_by_default: bool) -> QCheckBox:
         option_toggle = QCheckBox(label)
         option_toggle.setChecked(enabled_by_default)
-        option_toggle.toggled.connect(self._refresh_summary)
+        option_toggle.toggled.connect(self._on_source_settings_changed)
         return option_toggle
 
     @staticmethod
     def _default_custom_folder_path() -> str:
         return os.getenv("TMPDIR", os.getenv("TEMP", "tmp"))
 
-    def _build_summary_section(self) -> None:
-        summary_group = QGroupBox("4. Export Summary")
-        summary_layout = QVBoxLayout(summary_group)
-
-        self._summary_field = QPlainTextEdit()
-        self._summary_field.setReadOnly(True)
-        self._summary_field.setMinimumHeight(150)
-        summary_layout.addWidget(self._summary_field)
-
-        self._main_layout.addWidget(summary_group)
-
     def _build_buttons(self) -> None:
-        self._init_buttons(has_cancel_button=True, ok_name="Playblast")
+        self._init_buttons(has_cancel_button=True, ok_name="Playblast Shot")
         self.buttons.rejected.connect(self.close)
         self.buttons.accepted.connect(self.do_export)
+
+        ok_button = self.buttons.button(QDialogButtonBox.Ok)
+        if ok_button is not None:
+            ok_button.setToolTip(
+                "Start playblast with current source and destination selections."
+            )
+
+        cancel_button = self.buttons.button(QDialogButtonBox.Cancel)
+        if cancel_button is not None:
+            cancel_button.setToolTip("Close without exporting.")
+
         self._main_layout.addWidget(self.buttons)
 
-    def _collect_location_order(self) -> list[SaveLocation]:
-        ordered_locations: list[SaveLocation] = []
-        seen_names: set[str] = set()
+    def _apply_viewport_option_tooltips(self) -> None:
+        self._use_lighting.setToolTip("Use viewport lighting for playblast capture.")
+        self._use_shadows.setToolTip("Render viewport shadows in playblast.")
+        self._use_ssao.setToolTip(
+            "Enable viewport anti-aliasing (SSAO/multi-sample setting)."
+        )
+        self._use_hardware_fog.setToolTip(
+            "Include hardware fog from viewport settings."
+        )
+        self._use_dof.setToolTip("Include camera depth of field in playblast.")
 
-        for config in self.shot_configs:
-            for location, _enabled in config.save_locs:
-                if location.name in seen_names:
+    def _set_default_source_tab(self) -> None:
+        self._refresh_source_tab_availability()
+        self._source_tabs.setCurrentIndex(self._default_source_tab_index())
+
+    def _refresh_source_tab_availability(self) -> None:
+        has_shot_context = self._shot is not None
+        self._source_tabs.setTabEnabled(self.SHOT_TAB_INDEX, has_shot_context)
+
+        selected_mode = self._selected_source_mode()
+        if selected_mode == "shot" and not has_shot_context:
+            self._source_tabs.setCurrentIndex(self._default_source_tab_index())
+
+    def _default_source_tab_index(self) -> int:
+        if self._shot is not None:
+            return self.SHOT_TAB_INDEX
+        return self.CUSTOM_TAB_INDEX
+
+    @staticmethod
+    def _resolve_pipeline_shot_context() -> Shot | None:
+        try:
+            conn = DB.Get(DB_Config)
+        except Exception:
+            return None
+
+        try:
+            code = str(mc.fileInfo("code", query=True)[0]).strip()
+        except Exception:
+            return None
+
+        if not code:
+            return None
+
+        try:
+            return conn.get_shot_by_code(code)
+        except Exception:
+            return None
+
+    @staticmethod
+    def _timeline_range() -> tuple[int, int]:
+        cut_in = int(mc.playbackOptions(minTime=True, query=True))
+        cut_out = int(mc.playbackOptions(maxTime=True, query=True))
+        if cut_out < cut_in:
+            cut_out = cut_in
+        return cut_in, cut_out
+
+    @staticmethod
+    def _available_custom_cameras() -> list[str]:
+        return [
+            str(c)
+            for c in (
+                mc.ls(cameras=True, visible=True) or mc.ls(cameras=True) or ["persp"]
+            )
+        ]
+
+    def _destination_locations(self) -> list[SaveLocation]:
+        return [
+            self.SAVE_LOCS.EDIT,  # type: ignore
+            self.SAVE_LOCS.CURRENT,
+            self.SAVE_LOCS.CUSTOM,
+        ]
+
+    def _default_destination_enabled(self, location: SaveLocation) -> bool:
+        return location.name == self.SAVE_LOCS.CURRENT.name
+
+    def _selected_source_mode(self) -> str:
+        current_index = self._source_tabs.currentIndex()
+        if current_index == self.SHOT_TAB_INDEX:
+            return "shot"
+        if getattr(self, "SEQUENCER_TAB_INDEX", -1) == current_index:
+            return "sequencer"
+        return "custom"
+
+    def _selected_destination_locations(self) -> list[SaveLocation]:
+        selected: list[SaveLocation] = []
+        for location in self._destination_locations():
+            toggle = self._destination_checkboxes.get(location.name)
+            if toggle and toggle.isChecked():
+                selected.append(location)
+        return selected
+
+    def _is_custom_destination_selected(self) -> bool:
+        custom_checkbox = self._destination_checkboxes.get(self.SAVE_LOCS.CUSTOM.name)
+        return bool(custom_checkbox and custom_checkbox.isChecked())
+
+    def _paths_for_filename(
+        self, filename: str
+    ) -> dict[Playblaster.PRESET, list[str | Path]]:
+        paths: dict[Playblaster.PRESET, list[str | Path]] = defaultdict(list)
+        for location in self._selected_destination_locations():
+            destination_dir = self._resolved_destination_path(location).strip()
+            if not destination_dir:
+                continue
+            paths[location.preset].append(str(Path(destination_dir) / filename))
+        return paths
+
+    @staticmethod
+    def _final_movie_path_for_base(
+        output_base: str | Path,
+        preset: Playblaster.PRESET,
+    ) -> Path:
+        return Path(str(output_base) + f".{preset.ext}")
+
+    def _final_movie_paths_for_location(
+        self,
+        shot_config: MShotPlayblastConfig,
+        location: SaveLocation,
+    ) -> list[Path]:
+        destination_dir = Path(self._resolved_destination_path(location)).expanduser()
+        resolved_destination_dir = destination_dir.resolve()
+
+        matching_paths: list[Path] = []
+        for output_base in shot_config.paths.get(location.preset, []):
+            resolved_output_base = Path(str(output_base)).expanduser().resolve()
+            if resolved_output_base.parent != resolved_destination_dir:
+                continue
+            matching_paths.append(
+                self._final_movie_path_for_base(resolved_output_base, location.preset)
+            )
+        return matching_paths
+
+    def _ordered_final_movie_paths_for_upload(
+        self,
+        shot_config: MShotPlayblastConfig,
+    ) -> list[Path]:
+        """Return deterministic output path order for upload path resolution."""
+
+        ordered_paths: list[Path] = []
+        seen_paths: set[Path] = set()
+
+        for location in self._destination_locations():
+            for output_path in self._final_movie_paths_for_location(
+                shot_config, location
+            ):
+                if output_path in seen_paths:
                     continue
-                seen_names.add(location.name)
-                ordered_locations.append(location)
-        return ordered_locations
+                seen_paths.add(output_path)
+                ordered_paths.append(output_path)
 
-    def _set_all_targets(self, enabled: bool) -> None:
-        for checkbox in self._enabled_shot_cbs.values():
-            if checkbox.isEnabled():
-                checkbox.setChecked(enabled)
+        for preset, output_bases in shot_config.paths.items():
+            for output_base in output_bases:
+                output_path = self._final_movie_path_for_base(output_base, preset)
+                resolved_output_path = output_path.expanduser().resolve()
+                if resolved_output_path in seen_paths:
+                    continue
+                seen_paths.add(resolved_output_path)
+                ordered_paths.append(resolved_output_path)
 
-    def _set_location_for_all(self, location_name: str, enabled: bool) -> None:
-        for location_map in self._enabled_loc_cbs.values():
-            checkbox = location_map.get(location_name)
-            if checkbox is not None:
-                checkbox.setChecked(enabled)
+        return ordered_paths
 
-    def _set_shot_locations_enabled(self, shot_id: str, enabled: bool) -> None:
-        for checkbox in self._enabled_loc_cbs.get(shot_id, {}).values():
-            checkbox.setEnabled(enabled)
+    def _preferred_edit_movie_paths_for_upload(
+        self,
+        shot_config: MShotPlayblastConfig,
+    ) -> list[Path]:
+        edit_location = self._save_locations_by_name.get(self.SAVE_LOCS.EDIT.name)  # type: ignore
+        if edit_location is None:
+            return []
+        return self._final_movie_paths_for_location(shot_config, edit_location)
+
+    def _resolve_shotgrid_upload_movie_path(
+        self,
+        config: MPlayblastConfig,
+    ) -> Path | None:
+        """Resolve upload movie path with stable preference ordering.
+
+        Preference order:
+        1) valid `Send to Edit` output
+        2) first valid output from the deterministic export order
+        """
+        if not config.shots:
+            return None
+
+        shot_config = config.shots[0]
+        preferred_paths = self._preferred_edit_movie_paths_for_upload(shot_config)
+        output_paths = self._ordered_final_movie_paths_for_upload(shot_config)
+        return resolve_preferred_upload_movie_path(
+            output_paths,
+            preferred_paths=preferred_paths,
+        )
+
+    def _should_upload_shot_playblast_to_shotgrid(self) -> bool:
+        return (
+            self._selected_source_mode() == "shot"
+            and self._is_shotgrid_upload_requested()
+        )
+
+    def _upload_shot_playblast_to_shotgrid(
+        self,
+        config: MPlayblastConfig,
+    ) -> list[str]:
+        if not config.shots:
+            return ["ShotGrid Upload: Skipped - no shot output was generated."]
+
+        shot_code = str(config.shots[0].shot.code or "").strip()
+        if not shot_code:
+            return ["ShotGrid Upload: Skipped - shot code is missing."]
+
+        movie_path = self._resolve_shotgrid_upload_movie_path(config)
+        if movie_path is None:
+            return [
+                "ShotGrid Upload: Skipped - no valid playblast movie file was found."
+            ]
+
+        version_name = default_version_name_from_movie_path(movie_path)
+        if not version_name:
+            version_name = f"{shot_code}_playblast"
+
+        artist_name = resolve_artist_display_name().strip() or None
+        upload_request = PlayblastVersionUploadRequest(
+            shot_code=shot_code,
+            movie_path=movie_path,
+            version_name=version_name,
+            description=self._shotgrid_upload_description() or None,
+            path_to_frames=str(movie_path),
+            artist_display_name=artist_name,
+        )
+
+        try:
+            upload_result = upload_playblast_version(upload_request)
+        except Exception as exc:
+            log.exception("ShotGrid upload failed for shot '%s'", shot_code)
+            return [f"ShotGrid Upload: Failed - {exc}"]
+
+        message_lines: list[str] = []
+        if upload_result.ok:
+            success_message = (
+                f"ShotGrid Upload: Success - {upload_result.version_name}"
+                f" (shot {upload_result.shot_code})."
+            )
+            if upload_result.version_id is not None:
+                success_message = (
+                    f"{success_message} Version ID: {upload_result.version_id}."
+                )
+            message_lines.append(success_message)
+        else:
+            message_lines.append(f"ShotGrid Upload: Failed - {upload_result.message}")
+
+        for warning in upload_result.warnings:
+            message_lines.append(f"ShotGrid Warning: {warning}")
+
+        return message_lines
+
+    def _selected_destination_directories(self) -> list[Path]:
+        directories: list[Path] = []
+        for location in self._selected_destination_locations():
+            destination_dir = self._resolved_destination_path(location).strip()
+            if destination_dir:
+                directories.append(Path(destination_dir))
+        return directories
+
+    def _resolve_output_name(self, prefix: str) -> str:
+        return resolve_versioned_playblast_basename(
+            prefix,
+            self._selected_destination_directories(),
+        )
+
+    def _resolved_destination_path(self, location: SaveLocation) -> str:
+        if location.name == self.SAVE_LOCS.CUSTOM.name:
+            return self._custom_folder_field.text().strip()
+        return str(location.path)
+
+    def _refresh_destination_path_labels(self) -> None:
+        for location_name, path_label in self._destination_path_labels.items():
+            location = self._save_locations_by_name[location_name]
+            path_label.setText(f"-> {self._resolved_destination_path(location)}")
+
+    def _refresh_shot_context_fields(self) -> None:
+        if self._shot is None:
+            self._shot_code_value.setText("-")
+            self._shot_range_value.setText("-")
+            return
+
+        self._shot_code_value.setText(self._shot.code)
+        self._shot_range_value.setText(f"{self._shot.cut_in} - {self._shot.cut_out}")
+
+    def _sync_custom_path_row_visibility(self) -> None:
+        is_visible = self._is_custom_destination_selected()
+        self._custom_folder_row.setVisible(is_visible)
+        self._custom_folder_field.setEnabled(is_visible)
+
+    def _sync_shotgrid_description_visibility(self) -> None:
+        show_description = self._is_shotgrid_upload_requested()
+        self._shotgrid_description_row.setVisible(show_description)
+        self._shotgrid_description_field.setEnabled(show_description)
+
+    def _is_shotgrid_upload_requested(self) -> bool:
+        return self._shotgrid_upload_checkbox.isChecked()
+
+    def _shotgrid_upload_description(self) -> str:
+        return self._shotgrid_description_field.text().strip()
+
+    def _validate_target_destination_state(self) -> str | None:
+        mode = self._selected_source_mode()
+
+        if mode == "shot":
+            if self._shot is None:
+                return (
+                    "No pipeline shot context was found. Use a pipeline shot file "
+                    "or switch to Custom Playblast."
+                )
+
+        if mode == "custom":
+            if self._custom_out.value() < self._custom_in.value():
+                return "Custom Out must be greater than or equal to Custom In."
+            if not str(self._custom_camera.currentText()).strip():
+                return "Choose a camera for Custom Playblast."
+
+        # Let subclasses run their own validation
+        subclass_error = self._validate_source_state(mode)
+        if subclass_error:
+            return subclass_error
+
+        if not self._selected_destination_locations():
+            return "Select at least one save destination."
+
+        if (
+            self._is_custom_destination_selected()
+            and not self._custom_folder_field.text().strip()
+        ):
+            return "Custom Folder path is required when Custom Folder destination is enabled."
+
+        return None
+
+    def _action_button_text(self) -> str:
+        mode = self._selected_source_mode()
+        if mode == "shot":
+            return "Playblast Shot"
+        if mode == "sequencer":
+            return "Playblast Sequencer"
+        return "Playblast Custom"
+
+    def _update_action_state(self) -> None:
+        ok_button = self.buttons.button(QDialogButtonBox.Ok)
+        if ok_button is None:
+            return
+
+        ok_button.setText(self._action_button_text())
+        validation_error = self._validate_target_destination_state()
+        ok_button.setEnabled(validation_error is None)
+        self._validation_label.setText(validation_error or "")
+        self._validation_label.setVisible(validation_error is not None)
+
+    def _update_ui_state(self) -> None:
+        self._refresh_source_tab_availability()
+        self._refresh_shot_context_fields()
+        # Allows subclasses to hook into the update state to refresh their custom fields
+        self._refresh_custom_ui_state()
+        self._sync_custom_path_row_visibility()
+        self._sync_shotgrid_description_visibility()
+        self._refresh_destination_path_labels()
+        self._update_action_state()
+
+    def _refresh_custom_ui_state(self) -> None:
+        """Override to update subclass specific UI fields"""
+        pass
+
+    def _on_source_mode_changed(self, _index: int) -> None:
+        self._update_ui_state()
+
+    def _on_destination_changed(self, _checked: bool) -> None:
+        self._update_ui_state()
+
+    def _on_custom_path_changed(self, _path: str) -> None:
+        self._update_ui_state()
+
+    def _on_custom_in_changed(self, in_frame: int) -> None:
+        self._custom_out.setMinimum(in_frame)
+        self._update_ui_state()
+
+    def _on_source_settings_changed(self, *_args) -> None:
+        self._update_ui_state()
+
+    def _on_shotgrid_upload_toggled(self, _enabled: bool) -> None:
+        self._update_ui_state()
+
+    def _set_custom_folder(self) -> None:
+        path_list = mc.fileDialog2(
+            caption="Select a custom playblast folder",
+            fileMode=2,
+            hideNameEdit=True,
+            okCaption="Select",
+            setProjectBtnEnabled=False,
+        )
+        if path_list:
+            self._custom_folder_field.setText(path_list[0])
 
     @staticmethod
     def _resolve_active_model_panel() -> str:
@@ -519,109 +940,21 @@ class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
     def use_ssao(self) -> bool:
         return self._use_ssao.isChecked()
 
-    def _refresh_summary(self, *_args) -> None:
-        lines: list[str] = []
-        lines.extend(self._summary_target_lines())
-        lines.append("")
-        lines.extend(self._summary_render_option_lines())
-        self._summary_field.setPlainText("\n".join(lines))
-
-    def _summary_target_lines(self) -> list[str]:
-        lines: list[str] = []
-        enabled_configs = [
-            config for config in self.shot_configs if self.is_shot_enabled(config.id)
-        ]
-        if not enabled_configs:
-            lines.append("No targets selected.")
-            return lines
-
-        lines.append("Selected targets:")
-        for config in enabled_configs:
-            lines.append(f"- {config.name}")
-            enabled_locations = [
-                location
-                for location in self._save_locs_by_shot[config.id]
-                if self.is_location_enabled(config.id, location.name)
-            ]
-            if not enabled_locations:
-                lines.append("  (no destination selected)")
-                continue
-
-            for location in enabled_locations:
-                lines.append(f"  -> {location.name}: {location.path}")
-        return lines
-
-    def _summary_render_option_lines(self) -> list[str]:
-        return [
-            "Viewport options:",
-            f"- Lighting: {'On' if self.use_lighting else 'Off'}",
-            f"- Shadows: {'On' if self.use_shadows else 'Off'}",
-            f"- Anti-aliasing: {'On' if self.use_ssao else 'Off'}",
-            f"- Hardware Fog: {'On' if self.use_hardware_fog else 'Off'}",
-            f"- Depth of Field: {'On' if self.use_dof else 'Off'}",
-        ]
-
-    def save_locations_to_paths(
-        self, dialog_id: str, locs: Iterable[SaveLocation], filename: str
-    ) -> dict[Playblaster.PRESET, list[str | Path]]:
-        paths: dict[Playblaster.PRESET, list[str | Path]] = defaultdict(list)
-        for location in locs:
-            if not self.is_location_enabled(dialog_id, location.name):
-                continue
-
-            destination_dir = str(location.path).strip()
-            if not destination_dir:
-                continue
-
-            output_base = Path(destination_dir) / filename
-            paths[location.preset].append(str(output_base))
-        return paths
-
-    def _set_custom_folder(self) -> None:
-        path_list = mc.fileDialog2(
-            caption="Select a custom playblast folder",
-            fileMode=2,
-            hideNameEdit=True,
-            okCaption="Select",
-            setProjectBtnEnabled=False,
-        )
-        if path_list:
-            self._custom_folder_field.setText(path_list[0])
-
     @abstractmethod
     def _generate_config(self) -> MPlayblastConfig:
         raise NotImplementedError
 
-    def is_shot_enabled(self, dialog_id: str) -> bool:
-        checkbox = self._enabled_shot_cbs.get(dialog_id)
-        return bool(checkbox and checkbox.isChecked())
-
-    def is_location_enabled(self, dialog_id: str, loc_name: str) -> bool:
-        location_map = self._enabled_loc_cbs.get(dialog_id)
-        if not location_map:
-            return False
-        checkbox = location_map.get(loc_name)
-        return bool(checkbox and checkbox.isChecked())
-
-    @staticmethod
-    def _output_count_for_shot(shot_cfg: MShotPlayblastConfig) -> int:
-        return sum(len(paths) for paths in shot_cfg.paths.values())
-
-    @staticmethod
-    def _collect_output_paths(config: MPlayblastConfig) -> list[str]:
-        output_paths: list[str] = []
-        for shot_cfg in config.shots:
-            for preset, bases in shot_cfg.paths.items():
-                for base in bases:
-                    output_paths.append(str(Path(str(base) + f".{preset.ext}")))
-        return output_paths
-
     def _validate_config(self, config: MPlayblastConfig) -> str | None:
+        validation_error = self._validate_target_destination_state()
+        if validation_error:
+            return validation_error
+
         if not config.shots:
-            return "No playblast targets are enabled."
+            return "No playblast targets are configured."
 
         for shot_cfg in config.shots:
-            if self._output_count_for_shot(shot_cfg) < 1:
+            output_count = sum(len(paths) for paths in shot_cfg.paths.values())
+            if output_count < 1:
                 return (
                     f"Target '{shot_cfg.shot.code}' has no output location selected. "
                     "Please enable at least one destination."
@@ -636,8 +969,18 @@ class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
 
         Returned lines are appended to the success dialog.
         """
-        del config
-        return []
+        if not self._should_upload_shot_playblast_to_shotgrid():
+            return []
+        return self._upload_shot_playblast_to_shotgrid(config)
+
+    @staticmethod
+    def _collect_output_paths(config: MPlayblastConfig) -> list[str]:
+        output_paths: list[str] = []
+        for shot_cfg in config.shots:
+            for preset, bases in shot_cfg.paths.items():
+                for base in bases:
+                    output_paths.append(str(Path(str(base) + f".{preset.ext}")))
+        return output_paths
 
     @staticmethod
     def _build_success_message(
@@ -697,3 +1040,32 @@ class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
         success_msg = self._build_success_message(output_paths, post_playblast_messages)
         MessageDialog(self.parent(), success_msg).exec_()
         self.close()
+
+    def _build_custom_playblast_config(self) -> MShotPlayblastConfig:
+        custom_in = self._custom_in.value()
+        custom_out = self._custom_out.value()
+        custom_code = self._scene_stem()
+        output_name = self._resolve_output_name(
+            f"{custom_code}_custom"
+            if self._selected_source_mode() == "custom" and custom_code != "custom"
+            else f"customPB_{self._shot.code}"
+            if self._shot
+            else "customPB"
+        )
+
+        return MShotPlayblastConfig(
+            camera=str(self._custom_camera.currentText()),
+            shot=dummy_shot(
+                code=custom_code,
+                cut_in=custom_in,
+                cut_out=custom_out,
+                cut_duration=max(0, custom_out - custom_in),
+            ),
+            paths=self._paths_for_filename(output_name),
+            use_sequencer=False,
+        )
+
+    @staticmethod
+    def _scene_stem() -> str:
+        scene_name = Path(str(mc.file(query=True, sceneName=True) or "")).stem
+        return scene_name or "playblast"

--- a/pipeline/pipe/m/playblast/ui.py
+++ b/pipeline/pipe/m/playblast/ui.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import getpass
+import json
 import logging
 import os
 from abc import abstractmethod
 from collections import defaultdict
+from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -22,6 +25,7 @@ from Qt.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
+from shared.util import get_production_path
 
 from pipe.glui.dialogs import ButtonPair, MessageDialog
 from pipe.util import Playblaster
@@ -39,6 +43,68 @@ if TYPE_CHECKING:
     )
 
 log = logging.getLogger(__name__)
+
+
+def _current_login_username() -> str:
+    """Return the current login username with a robust fallback."""
+    try:
+        return os.getlogin()
+    except OSError:
+        return getpass.getuser()
+
+
+@lru_cache(maxsize=1)
+def _username_display_map() -> dict[str, str]:
+    """Load username->display name mappings from production JSON."""
+    mapping_path = get_production_path() / "json" / "usernames.json"
+    if not mapping_path.exists():
+        log.warning(
+            "Username mapping file was not found at %s. Falling back to login usernames.",
+            mapping_path,
+        )
+        return {}
+
+    try:
+        raw_data = json.loads(mapping_path.read_text(encoding="utf-8"))
+    except Exception:
+        log.exception(
+            "Could not load username mapping from %s. Falling back to login usernames.",
+            mapping_path,
+        )
+        return {}
+
+    if not isinstance(raw_data, dict):
+        log.warning(
+            "Username mapping file at %s must be a JSON object. Falling back to login usernames.",
+            mapping_path,
+        )
+        return {}
+
+    display_map: dict[str, str] = {}
+    for username, display_name in raw_data.items():
+        if not isinstance(username, str) or not isinstance(display_name, str):
+            continue
+        normalized_username = username.strip()
+        normalized_display_name = display_name.strip()
+        if not normalized_username or not normalized_display_name:
+            continue
+        display_map[normalized_username] = normalized_display_name
+        display_map.setdefault(normalized_username.lower(), normalized_display_name)
+
+    return display_map
+
+
+def resolve_artist_display_name() -> str:
+    """Resolve the artist HUD display name with username fallback."""
+    username = _current_login_username().strip()
+    if not username:
+        return ""
+
+    mapped_name = _username_display_map().get(username)
+    if mapped_name:
+        return mapped_name
+
+    return _username_display_map().get(username.lower(), username)
 
 
 class ClickableQLabel(QLabel):
@@ -103,7 +169,7 @@ class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
         )
         ARTIST = HudDefinition(
             "LnDartist",
-            command=lambda: os.getlogin(),
+            command=resolve_artist_display_name,
             event="SceneOpened",
             label="Artist:",
             section=5,

--- a/pipeline/pipe/m/playblast/ui.py
+++ b/pipeline/pipe/m/playblast/ui.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-import getpass
-import json
 import logging
 import os
 from abc import abstractmethod
 from collections import defaultdict
-from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -25,9 +22,9 @@ from Qt.QtWidgets import (
     QVBoxLayout,
     QWidget,
 )
-from shared.util import get_production_path
 
 from pipe.glui.dialogs import ButtonPair, MessageDialog
+from pipe.playblast_artist import resolve_artist_display_name
 from pipe.util import Playblaster
 
 from .playblaster import MPlayblaster
@@ -43,68 +40,6 @@ if TYPE_CHECKING:
     )
 
 log = logging.getLogger(__name__)
-
-
-def _current_login_username() -> str:
-    """Return the current login username with a robust fallback."""
-    try:
-        return os.getlogin()
-    except OSError:
-        return getpass.getuser()
-
-
-@lru_cache(maxsize=1)
-def _username_display_map() -> dict[str, str]:
-    """Load username->display name mappings from production JSON."""
-    mapping_path = get_production_path() / "json" / "usernames.json"
-    if not mapping_path.exists():
-        log.warning(
-            "Username mapping file was not found at %s. Falling back to login usernames.",
-            mapping_path,
-        )
-        return {}
-
-    try:
-        raw_data = json.loads(mapping_path.read_text(encoding="utf-8"))
-    except Exception:
-        log.exception(
-            "Could not load username mapping from %s. Falling back to login usernames.",
-            mapping_path,
-        )
-        return {}
-
-    if not isinstance(raw_data, dict):
-        log.warning(
-            "Username mapping file at %s must be a JSON object. Falling back to login usernames.",
-            mapping_path,
-        )
-        return {}
-
-    display_map: dict[str, str] = {}
-    for username, display_name in raw_data.items():
-        if not isinstance(username, str) or not isinstance(display_name, str):
-            continue
-        normalized_username = username.strip()
-        normalized_display_name = display_name.strip()
-        if not normalized_username or not normalized_display_name:
-            continue
-        display_map[normalized_username] = normalized_display_name
-        display_map.setdefault(normalized_username.lower(), normalized_display_name)
-
-    return display_map
-
-
-def resolve_artist_display_name() -> str:
-    """Resolve the artist HUD display name with username fallback."""
-    username = _current_login_username().strip()
-    if not username:
-        return ""
-
-    mapped_name = _username_display_map().get(username)
-    if mapped_name:
-        return mapped_name
-
-    return _username_display_map().get(username.lower(), username)
 
 
 class ClickableQLabel(QLabel):

--- a/pipeline/pipe/m/playblast/ui.py
+++ b/pipeline/pipe/m/playblast/ui.py
@@ -704,6 +704,22 @@ class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
         del config
         return []
 
+    @staticmethod
+    def _build_success_message(
+        output_paths: list[str],
+        post_playblast_messages: list[str],
+    ) -> str:
+        message_lines = ["Local playblast export successful."]
+        if output_paths:
+            message_lines.append("")
+            message_lines.append("Outputs:")
+            message_lines.extend(output_paths)
+        if post_playblast_messages:
+            message_lines.append("")
+            message_lines.append("Post-export:")
+            message_lines.extend(post_playblast_messages)
+        return "\n".join(message_lines)
+
     def do_export(self) -> None:
         try:
             config = self._generate_config()
@@ -737,13 +753,12 @@ class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
             post_playblast_messages = self._after_local_playblast(config)
         except Exception as exc:
             log.exception("Post-playblast actions failed")
-            post_playblast_messages = [f"Post-playblast actions failed: {exc}"]
+            post_playblast_messages = [
+                "Post-export actions failed. Local playblast files were still written.",
+                f"Reason: {exc}",
+            ]
 
         output_paths = self._collect_output_paths(config)
-        success_msg = "Playblast(s) successful!"
-        if output_paths:
-            success_msg += "\n\nOutputs:\n" + "\n".join(output_paths)
-        if post_playblast_messages:
-            success_msg += "\n\n" + "\n".join(post_playblast_messages)
+        success_msg = self._build_success_message(output_paths, post_playblast_messages)
         MessageDialog(self.parent(), success_msg).exec_()
         self.close()

--- a/pipeline/pipe/m/playblast/ui.py
+++ b/pipeline/pipe/m/playblast/ui.py
@@ -1,25 +1,26 @@
 from __future__ import annotations
 
 import logging
-import maya.cmds as mc
 import os
-
 from abc import abstractmethod
 from collections import defaultdict
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+import maya.cmds as mc
 from Qt import QtCore, QtWidgets
 from Qt.QtWidgets import QCheckBox, QHBoxLayout, QLabel, QWidget
 
 from pipe.glui.dialogs import ButtonPair, MessageDialog
-from pipe.util import checkbox_callback_helper, Playblaster
+from pipe.util import Playblaster, checkbox_callback_helper
 
 from .playblaster import MPlayblaster
 from .struct import HudDefinition, SaveLocation
 
 if TYPE_CHECKING:
-    from .struct import MPlayblastConfig, MShotDialogConfig
     from typing import Callable, Iterable
+
+    from .struct import MPlayblastConfig, MShotDialogConfig, MShotPlayblastConfig
 
 log = logging.getLogger(__name__)
 
@@ -287,7 +288,8 @@ class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
         paths: dict[Playblaster.PRESET, list[str | Path]] = defaultdict(list)
         for loc in locs:
             if self.is_location_enabled(dialog_id, loc.name):
-                paths[loc.preset].append(str(loc.path) + "/" + filename)
+                output_base = Path(str(loc.path)) / filename
+                paths[loc.preset].append(str(output_base))
 
         return paths
 
@@ -315,8 +317,62 @@ class PlayblastDialog(ButtonPair, QtWidgets.QMainWindow):
     def is_location_enabled(self, dialog_id: str, loc_name: str) -> bool:
         return self._enabled_loc_cbs[dialog_id][loc_name].isChecked()
 
-    def do_export(self):
-        self.playblaster.configure(self._generate_config()).playblast()
+    @staticmethod
+    def _output_count_for_shot(shot_cfg: MShotPlayblastConfig) -> int:
+        return sum(len(paths) for paths in shot_cfg.paths.values())
 
-        MessageDialog(self.parent(), "Playblast(s) successful!").exec_()
+    @staticmethod
+    def _collect_output_paths(config: MPlayblastConfig) -> list[str]:
+        output_paths: list[str] = []
+        for shot_cfg in config.shots:
+            for preset, bases in shot_cfg.paths.items():
+                for base in bases:
+                    output_paths.append(str(Path(str(base) + f".{preset.ext}")))
+        return output_paths
+
+    def _validate_config(self, config: MPlayblastConfig) -> str | None:
+        if not config.shots:
+            return "No playblast targets are enabled."
+
+        for shot_cfg in config.shots:
+            if self._output_count_for_shot(shot_cfg) < 1:
+                return (
+                    f"Target '{shot_cfg.shot.code}' has no output location selected. "
+                    "Please enable at least one destination."
+                )
+        return None
+
+    def do_export(self):
+        try:
+            config = self._generate_config()
+        except Exception as exc:
+            log.exception("Playblast config generation failed")
+            MessageDialog(
+                self.parent(),
+                f"Could not generate playblast settings.\n\n{exc}",
+                "Playblast Error",
+            ).exec_()
+            return
+
+        validation_error = self._validate_config(config)
+        if validation_error:
+            MessageDialog(self.parent(), validation_error, "Playblast").exec_()
+            return
+
+        try:
+            self.playblaster.configure(config).playblast()
+        except Exception as exc:
+            log.exception("Playblast export failed")
+            MessageDialog(
+                self.parent(),
+                f"Playblast failed.\n\n{exc}",
+                "Playblast Error",
+            ).exec_()
+            return
+
+        output_paths = self._collect_output_paths(config)
+        success_msg = "Playblast(s) successful!"
+        if output_paths:
+            success_msg += "\n\nOutputs:\n" + "\n".join(output_paths)
+        MessageDialog(self.parent(), success_msg).exec_()
         self.close()

--- a/pipeline/pipe/playblast_artist.py
+++ b/pipeline/pipe/playblast_artist.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import getpass
+import json
+import logging
+import os
+from functools import lru_cache
+from pathlib import Path
+
+from shared.util import get_production_path
+
+log = logging.getLogger(__name__)
+
+
+def _current_login_username() -> str:
+    """Return the current login username with a robust fallback."""
+    try:
+        return os.getlogin()
+    except OSError:
+        return getpass.getuser()
+
+
+def _username_mapping_path() -> Path:
+    return get_production_path() / "json" / "usernames.json"
+
+
+@lru_cache(maxsize=1)
+def _username_display_map() -> dict[str, str]:
+    """Load username->display name mappings from production JSON."""
+    mapping_path = _username_mapping_path()
+    if not mapping_path.exists():
+        log.warning(
+            "Username mapping file was not found at %s. Falling back to login usernames.",
+            mapping_path,
+        )
+        return {}
+
+    try:
+        raw_data = json.loads(mapping_path.read_text(encoding="utf-8"))
+    except Exception:
+        log.exception(
+            "Could not load username mapping from %s. Falling back to login usernames.",
+            mapping_path,
+        )
+        return {}
+
+    if not isinstance(raw_data, dict):
+        log.warning(
+            "Username mapping file at %s must be a JSON object. Falling back to login usernames.",
+            mapping_path,
+        )
+        return {}
+
+    display_map: dict[str, str] = {}
+    for username, display_name in raw_data.items():
+        if not isinstance(username, str) or not isinstance(display_name, str):
+            continue
+
+        normalized_username = username.strip()
+        normalized_display_name = display_name.strip()
+        if not normalized_username or not normalized_display_name:
+            continue
+
+        display_map[normalized_username] = normalized_display_name
+        display_map.setdefault(normalized_username.lower(), normalized_display_name)
+
+    return display_map
+
+
+def resolve_artist_display_name() -> str:
+    """Resolve the artist display name with username fallback."""
+    username = _current_login_username().strip()
+    if not username:
+        return ""
+
+    username_map = _username_display_map()
+    mapped_name = username_map.get(username)
+    if mapped_name:
+        return mapped_name
+
+    return username_map.get(username.lower(), username)
+
+
+__all__ = [
+    "resolve_artist_display_name",
+]

--- a/pipeline/pipe/playblast_naming.py
+++ b/pipeline/pipe/playblast_naming.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import logging
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable
+
+log = logging.getLogger(__name__)
+
+PLAYBLAST_VERSION_PADDING = 3
+
+
+def playblast_date_folder(now: datetime | None = None) -> str:
+    """Return the ISO date folder token used by playblast exports."""
+    timestamp = now or datetime.now()
+    return timestamp.strftime("%Y-%m-%d")
+
+
+def playblast_version_token(
+    version: int, *, padding: int = PLAYBLAST_VERSION_PADDING
+) -> str:
+    """Return a normalized version token like 'v001'."""
+    if version < 1:
+        raise ValueError("Playblast version must be at least 1.")
+    return f"v{version:0{padding}d}"
+
+
+def playblast_output_basename(
+    prefix: str,
+    *,
+    version: int,
+    now: datetime | None = None,
+    padding: int = PLAYBLAST_VERSION_PADDING,
+) -> str:
+    """Build a final playblast basename as '<prefix>_YYYY-MM-DD.v###'."""
+    normalized_prefix = prefix.strip()
+    if not normalized_prefix:
+        raise ValueError("Playblast output prefix cannot be empty.")
+
+    day_token = playblast_date_folder(now)
+    version_token = playblast_version_token(version, padding=padding)
+    return f"{normalized_prefix}_{day_token}.{version_token}"
+
+
+def next_playblast_version(
+    prefix: str,
+    destination_dirs: Iterable[Path | str],
+    *,
+    now: datetime | None = None,
+) -> int:
+    """Return the next available version number across destination folders."""
+    normalized_prefix = prefix.strip()
+    if not normalized_prefix:
+        raise ValueError("Playblast output prefix cannot be empty.")
+
+    day_token = playblast_date_folder(now)
+    version_pattern = _playblast_version_pattern(normalized_prefix, day_token)
+    highest_version = 0
+
+    for directory in _existing_directories(destination_dirs):
+        for version in _versions_in_directory(directory, version_pattern):
+            highest_version = max(highest_version, version)
+
+    return highest_version + 1
+
+
+def resolve_versioned_playblast_basename(
+    prefix: str,
+    destination_dirs: Iterable[Path | str],
+    *,
+    now: datetime | None = None,
+    padding: int = PLAYBLAST_VERSION_PADDING,
+) -> str:
+    """Resolve a new basename using the next version across all destinations."""
+    next_version = next_playblast_version(prefix, destination_dirs, now=now)
+    return playblast_output_basename(
+        prefix,
+        version=next_version,
+        now=now,
+        padding=padding,
+    )
+
+
+def _playblast_version_pattern(prefix: str, day_token: str) -> re.Pattern[str]:
+    escaped_prefix = re.escape(prefix)
+    escaped_day_token = re.escape(day_token)
+    return re.compile(
+        rf"^{escaped_prefix}_{escaped_day_token}\.v(?P<version>\d+)(?:\..+)?$"
+    )
+
+
+def _existing_directories(destination_dirs: Iterable[Path | str]) -> list[Path]:
+    directories: list[Path] = []
+    for raw_path in destination_dirs:
+        path = Path(str(raw_path))
+        if path.exists() and path.is_dir():
+            directories.append(path)
+    return directories
+
+
+def _versions_in_directory(directory: Path, pattern: re.Pattern[str]) -> list[int]:
+    versions: list[int] = []
+    try:
+        for item in directory.iterdir():
+            if not item.is_file():
+                continue
+            match = pattern.match(item.name)
+            if not match:
+                continue
+            try:
+                versions.append(int(match.group("version")))
+            except Exception:
+                continue
+    except Exception:
+        log.warning("Could not scan playblast versions in %s", directory, exc_info=True)
+
+    return versions

--- a/pipeline/pipe/playblast_shotgrid.py
+++ b/pipeline/pipe/playblast_shotgrid.py
@@ -1,0 +1,391 @@
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+log = logging.getLogger(__name__)
+
+UPLOAD_STATUS_SUCCESS = "success"
+UPLOAD_STATUS_FAILED = "failed"
+
+
+@dataclass(frozen=True)
+class PlayblastVersionUploadRequest:
+    """Normalized input for creating and uploading a ShotGrid Version."""
+
+    shot_code: str
+    movie_path: Path | str
+    version_name: str
+    description: str | None = None
+    path_to_frames: str | None = None
+    artist_display_name: str | None = None
+    task_id: int | None = None
+    playlist_id: int | None = None
+    upload_field: str = "sg_uploaded_movie"
+    extra_version_fields: Mapping[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class PlayblastVersionUploadResult:
+    """Outcome for a playblast ShotGrid upload attempt."""
+
+    status: str
+    message: str
+    shot_code: str
+    version_name: str
+    movie_path: Path | None = None
+    version_id: int | None = None
+    attachment_id: int | None = None
+    warnings: tuple[str, ...] = ()
+
+    @property
+    def ok(self) -> bool:
+        return self.status == UPLOAD_STATUS_SUCCESS
+
+
+@dataclass(frozen=True)
+class _NormalizedUploadRequest:
+    shot_code: str
+    movie_path: Path
+    version_name: str
+    description: str | None
+    path_to_frames: str | None
+    artist_display_name: str | None
+    task_id: int | None
+    playlist_id: int | None
+    upload_field: str
+    extra_version_fields: dict[str, Any]
+
+
+def default_version_name_from_movie_path(movie_path: Path | str) -> str:
+    """Derive a default Version code from the playblast filename stem."""
+    return Path(str(movie_path)).stem.strip()
+
+
+def upload_playblast_version(
+    request: PlayblastVersionUploadRequest,
+    *,
+    conn: Any | None = None,
+) -> PlayblastVersionUploadResult:
+    """Create a ShotGrid Version for a shot and upload the playblast movie.
+
+    This is the single entrypoint for playblast-to-ShotGrid uploads.
+    """
+
+    normalized_or_error = _normalize_request(request)
+    if isinstance(normalized_or_error, PlayblastVersionUploadResult):
+        return normalized_or_error
+    normalized = normalized_or_error
+
+    try:
+        connection = conn or _default_db_connection()
+    except Exception as exc:
+        log.exception("Could not resolve ShotGrid connection")
+        return _failed_result(
+            normalized,
+            f"Could not connect to ShotGrid: {exc}",
+        )
+
+    try:
+        shot = connection.get_shot_by_code(normalized.shot_code)
+    except Exception as exc:
+        log.exception("Could not resolve shot '%s' in ShotGrid", normalized.shot_code)
+        return _failed_result(
+            normalized,
+            f"Could not resolve shot '{normalized.shot_code}' in ShotGrid: {exc}",
+        )
+
+    shot_id = _extract_entity_id(shot)
+    if shot_id is None:
+        return _failed_result(
+            normalized,
+            f"Shot '{normalized.shot_code}' is missing a valid ShotGrid id.",
+        )
+
+    project_id = _resolve_project_id(connection)
+    if project_id is None:
+        return _failed_result(
+            normalized,
+            "Could not resolve ShotGrid project id from the DB connection.",
+        )
+
+    warnings: list[str] = []
+    user_id = _resolve_user_id(connection, normalized.artist_display_name, warnings)
+
+    payload = _build_version_payload(
+        normalized,
+        shot_id=shot_id,
+        project_id=project_id,
+        user_id=user_id,
+    )
+
+    shotgrid_client = _resolve_shotgrid_client(connection)
+    if shotgrid_client is None:
+        return _failed_result(
+            normalized,
+            "DB connection does not expose a ShotGrid client for Version creation.",
+            warnings=warnings,
+        )
+
+    try:
+        created_version = shotgrid_client.create("Version", payload)
+    except Exception as exc:
+        log.exception(
+            "ShotGrid Version creation failed for shot '%s'", normalized.shot_code
+        )
+        return _failed_result(
+            normalized,
+            f"ShotGrid Version creation failed: {exc}",
+            warnings=warnings,
+        )
+
+    version_id = _extract_entity_id(created_version)
+    if version_id is None:
+        return _failed_result(
+            normalized,
+            "ShotGrid did not return a valid Version id after creation.",
+            warnings=warnings,
+        )
+
+    try:
+        attachment_id = connection.upload_version_movie(
+            version_id,
+            str(normalized.movie_path),
+            field=normalized.upload_field,
+        )
+    except Exception as exc:
+        log.exception("ShotGrid movie upload failed for Version %s", version_id)
+        return _failed_result(
+            normalized,
+            f"ShotGrid movie upload failed: {exc}",
+            version_id=version_id,
+            warnings=warnings,
+        )
+
+    return PlayblastVersionUploadResult(
+        status=UPLOAD_STATUS_SUCCESS,
+        message="Version created and movie uploaded to ShotGrid.",
+        shot_code=normalized.shot_code,
+        version_name=normalized.version_name,
+        movie_path=normalized.movie_path,
+        version_id=version_id,
+        attachment_id=_extract_entity_id(attachment_id),
+        warnings=tuple(warnings),
+    )
+
+
+def _normalize_request(
+    request: PlayblastVersionUploadRequest,
+) -> _NormalizedUploadRequest | PlayblastVersionUploadResult:
+    shot_code = str(request.shot_code).strip()
+    if not shot_code:
+        return PlayblastVersionUploadResult(
+            status=UPLOAD_STATUS_FAILED,
+            message="Shot code is required for ShotGrid upload.",
+            shot_code="",
+            version_name=str(request.version_name).strip(),
+            movie_path=None,
+        )
+
+    version_name = str(request.version_name).strip()
+    if not version_name:
+        return PlayblastVersionUploadResult(
+            status=UPLOAD_STATUS_FAILED,
+            message="Version name is required for ShotGrid upload.",
+            shot_code=shot_code,
+            version_name="",
+            movie_path=None,
+        )
+
+    movie_path = Path(str(request.movie_path)).expanduser().resolve()
+    if not movie_path.exists() or not movie_path.is_file():
+        return PlayblastVersionUploadResult(
+            status=UPLOAD_STATUS_FAILED,
+            message=f"Playblast movie file was not found: {movie_path}",
+            shot_code=shot_code,
+            version_name=version_name,
+            movie_path=movie_path,
+        )
+
+    if movie_path.stat().st_size < 1:
+        return PlayblastVersionUploadResult(
+            status=UPLOAD_STATUS_FAILED,
+            message=f"Playblast movie file is empty: {movie_path}",
+            shot_code=shot_code,
+            version_name=version_name,
+            movie_path=movie_path,
+        )
+
+    upload_field = str(request.upload_field).strip()
+    if not upload_field:
+        return PlayblastVersionUploadResult(
+            status=UPLOAD_STATUS_FAILED,
+            message="Upload field cannot be empty.",
+            shot_code=shot_code,
+            version_name=version_name,
+            movie_path=movie_path,
+        )
+
+    description = _optional_text(request.description)
+    path_to_frames = _optional_text(request.path_to_frames) or str(movie_path)
+    artist_display_name = _optional_text(request.artist_display_name)
+    task_id = _optional_positive_int(request.task_id)
+    playlist_id = _optional_positive_int(request.playlist_id)
+
+    normalized_extra_fields: dict[str, Any] = {}
+    for field_name, value in request.extra_version_fields.items():
+        normalized_name = str(field_name).strip()
+        if not normalized_name:
+            continue
+        if value is None:
+            continue
+        normalized_extra_fields[normalized_name] = value
+
+    return _NormalizedUploadRequest(
+        shot_code=shot_code,
+        movie_path=movie_path,
+        version_name=version_name,
+        description=description,
+        path_to_frames=path_to_frames,
+        artist_display_name=artist_display_name,
+        task_id=task_id,
+        playlist_id=playlist_id,
+        upload_field=upload_field,
+        extra_version_fields=normalized_extra_fields,
+    )
+
+
+def _optional_text(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _optional_positive_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        parsed = int(value)
+    except Exception:
+        return None
+    if parsed < 1:
+        return None
+    return parsed
+
+
+def _default_db_connection() -> Any:
+    from env_sg import DB_Config
+
+    from pipe.db import DB
+
+    return DB.Get(DB_Config)
+
+
+def _resolve_project_id(connection: Any) -> int | None:
+    project_id = getattr(connection, "_id", None)
+    if isinstance(project_id, int) and project_id > 0:
+        return project_id
+    return None
+
+
+def _resolve_shotgrid_client(connection: Any) -> Any | None:
+    return getattr(connection, "_sg", None)
+
+
+def _resolve_user_id(
+    connection: Any,
+    artist_display_name: str | None,
+    warnings: list[str],
+) -> int | None:
+    if not artist_display_name:
+        return None
+
+    try:
+        user = connection.get_user_by_name(artist_display_name)
+    except Exception:
+        warnings.append(
+            f"Could not resolve ShotGrid user '{artist_display_name}'. Continuing without user link."
+        )
+        return None
+
+    user_id = _extract_entity_id(user)
+    if user_id is None:
+        warnings.append(
+            f"Resolved user for '{artist_display_name}' is missing a valid id. Continuing without user link."
+        )
+        return None
+    return user_id
+
+
+def _build_version_payload(
+    request: _NormalizedUploadRequest,
+    *,
+    shot_id: int,
+    project_id: int,
+    user_id: int | None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "code": request.version_name,
+        "entity": {"type": "Shot", "id": shot_id},
+        "project": {"type": "Project", "id": project_id},
+    }
+
+    if request.description:
+        payload["description"] = request.description
+    if request.path_to_frames:
+        payload["sg_path_to_frames"] = request.path_to_frames
+    if user_id is not None:
+        payload["user"] = {"type": "HumanUser", "id": user_id}
+    if request.task_id is not None:
+        payload["sg_task"] = {"type": "Task", "id": request.task_id}
+    if request.playlist_id is not None:
+        payload["playlists"] = [{"type": "Playlist", "id": request.playlist_id}]
+
+    payload.update(request.extra_version_fields)
+    return payload
+
+
+def _extract_entity_id(entity: Any) -> int | None:
+    if isinstance(entity, int) and entity > 0:
+        return entity
+    if isinstance(entity, Mapping):
+        entity_id = entity.get("id")
+        if isinstance(entity_id, int) and entity_id > 0:
+            return entity_id
+        return None
+
+    entity_id = getattr(entity, "id", None)
+    if isinstance(entity_id, int) and entity_id > 0:
+        return entity_id
+    return None
+
+
+def _failed_result(
+    request: _NormalizedUploadRequest,
+    message: str,
+    *,
+    version_id: int | None = None,
+    warnings: list[str] | None = None,
+) -> PlayblastVersionUploadResult:
+    return PlayblastVersionUploadResult(
+        status=UPLOAD_STATUS_FAILED,
+        message=message,
+        shot_code=request.shot_code,
+        version_name=request.version_name,
+        movie_path=request.movie_path,
+        version_id=version_id,
+        warnings=tuple(warnings or []),
+    )
+
+
+__all__ = [
+    "PlayblastVersionUploadRequest",
+    "PlayblastVersionUploadResult",
+    "UPLOAD_STATUS_FAILED",
+    "UPLOAD_STATUS_SUCCESS",
+    "default_version_name_from_movie_path",
+    "upload_playblast_version",
+]

--- a/pipeline/pipe/playblast_shotgrid.py
+++ b/pipeline/pipe/playblast_shotgrid.py
@@ -132,33 +132,20 @@ def upload_playblast_version(
             f"Shot '{normalized.shot_code}' is missing a valid ShotGrid id.",
         )
 
-    project_id = _resolve_project_id(connection)
-    if project_id is None:
-        return _failed_result(
-            normalized,
-            "Could not resolve ShotGrid project id from the DB connection.",
-        )
-
     warnings: list[str] = []
     user_id = _resolve_user_id(connection, normalized.artist_display_name, warnings)
 
-    payload = _build_version_payload(
-        normalized,
-        shot_id=shot_id,
-        project_id=project_id,
-        user_id=user_id,
-    )
-
-    shotgrid_client = _resolve_shotgrid_client(connection)
-    if shotgrid_client is None:
-        return _failed_result(
-            normalized,
-            "DB connection does not expose a ShotGrid client for Version creation.",
-            warnings=warnings,
-        )
-
     try:
-        created_version = shotgrid_client.create("Version", payload)
+        created_version = connection.create_version_for_shot(
+            shot=shot,
+            code=normalized.version_name,
+            user=user_id,
+            task=normalized.task_id,
+            video_path=normalized.path_to_frames,
+            description=normalized.description,
+            playlist_id=normalized.playlist_id,
+            extra_fields=normalized.extra_version_fields,
+        )
     except Exception as exc:
         log.exception(
             "ShotGrid Version creation failed for shot '%s'", normalized.shot_code
@@ -331,17 +318,6 @@ def _default_db_connection() -> Any:
     return DB.Get(DB_Config)
 
 
-def _resolve_project_id(connection: Any) -> int | None:
-    project_id = getattr(connection, "_id", None)
-    if isinstance(project_id, int) and project_id > 0:
-        return project_id
-    return None
-
-
-def _resolve_shotgrid_client(connection: Any) -> Any | None:
-    return getattr(connection, "_sg", None)
-
-
 def _resolve_user_id(
     connection: Any,
     artist_display_name: str | None,
@@ -365,34 +341,6 @@ def _resolve_user_id(
         )
         return None
     return user_id
-
-
-def _build_version_payload(
-    request: _NormalizedUploadRequest,
-    *,
-    shot_id: int,
-    project_id: int,
-    user_id: int | None,
-) -> dict[str, Any]:
-    payload: dict[str, Any] = {
-        "code": request.version_name,
-        "entity": {"type": "Shot", "id": shot_id},
-        "project": {"type": "Project", "id": project_id},
-    }
-
-    if request.description:
-        payload["description"] = request.description
-    if request.path_to_frames:
-        payload["sg_path_to_frames"] = request.path_to_frames
-    if user_id is not None:
-        payload["user"] = {"type": "HumanUser", "id": user_id}
-    if request.task_id is not None:
-        payload["sg_task"] = {"type": "Task", "id": request.task_id}
-    if request.playlist_id is not None:
-        payload["playlists"] = [{"type": "Playlist", "id": request.playlist_id}]
-
-    payload.update(request.extra_version_fields)
-    return payload
 
 
 def _extract_entity_id(entity: Any) -> int | None:

--- a/pipeline/pipe/playblast_shotgrid.py
+++ b/pipeline/pipe/playblast_shotgrid.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any, Iterable, Mapping
 
 log = logging.getLogger(__name__)
 
@@ -62,6 +62,34 @@ class _NormalizedUploadRequest:
 def default_version_name_from_movie_path(movie_path: Path | str) -> str:
     """Derive a default Version code from the playblast filename stem."""
     return Path(str(movie_path)).stem.strip()
+
+
+def resolve_preferred_upload_movie_path(
+    output_paths: Iterable[Path | str],
+    *,
+    preferred_paths: Iterable[Path | str] | None = None,
+) -> Path | None:
+    """Resolve a deterministic movie path for ShotGrid upload.
+
+    Selection order:
+    1) first valid file in `preferred_paths`
+    2) first valid file in `output_paths`
+
+    A valid file exists on disk and is non-empty.
+    """
+
+    normalized_outputs = _normalized_unique_paths(output_paths)
+    normalized_preferred = _normalized_unique_paths(preferred_paths or [])
+
+    for path in normalized_preferred:
+        if _is_valid_movie_file(path):
+            return path
+
+    for path in normalized_outputs:
+        if _is_valid_movie_file(path):
+            return path
+
+    return None
 
 
 def upload_playblast_version(
@@ -257,6 +285,25 @@ def _normalize_request(
     )
 
 
+def _normalized_unique_paths(paths: Iterable[Path | str]) -> list[Path]:
+    normalized_paths: list[Path] = []
+    seen_paths: set[Path] = set()
+    for raw_path in paths:
+        path = Path(str(raw_path)).expanduser().resolve()
+        if path in seen_paths:
+            continue
+        seen_paths.add(path)
+        normalized_paths.append(path)
+    return normalized_paths
+
+
+def _is_valid_movie_file(path: Path) -> bool:
+    try:
+        return path.exists() and path.is_file() and path.stat().st_size > 0
+    except Exception:
+        return False
+
+
 def _optional_text(value: Any) -> str | None:
     if value is None:
         return None
@@ -387,5 +434,6 @@ __all__ = [
     "UPLOAD_STATUS_FAILED",
     "UPLOAD_STATUS_SUCCESS",
     "default_version_name_from_movie_path",
+    "resolve_preferred_upload_movie_path",
     "upload_playblast_version",
 ]

--- a/pipeline/pipe/playblast_shotgrid.py
+++ b/pipeline/pipe/playblast_shotgrid.py
@@ -113,7 +113,7 @@ def upload_playblast_version(
         log.exception("Could not resolve ShotGrid connection")
         return _failed_result(
             normalized,
-            f"Could not connect to ShotGrid: {exc}",
+            "Could not connect to ShotGrid: " f"{_format_exception_details(exc)}",
         )
 
     try:
@@ -122,7 +122,9 @@ def upload_playblast_version(
         log.exception("Could not resolve shot '%s' in ShotGrid", normalized.shot_code)
         return _failed_result(
             normalized,
-            f"Could not resolve shot '{normalized.shot_code}' in ShotGrid: {exc}",
+            "Could not resolve shot "
+            f"'{normalized.shot_code}' in ShotGrid: "
+            f"{_format_exception_details(exc)}",
         )
 
     shot_id = _extract_entity_id(shot)
@@ -152,7 +154,7 @@ def upload_playblast_version(
         )
         return _failed_result(
             normalized,
-            f"ShotGrid Version creation failed: {exc}",
+            "ShotGrid Version creation failed: " f"{_format_exception_details(exc)}",
             warnings=warnings,
         )
 
@@ -174,7 +176,7 @@ def upload_playblast_version(
         log.exception("ShotGrid movie upload failed for Version %s", version_id)
         return _failed_result(
             normalized,
-            f"ShotGrid movie upload failed: {exc}",
+            "ShotGrid movie upload failed: " f"{_format_exception_details(exc)}",
             version_id=version_id,
             warnings=warnings,
         )
@@ -308,6 +310,32 @@ def _optional_positive_int(value: Any) -> int | None:
     if parsed < 1:
         return None
     return parsed
+
+
+def _format_exception_details(exc: BaseException) -> str:
+    """Flatten exception/cause/context chain into one readable message."""
+    messages: list[str] = []
+    visited_exception_ids: set[int] = set()
+    current_exc: BaseException | None = exc
+
+    while current_exc is not None:
+        exception_id = id(current_exc)
+        if exception_id in visited_exception_ids:
+            break
+        visited_exception_ids.add(exception_id)
+
+        exception_name = type(current_exc).__name__
+        exception_message = str(current_exc).strip()
+        if exception_message:
+            messages.append(f"{exception_name}: {exception_message}")
+        else:
+            messages.append(exception_name)
+
+        current_exc = current_exc.__cause__ or current_exc.__context__
+
+    if not messages:
+        return "Unknown exception."
+    return " <- ".join(messages)
 
 
 def _default_db_connection() -> Any:


### PR DESCRIPTION
This is an over the top over haul that overturns the old playblasting tools

The playblasting itself has not changed much, other than to replace netIDs with actual names (You're welvome darthvad)

But we did remove the matrix UI in favor of tabs. Technically this means you cant do a custom playblast and a shot playblast at the same time but I don't know why you would do that anyways, and neither do the animators

What we have gained? Clarity! Just look at these UIs!

<img width="666" height="652" alt="image" src="https://github.com/user-attachments/assets/60d541dc-3236-46a4-bb13-f392f86446ee" />

<img width="666" height="630" alt="image" src="https://github.com/user-attachments/assets/97eb7a0e-1fc0-4cde-a8da-b9cd8ecc4120" />

<img width="666" height="630" alt="image" src="https://github.com/user-attachments/assets/5a9fd0bd-cdd6-480d-aef6-12e142359bc1" />

<img width="1321" height="1032" alt="image" src="https://github.com/user-attachments/assets/a3798623-fcfe-447b-ab2b-c4df6a39cea8" />

Notice that little "Upload to shotgrid" toggle? Thats the biggest win if I do say so myself. 

The houdini playblaster might still need some love. Noteably:
- Upload to shotgrid places it as a shot version, but FX actually needs to place it in a dailies review, so that isnt automatic yet
- We can totally burn in text for things like shotcode and author and frame number. Maya supports HUD stuff so its already all there, but houdini is not so nice (though I haven't looked into it much). Fortunately we got ffmpeg so we can ball later when I have time regardless of what houdini supports