### PR TITLE
More Rig build Tests

### DIFF
--- a/pipeline/pipe/m/rig/builder/test/common.py
+++ b/pipeline/pipe/m/rig/builder/test/common.py
@@ -9,10 +9,18 @@ CONTROLS_SET_NAME = "rig_controllers_grp"
 GEO_SET_NAME = "rig_geo_grp"
 
 
-def is_visible(object: str) -> bool:
+def get_dag_path(transform: str) -> MDagPath:
     sel: MSelectionList = MSelectionList()
-    sel.add(object)
+    sel.add(transform)
     dag_path: MDagPath = sel.getDagPath(0)
+    return dag_path
+
+
+def is_visible(object: str) -> bool:
+    try:
+        dag_path: MDagPath = get_dag_path(object)
+    except TypeError:
+        return False
     return dag_path.isVisible()
 
 
@@ -57,9 +65,22 @@ def get_all_controls_by_name() -> list[str]:
     ]
 
 
-def is_control(transform: str) -> bool:
+def get_all_visible_meshes() -> list[str]:
+    mesh_shapes: list[str] = cmds.ls(type="mesh")
+    mesh_transforms: list[str] = cmds.listRelatives(mesh_shapes, parent=True) or []  # type: ignore
+
+    visible_geo: list[str] = [geo for geo in mesh_transforms if is_visible(geo)]
+    return visible_geo
+
+
+def is_control(transform: str, strict: bool = True) -> bool:
     """Returns True if the given transform is a tagged controller."""
-    return cmds.controller(transform, query=True, isController=True)  # type: ignore
+    if strict:
+        return cmds.controller(transform, query=True, isController=True)  # type: ignore
+    else:
+        return cmds.controller(transform, query=True, isController=True) or bool(
+            MATCH_CONTROLS_REGEX.search(transform)
+        )  # type: ignore
 
 
 def format_max_items(

--- a/pipeline/pipe/m/rig/builder/test/common.py
+++ b/pipeline/pipe/m/rig/builder/test/common.py
@@ -1,6 +1,6 @@
 import json
 import re
-from typing import Iterator, Literal
+from typing import Iterable, Iterator, Literal
 
 from maya import cmds
 from maya.api.OpenMaya import MDagPath, MFnDagNode, MItDag, MSelectionList
@@ -60,3 +60,42 @@ def get_all_controls_by_name() -> list[str]:
 def is_control(transform: str) -> bool:
     """Returns True if the given transform is a tagged controller."""
     return cmds.controller(transform, query=True, isController=True)  # type: ignore
+
+
+def format_max_items(
+    iterable: Iterable, item_name: str = "item(s)", max_items: int = 10
+):
+    displayed_items = []
+    count = 0
+
+    # Try to get length if possible
+    try:
+        total_len = len(iterable)  # works for lists, tuples, sets # type: ignore
+    except TypeError:
+        total_len = None
+
+    it: Iterator = iter(iterable)
+    try:
+        while count < max_items:
+            displayed_items.append(next(it))
+            count += 1
+    except StopIteration:
+        # Less than max_items
+        return f"[{', '.join(map(str, displayed_items))}]"
+
+    # Check if there are more items without consuming all
+    try:
+        next(it)
+        more = True
+    except StopIteration:
+        more = False
+
+    result = f"[{', '.join(map(str, displayed_items))}"
+    if more:
+        result += ", ...]"
+    else:
+        result += "]"
+
+    if total_len is not None:
+        result += f" {total_len} {item_name}"
+    return result

--- a/pipeline/pipe/m/rig/builder/test/common.py
+++ b/pipeline/pipe/m/rig/builder/test/common.py
@@ -19,7 +19,7 @@ def get_dag_path(transform: str) -> MDagPath:
 def is_visible(object: str) -> bool:
     try:
         dag_path: MDagPath = get_dag_path(object)
-    except TypeError:
+    except Exception:
         return False
     return dag_path.isVisible()
 

--- a/pipeline/pipe/m/rig/builder/test/core.py
+++ b/pipeline/pipe/m/rig/builder/test/core.py
@@ -21,7 +21,10 @@ class TestRunner:
         """Runs all of the TestRunner's tests and returns True if all tests passed."""
         passing: bool = True
         for test in self.tests:
-            test_passed = test.run()
+            try:
+                test_passed = test.run()
+            except Exception:
+                test_passed = False
             if self._test_run_callback is not None:
                 self._test_run_callback(test, test_passed)
             if not test_passed:

--- a/pipeline/pipe/m/rig/builder/test/core.py
+++ b/pipeline/pipe/m/rig/builder/test/core.py
@@ -23,7 +23,8 @@ class TestRunner:
         for test in self.tests:
             try:
                 test_passed = test.run()
-            except Exception:
+            except Exception as e:
+                test_log.error(f"{test.name}: {e}", exc_info=e)
                 test_passed = False
             if self._test_run_callback is not None:
                 self._test_run_callback(test, test_passed)

--- a/pipeline/pipe/m/rig/builder/test/tests/__init__.py
+++ b/pipeline/pipe/m/rig/builder/test/tests/__init__.py
@@ -8,6 +8,7 @@ from .joint import TestHiddenJoints
 from .namespace import TestNamespaces
 from .ng import TestNgSkinData
 from .node import TestUnknownNodes
+from .root_transform import TestRootRotate, TestRootScale, TestRootTranslation
 
 RIG_BUILD_TESTS: list[type[RigBuildTest]] = [
     TestHiddenJoints,
@@ -21,6 +22,9 @@ RIG_BUILD_TESTS: list[type[RigBuildTest]] = [
     TestUnknownNodes,
     TestCyclesDG,
     TestNgSkinData,
+    TestRootTranslation,
+    TestRootRotate,
+    TestRootScale,
 ]
 
 __all__ = [
@@ -36,4 +40,7 @@ __all__ = [
     "TestNamespaces",
     "TestNgSkinData",
     "TestUnknownNodes",
+    "TestRootTranslation",
+    "TestRootRotate",
+    "TestRootScale",
 ]

--- a/pipeline/pipe/m/rig/builder/test/tests/__init__.py
+++ b/pipeline/pipe/m/rig/builder/test/tests/__init__.py
@@ -15,6 +15,7 @@ RIG_BUILD_TESTS: list[type[RigBuildTest]] = [
     TestControlsZeroed,
     TestDuplicateDagNames,
     TestGeoInSet,
+    TestNamespaces,
     TestUnknownNodes,
     TestCyclesDG,
     TestNgSkinData,

--- a/pipeline/pipe/m/rig/builder/test/tests/__init__.py
+++ b/pipeline/pipe/m/rig/builder/test/tests/__init__.py
@@ -3,6 +3,7 @@ from .control import TestControlsInSet, TestControlsTagged, TestControlsZeroed
 from .cycle import TestCyclesDG
 from .duplicate import TestDuplicateDagNames
 from .geo import TestGeoInSet
+from .hierarchy import TestSingleHierachy
 from .joint import TestHiddenJoints
 from .namespace import TestNamespaces
 from .ng import TestNgSkinData
@@ -15,6 +16,7 @@ RIG_BUILD_TESTS: list[type[RigBuildTest]] = [
     TestControlsZeroed,
     TestDuplicateDagNames,
     TestGeoInSet,
+    TestSingleHierachy,
     TestNamespaces,
     TestUnknownNodes,
     TestCyclesDG,
@@ -29,6 +31,7 @@ __all__ = [
     "TestCyclesDG",
     "TestDuplicateDagNames",
     "TestGeoInSet",
+    "TestSingleHierachy",
     "TestHiddenJoints",
     "TestNamespaces",
     "TestNgSkinData",

--- a/pipeline/pipe/m/rig/builder/test/tests/control.py
+++ b/pipeline/pipe/m/rig/builder/test/tests/control.py
@@ -1,7 +1,7 @@
 from maya import cmds
 
 from .. import RigBuildTest
-from ..common import CONTROLS_SET_NAME, get_all_controls_by_name
+from ..common import CONTROLS_SET_NAME, format_max_items, get_all_controls_by_name
 
 
 class TestControlsZeroed(RigBuildTest):
@@ -52,7 +52,8 @@ class TestControlsZeroed(RigBuildTest):
 
         if problem_controls:
             self.log_warn(
-                f"Scene has controls with non zeroed transforms: {problem_controls}"
+                "Scene has controls with non zeroed transforms: "
+                "{format_max_items(problem_controls, 'controls')}"
             )
             return False
         else:
@@ -76,7 +77,8 @@ class TestControlsTagged(RigBuildTest):
         problem_controls = set(controls) - set(tagged_controls)
         if problem_controls:
             self.log_warn(
-                f"Scene has controls that aren't tagged as controllers: {problem_controls}"
+                "Scene has controls that aren't tagged as controllers: "
+                "{format_max_items(problem_controls, 'controls')}"
             )
             return False
         else:
@@ -103,7 +105,8 @@ class TestControlsInSet(RigBuildTest):
             problem_controls = set(controls)
         if problem_controls:
             self.log_warn(
-                f'Scene has controls that aren\'t in the controls set: {problem_controls} needs added to the "{CONTROLS_SET_NAME}" set.'
+                "Scene has controls that aren't in the controls set: "
+                f"{format_max_items(problem_controls, 'control(s)')} need added to the \"{CONTROLS_SET_NAME}\" set."
             )
             return False
         else:

--- a/pipeline/pipe/m/rig/builder/test/tests/duplicate.py
+++ b/pipeline/pipe/m/rig/builder/test/tests/duplicate.py
@@ -3,7 +3,7 @@ from collections import Counter, defaultdict
 from maya.api.OpenMaya import MItDag
 
 from .. import RigBuildTest
-from ..common import iter_dag_nodes
+from ..common import format_max_items, iter_dag_nodes
 
 
 class TestDuplicateDagNames(RigBuildTest):
@@ -30,7 +30,9 @@ class TestDuplicateDagNames(RigBuildTest):
             if count > 1
         ]
         if duplicates:
-            self.log_warn(f"Scene has duplicate DAG node names: {duplicates}")
+            self.log_warn(
+                f"Scene has duplicate DAG node names: {format_max_items(duplicates, 'duplicate(s)')}"
+            )
             return False
         else:
             self.log_success()

--- a/pipeline/pipe/m/rig/builder/test/tests/geo.py
+++ b/pipeline/pipe/m/rig/builder/test/tests/geo.py
@@ -1,7 +1,12 @@
 from maya import cmds
 
 from .. import RigBuildTest
-from ..common import GEO_SET_NAME, format_max_items, is_control, is_visible
+from ..common import (
+    GEO_SET_NAME,
+    format_max_items,
+    get_all_visible_meshes,
+    is_control,
+)
 
 
 class TestGeoInSet(RigBuildTest):
@@ -14,10 +19,7 @@ class TestGeoInSet(RigBuildTest):
         super().__init__("All geometry in set")
 
     def run(self) -> bool:
-        mesh_shapes: list[str] = cmds.ls(type="mesh")
-        mesh_transforms: list[str] = cmds.listRelatives(mesh_shapes, parent=True) or []  # type: ignore
-
-        visible_geo: set[str] = set(geo for geo in mesh_transforms if is_visible(geo))
+        visible_geo: set[str] = set(get_all_visible_meshes())
         problem_meshes: set[str]
         try:
             meshes_in_set: list[str] = cmds.sets(GEO_SET_NAME, query=True)  # type: ignore

--- a/pipeline/pipe/m/rig/builder/test/tests/geo.py
+++ b/pipeline/pipe/m/rig/builder/test/tests/geo.py
@@ -1,7 +1,7 @@
 from maya import cmds
 
 from .. import RigBuildTest
-from ..common import GEO_SET_NAME, is_control, is_visible
+from ..common import GEO_SET_NAME, format_max_items, is_control, is_visible
 
 
 class TestGeoInSet(RigBuildTest):
@@ -30,7 +30,8 @@ class TestGeoInSet(RigBuildTest):
 
         if problem_meshes:
             self.log_warn(
-                f'Scene has geometry that isn\'t in the geo set: {problem_meshes} needs added to the "{GEO_SET_NAME}" set.'
+                f"Scene has geometry that isn't in the geo set: "
+                f'{format_max_items(problem_meshes, "mesh(es)")} needs added to the "{GEO_SET_NAME}" set.'
             )
             return False
         else:

--- a/pipeline/pipe/m/rig/builder/test/tests/hierarchy.py
+++ b/pipeline/pipe/m/rig/builder/test/tests/hierarchy.py
@@ -1,0 +1,30 @@
+from maya import cmds
+
+from .. import RigBuildTest
+from ..common import format_max_items
+
+DEFAULT_NODES = {"persp", "top", "front", "side"}
+
+
+class TestSingleHierachy(RigBuildTest):
+    """
+    Checks that the scene consists of only a single rig hierarchy.
+    (No more than one root node).
+    """
+
+    def __init__(self):
+        super().__init__("Single hierarchy")
+
+    def run(self) -> bool:
+        top_level_nodes = cmds.ls(assemblies=True)
+        non_default_top_level_nodes = [
+            node for node in top_level_nodes if node not in DEFAULT_NODES
+        ]
+        if len(non_default_top_level_nodes) > 1:
+            self.log_warn(
+                f"Scene has more than one root node: {format_max_items(non_default_top_level_nodes, 'node(s)')}"
+            )
+            return False
+        else:
+            self.log_success()
+            return True

--- a/pipeline/pipe/m/rig/builder/test/tests/joint.py
+++ b/pipeline/pipe/m/rig/builder/test/tests/joint.py
@@ -1,7 +1,7 @@
 from maya import cmds
 
 from .. import RigBuildTest
-from ..common import is_visible
+from ..common import format_max_items, is_visible
 
 
 class TestHiddenJoints(RigBuildTest):
@@ -27,7 +27,9 @@ class TestHiddenJoints(RigBuildTest):
             if cmds.getAttr(f"{joint}.drawStyle") != 2:
                 problem_joints.append(joint)
         if problem_joints:
-            self.log_warn(f"Scene has visible joints: {problem_joints}")
+            self.log_warn(
+                f"Scene has visible joints: {format_max_items(problem_joints, 'joint(s)')}"
+            )
             return False
         else:
             self.log_success()

--- a/pipeline/pipe/m/rig/builder/test/tests/namespace.py
+++ b/pipeline/pipe/m/rig/builder/test/tests/namespace.py
@@ -1,6 +1,7 @@
 from maya import cmds
 
 from .. import RigBuildTest
+from ..common import format_max_items
 
 
 class TestNamespaces(RigBuildTest):
@@ -29,7 +30,9 @@ class TestNamespaces(RigBuildTest):
                     or []
                 )
                 namespace_nodes.extend(nodes)
-            self.log_warn(f"Scene has nodes in namespaces: {namespace_nodes}")
+            self.log_warn(
+                f"Scene has nodes in namespaces: {format_max_items(namespace_nodes, 'node(s)')}"
+            )
             return False
         else:
             self.log_success()

--- a/pipeline/pipe/m/rig/builder/test/tests/namespace.py
+++ b/pipeline/pipe/m/rig/builder/test/tests/namespace.py
@@ -3,6 +3,8 @@ from maya import cmds
 from .. import RigBuildTest
 from ..common import format_max_items
 
+DEFAULT_NAMESPACES = {"UI", "shared"}
+
 
 class TestNamespaces(RigBuildTest):
     """
@@ -14,10 +16,9 @@ class TestNamespaces(RigBuildTest):
         super().__init__("No namespaces")
 
     def run(self) -> bool:
-        default_namespace = {"UI", "shared"}
         namespaces = cmds.namespaceInfo(listOnlyNamespaces=True, recurse=True) or []
         bad_namespaces: list[str] = [
-            ns for ns in namespaces if ns not in default_namespace
+            ns for ns in namespaces if ns not in DEFAULT_NAMESPACES
         ]
         if bad_namespaces:
             namespace_nodes: list[str] = []

--- a/pipeline/pipe/m/rig/builder/test/tests/ng.py
+++ b/pipeline/pipe/m/rig/builder/test/tests/ng.py
@@ -1,6 +1,7 @@
 from maya import cmds
 
 from .. import RigBuildTest
+from ..common import format_max_items
 
 
 class TestNgSkinData(RigBuildTest):
@@ -16,7 +17,9 @@ class TestNgSkinData(RigBuildTest):
     def run(self) -> bool:
         ng_data_nodes = cmds.ls(type="ngst2SkinLayerData")
         if ng_data_nodes:
-            self.log_warn(f"Scene has ngst2SkinLayerData nodes: {ng_data_nodes}")
+            self.log_warn(
+                f"Scene has ngst2SkinLayerData nodes: {format_max_items(ng_data_nodes, 'node(s)')}"
+            )
             return False
         else:
             self.log_success()

--- a/pipeline/pipe/m/rig/builder/test/tests/node.py
+++ b/pipeline/pipe/m/rig/builder/test/tests/node.py
@@ -1,6 +1,7 @@
 from maya import cmds
 
 from .. import RigBuildTest
+from ..common import format_max_items
 
 
 class TestUnknownNodes(RigBuildTest):
@@ -14,7 +15,9 @@ class TestUnknownNodes(RigBuildTest):
     def run(self) -> bool:
         unknown_nodes = cmds.ls(type="unknown")
         if unknown_nodes:
-            self.log_warn(f"Scene has unknown nodes: {unknown_nodes}")
+            self.log_warn(
+                f"Scene has unknown nodes: {format_max_items(unknown_nodes, 'node(s)')}"
+            )
             return False
         else:
             self.log_success()

--- a/pipeline/pipe/m/rig/builder/test/tests/root_transform.py
+++ b/pipeline/pipe/m/rig/builder/test/tests/root_transform.py
@@ -1,0 +1,214 @@
+from typing import Iterable
+
+import numpy as np
+from maya import cmds
+from maya.api.OpenMaya import (
+    MDagPath,
+    MEulerRotation,
+    MFnMesh,
+    MFnTransform,
+    MItDag,
+    MMatrix,
+    MPointArray,
+    MSelectionList,
+    MSpace,
+    MVector,
+)
+from numpy.typing import NDArray
+
+from .. import RigBuildTest
+from ..common import get_all_visible_meshes, get_dag_path, is_control
+
+EPSILON: float = 0.01
+
+
+def _get_root_control() -> str | None:
+    it = MItDag(MItDag.kBreadthFirst)
+    while not it.isDone():
+        dag: MDagPath = it.getPath()
+        name = dag.partialPathName()
+        if not name:
+            it.next()
+            continue
+        if is_control(name, strict=False):
+            return name
+        it.next()
+    return None
+
+
+def _get_visible_mesh_shapes() -> list[str]:
+    visible_mesh_transforms = get_all_visible_meshes()
+    visible_mesh_shapes: list[str] = [
+        shape
+        for mesh in visible_mesh_transforms
+        for shape in (
+            cmds.listRelatives(mesh, shapes=True, type="mesh", noIntermediate=True)
+            or []
+        )
+    ]
+    return visible_mesh_shapes
+
+
+def _get_mesh_points(mesh_shape: str) -> NDArray[np.float64]:
+    msel: MSelectionList = MSelectionList()
+    msel.add(mesh_shape)
+    mesh_dag: MDagPath = msel.getDagPath(0)
+
+    # make the function set and get the points
+    fn_mesh: MFnMesh = MFnMesh(mesh_dag)
+
+    mesh_points: MPointArray = fn_mesh.getPoints(space=MSpace.kWorld)
+    np_points = np.array(
+        [[pt.x, pt.y, pt.z, pt.w] for pt in mesh_points], dtype=np.float64
+    )
+    return np_points
+
+
+def _transform_mesh_points(
+    points: NDArray[np.float64], matrix: MMatrix
+) -> NDArray[np.float64]:
+    np_matrix = np.array(matrix, dtype=np.float64).reshape(4, 4)
+    return points @ np_matrix
+
+
+def _compare_points(
+    current_points: NDArray[np.float64],
+    expected_points: NDArray[np.float64],
+    epsilon: float = EPSILON,
+) -> bool:
+    return np.allclose(current_points, expected_points, atol=EPSILON)
+
+
+def _compare_before_after_transform(
+    control: str,
+    meshes: Iterable[str],
+    translation: tuple[float, float, float] | None = None,
+    rotation: tuple[float, float, float] | None = None,
+    scale: tuple[float, float, float] | None = None,
+) -> bool:
+    mesh_points_mapping = {mesh: _get_mesh_points(mesh) for mesh in meshes}
+
+    control_dag = get_dag_path(control)
+    transform_mfn = MFnTransform(control_dag)
+    original_world_matrix: MMatrix = control_dag.inclusiveMatrix()
+
+    original_translation = transform_mfn.translation(MSpace.kTransform)
+    original_rotation = transform_mfn.rotation(MSpace.kTransform)
+    original_scale = transform_mfn.scale()
+
+    # Apply our transform
+    if translation is not None:
+        transform_mfn.translateBy(MVector(translation), MSpace.kTransform)
+    if rotation is not None:
+        transform_mfn.rotateBy(MEulerRotation(rotation), MSpace.kTransform)
+    if scale is not None:
+        transform_mfn.scaleBy(scale)
+
+    new_world_matrix: MMatrix = control_dag.inclusiveMatrix()
+    offset_matrix = original_world_matrix.inverse() * new_world_matrix
+    all_match = True
+    for mesh, original_points in mesh_points_mapping.items():
+        # Transform the original points by the offset
+        transformed_points = _transform_mesh_points(original_points, offset_matrix)
+        new_points = _get_mesh_points(mesh)
+        if not _compare_points(transformed_points, new_points):
+            all_match = False
+            break
+
+    # Reset transform
+    if translation is not None:
+        transform_mfn.setTranslation(original_translation, MSpace.kTransform)
+    if rotation is not None:
+        transform_mfn.setRotation(original_rotation, MSpace.kTransform)
+    if scale is not None:
+        transform_mfn.setScale(original_scale)
+
+    return all_match
+
+
+class TestRootTranslation(RigBuildTest):
+    """
+    Checks that scaling the root control behaves as expected (a rigid transformation of the points).
+    """
+
+    def __init__(self):
+        super().__init__("Root control translation")
+
+    def run(self) -> bool:
+        root_control = _get_root_control()
+        if root_control is None:
+            self.log_warn("Rig had no root control")
+            return False
+        visible_mesh_shapes = _get_visible_mesh_shapes()
+        translation_value = (1, 1, 1)
+        passed = _compare_before_after_transform(
+            control=root_control,
+            meshes=visible_mesh_shapes,
+            translation=translation_value,
+        )
+        if not passed:
+            self.log_warn(
+                f"Rig did not behave properly when {root_control} was translated by {translation_value}"
+            )
+            return False
+        else:
+            self.log_success()
+            return True
+
+
+class TestRootRotate(RigBuildTest):
+    """
+    Checks that scaling the root control behaves as expected (a rigid transformation of the points).
+    """
+
+    def __init__(self):
+        super().__init__("Root control rotate")
+
+    def run(self) -> bool:
+        root_control = _get_root_control()
+        if root_control is None:
+            self.log_warn("Rig had no root control")
+            return False
+        visible_mesh_shapes = _get_visible_mesh_shapes()
+        rotation_value = (0, 90, 0)
+        passed = _compare_before_after_transform(
+            control=root_control,
+            meshes=visible_mesh_shapes,
+            rotation=rotation_value,
+        )
+        if not passed:
+            self.log_warn(
+                f"Rig did not behave properly when {root_control} was rotated by {rotation_value}"
+            )
+            return False
+        else:
+            self.log_success()
+            return True
+
+
+class TestRootScale(RigBuildTest):
+    """
+    Checks that scaling the root control behaves as expected (a rigid transformation of the points).
+    """
+
+    def __init__(self):
+        super().__init__("Root control scale")
+
+    def run(self) -> bool:
+        root_control = _get_root_control()
+        if root_control is None:
+            self.log_warn("Rig had no root control")
+            return False
+        visible_mesh_shapes = _get_visible_mesh_shapes()
+        scale_value = (5, 5, 5)
+        passed = _compare_before_after_transform(
+            control=root_control, meshes=visible_mesh_shapes, scale=scale_value
+        )
+        if not passed:
+            self.log_warn(
+                f"Rig did not behave properly when {root_control} was scaled by {scale_value}"
+            )
+            return False
+        else:
+            self.log_success()
+            return True


### PR DESCRIPTION
* Added a new `format_max_items`  in `common.py` to format and truncate long lists in log messages. Fixing a crash
* Added a new test, `TestSingleHierachy`, to ensure that the scene contains only a single rig hierarchy (i.e., only one root node besides Maya's default nodes)

* Added tests for root control transformation (make sure rig behaves when using global scale for example)