### PR TITLE
fix material bindings on export for instanced meshes

### DIFF
--- a/pipeline/pipe/m/publish/asset.py
+++ b/pipeline/pipe/m/publish/asset.py
@@ -806,6 +806,7 @@ class AssetPublisher(Publisher):
                     ),
                     "selection": True,
                     "stripNamespaces": True,
+                    "exportCollectionBasedBindings": True,
                     **self._get_mayausd_kwargs(),
                 }
 


### PR DESCRIPTION
The Maya USD export fails to bind materials properly when using direct material bindings on instanced meshes. We have no reason not to use collections bindings, so this fixes that.