### PR TITLE
fix the Substance export to map AO to ORM Red channel

### DIFF
--- a/pipeline/pipe/sp/export.py
+++ b/pipeline/pipe/sp/export.py
@@ -717,7 +717,7 @@ class Exporter:
                         "destChannel": "R",
                         "srcChannel": "R",
                         "srcMapType": "documentMap",
-                        "srcMapName": "opacity",
+                        "srcMapName": "ambientOcclusion",
                     },
                     {
                         "destChannel": "G",


### PR DESCRIPTION
turns out the substance export also hooked the opacity map to the occlusion channel of the ORM texture. since we've changed to using the O channel as Occlusion in our materials this no longer bakes maps properly.

This pull request should fix that