### PR TITLE
re-add namespace handling to handle multiple rigs (screw you maya)

### DIFF
--- a/pipeline/pipe/m/publish/anim.py
+++ b/pipeline/pipe/m/publish/anim.py
@@ -86,7 +86,7 @@ class AnimPublisher(Publisher):
             ),
             "frameStride": 1.0,
             "shadingMode": "none",
-            "stripNamespaces": True,
+            "stripNamespaces": False,
         }
 
     def _get_confirm_message(self):

--- a/pipeline/pipe/m/publish/usdchaser/utils.py
+++ b/pipeline/pipe/m/publish/usdchaser/utils.py
@@ -278,6 +278,9 @@ def split_by_namespace(
                 edit.Add(Sdf.NamespaceEdit.Remove(prim.GetPath()))
 
         layer.Apply(edit)
+        if not remove_namespace(layer, path_dag_map):
+            raise RuntimeError(f"Could not remove namespace on layer `{layer_name}`")
+
         layer.Save()
         layers.update({layer_name: layer})
 


### PR DESCRIPTION
turns out the maya USD exporter just completely fails without an error message when exporting anything that consists of more than one namespace with stripNamespaces set to True. 

:| 

anyways, this works around that