### PR TITLE
Rig Build Tests 3: Dawn of The Dinosaurs

### DIFF
--- a/pipeline/pipe/m/rig/builder/test/common.py
+++ b/pipeline/pipe/m/rig/builder/test/common.py
@@ -7,6 +7,8 @@ from maya.api.OpenMaya import MDagPath, MFnDagNode, MItDag, MSelectionList
 
 CONTROLS_SET_NAME = "rig_controllers_grp"
 GEO_SET_NAME = "rig_geo_grp"
+ROOT_NODE_NAME = "rig"
+GEO_GROUP_NAME = "geo"
 
 
 def get_dag_path(transform: str) -> MDagPath:
@@ -65,12 +67,12 @@ def get_all_controls_by_name() -> list[str]:
     ]
 
 
-def get_all_visible_meshes() -> list[str]:
+def get_all_visible_meshes() -> set[str]:
     mesh_shapes: list[str] = cmds.ls(type="mesh")
     mesh_transforms: list[str] = cmds.listRelatives(mesh_shapes, parent=True) or []  # type: ignore
 
-    visible_geo: set[str] = set(geo for geo in mesh_transforms if is_visible(geo))
-    return list(visible_geo)
+    visible_geo = set(geo for geo in mesh_transforms if is_visible(geo))
+    return visible_geo
 
 
 def is_control(transform: str, strict: bool = True) -> bool:

--- a/pipeline/pipe/m/rig/builder/test/tests/__init__.py
+++ b/pipeline/pipe/m/rig/builder/test/tests/__init__.py
@@ -2,7 +2,7 @@ from ...test.core import RigBuildTest
 from .control import TestControlsInSet, TestControlsTagged, TestControlsZeroed
 from .cycle import TestCyclesDG
 from .duplicate import TestDuplicateDagNames
-from .geo import TestGeoInGroup, TestGeoInSet
+from .geo import TestGeoInGroup, TestGeoInSet, TestGeoNotSelectable
 from .hierarchy import TestRootNodeNaming, TestSingleHierachy
 from .joint import TestHiddenJoints
 from .namespace import TestNamespaces
@@ -19,6 +19,7 @@ RIG_BUILD_TESTS: list[type[RigBuildTest]] = [
     TestDuplicateDagNames,
     TestGeoInSet,
     TestGeoInGroup,
+    TestGeoNotSelectable,
     TestSingleHierachy,
     TestRootNodeNaming,
     TestNamespaces,
@@ -40,6 +41,7 @@ __all__ = [
     "TestDuplicateDagNames",
     "TestGeoInGroup",
     "TestGeoInSet",
+    "TestGeoNotSelectable",
     "TestSingleHierachy",
     "TestRootNodeNaming",
     "TestHiddenJoints",

--- a/pipeline/pipe/m/rig/builder/test/tests/__init__.py
+++ b/pipeline/pipe/m/rig/builder/test/tests/__init__.py
@@ -2,13 +2,14 @@ from ...test.core import RigBuildTest
 from .control import TestControlsInSet, TestControlsTagged, TestControlsZeroed
 from .cycle import TestCyclesDG
 from .duplicate import TestDuplicateDagNames
-from .geo import TestGeoInSet
-from .hierarchy import TestSingleHierachy
+from .geo import TestGeoInGroup, TestGeoInSet
+from .hierarchy import TestRootNodeNaming, TestSingleHierachy
 from .joint import TestHiddenJoints
 from .namespace import TestNamespaces
 from .ng import TestNgSkinData
 from .node import TestUnknownNodes
 from .root_transform import TestRootRotate, TestRootScale, TestRootTranslation
+from .visibility import TestHiddenRigNodes
 
 RIG_BUILD_TESTS: list[type[RigBuildTest]] = [
     TestHiddenJoints,
@@ -17,8 +18,11 @@ RIG_BUILD_TESTS: list[type[RigBuildTest]] = [
     TestControlsZeroed,
     TestDuplicateDagNames,
     TestGeoInSet,
+    TestGeoInGroup,
     TestSingleHierachy,
+    TestRootNodeNaming,
     TestNamespaces,
+    TestHiddenRigNodes,
     TestUnknownNodes,
     TestCyclesDG,
     TestNgSkinData,
@@ -34,8 +38,10 @@ __all__ = [
     "TestControlsZeroed",
     "TestCyclesDG",
     "TestDuplicateDagNames",
+    "TestGeoInGroup",
     "TestGeoInSet",
     "TestSingleHierachy",
+    "TestRootNodeNaming",
     "TestHiddenJoints",
     "TestNamespaces",
     "TestNgSkinData",
@@ -43,4 +49,5 @@ __all__ = [
     "TestRootTranslation",
     "TestRootRotate",
     "TestRootScale",
+    "TestHiddenRigNodes",
 ]

--- a/pipeline/pipe/m/rig/builder/test/tests/geo.py
+++ b/pipeline/pipe/m/rig/builder/test/tests/geo.py
@@ -1,4 +1,5 @@
 from maya import cmds
+from maya.api.OpenMaya import MFnDependencyNode
 
 from .. import RigBuildTest
 from ..common import (
@@ -6,6 +7,7 @@ from ..common import (
     GEO_SET_NAME,
     format_max_items,
     get_all_visible_meshes,
+    get_dag_path,
     is_control,
 )
 
@@ -67,6 +69,56 @@ class TestGeoInGroup(RigBuildTest):
             self.log_warn(
                 f"Scene has geometry that isn't in the geo group: "
                 f'{format_max_items(problem_meshes, "mesh(es)")} need added to the "{GEO_GROUP_NAME}" group.'
+            )
+            return False
+        else:
+            self.log_success()
+            return True
+
+
+def _get_effective_display_type(object: str) -> int:
+    """
+    Returns the effective overrideDisplayType considering inheritance.
+    0 = Normal, 1 = Template, 2 = Reference
+    """
+    path = get_dag_path(object)
+
+    while True:
+        fn = MFnDependencyNode(path.node())
+        override_enabled = fn.findPlug("overrideEnabled", False).asBool()
+        if override_enabled:
+            return fn.findPlug("overrideDisplayType", False).asInt()
+        if path.length() == 0:
+            break
+        try:
+            path.pop()  # move to parent
+        except RuntimeError:
+            break
+    return 0  # default: Normal
+
+
+class TestGeoNotSelectable(RigBuildTest):
+    """
+    Checks that the scene has no visible geometry that is selectable (other than controls).
+    """
+
+    def __init__(self):
+        super().__init__("No selectable geometry")
+
+    def run(self) -> bool:
+        if not cmds.objExists(GEO_GROUP_NAME):
+            self.log_warn(f'Scene missing the geo group "{GEO_GROUP_NAME}"')
+            return False
+        visible_geo: set[str] = get_all_visible_meshes()
+        selectable_geo = set(
+            geo for geo in visible_geo if _get_effective_display_type(geo) == 0
+        )
+        selectable_visible_geo = visible_geo & selectable_geo
+        problem_geo = set(geo for geo in selectable_visible_geo if not is_control(geo))
+        if problem_geo:
+            self.log_warn(
+                f"Scene has geometry that is selectable: "
+                f'{format_max_items(problem_geo, "mesh(es)")} need to set to reference display to make them unselectable.'
             )
             return False
         else:

--- a/pipeline/pipe/m/rig/builder/test/tests/geo.py
+++ b/pipeline/pipe/m/rig/builder/test/tests/geo.py
@@ -106,9 +106,6 @@ class TestGeoNotSelectable(RigBuildTest):
         super().__init__("No selectable geometry")
 
     def run(self) -> bool:
-        if not cmds.objExists(GEO_GROUP_NAME):
-            self.log_warn(f'Scene missing the geo group "{GEO_GROUP_NAME}"')
-            return False
         visible_geo: set[str] = get_all_visible_meshes()
         selectable_geo = set(
             geo for geo in visible_geo if _get_effective_display_type(geo) == 0

--- a/pipeline/pipe/m/rig/builder/test/tests/geo.py
+++ b/pipeline/pipe/m/rig/builder/test/tests/geo.py
@@ -2,6 +2,7 @@ from maya import cmds
 
 from .. import RigBuildTest
 from ..common import (
+    GEO_GROUP_NAME,
     GEO_SET_NAME,
     format_max_items,
     get_all_visible_meshes,
@@ -19,7 +20,7 @@ class TestGeoInSet(RigBuildTest):
         super().__init__("All geometry in set")
 
     def run(self) -> bool:
-        visible_geo: set[str] = set(get_all_visible_meshes())
+        visible_geo: set[str] = get_all_visible_meshes()
         problem_meshes: set[str]
         try:
             meshes_in_set: list[str] = cmds.sets(GEO_SET_NAME, query=True)  # type: ignore
@@ -33,7 +34,39 @@ class TestGeoInSet(RigBuildTest):
         if problem_meshes:
             self.log_warn(
                 f"Scene has geometry that isn't in the geo set: "
-                f'{format_max_items(problem_meshes, "mesh(es)")} needs added to the "{GEO_SET_NAME}" set.'
+                f'{format_max_items(problem_meshes, "mesh(es)")} need added to the "{GEO_SET_NAME}" set.'
+            )
+            return False
+        else:
+            self.log_success()
+            return True
+
+
+class TestGeoInGroup(RigBuildTest):
+    """
+    Checks that the scene has no visible geometry that isn't in the geo group.
+    This group is used for animation export and as such all non-control visible geometry should be in it.
+    """
+
+    def __init__(self):
+        super().__init__("All geometry in group")
+
+    def run(self) -> bool:
+        if not cmds.objExists(GEO_GROUP_NAME):
+            self.log_warn(f'Scene missing the geo group "{GEO_GROUP_NAME}"')
+            return False
+        visible_geo: set[str] = get_all_visible_meshes()
+        objects_in_group: list[str] = (
+            cmds.listRelatives(GEO_GROUP_NAME, allDescendents=True) or []
+        )
+        visible_meshes_not_in_group = visible_geo - set(objects_in_group)
+        problem_meshes = set(
+            mesh for mesh in visible_meshes_not_in_group if not is_control(mesh)
+        )
+        if problem_meshes:
+            self.log_warn(
+                f"Scene has geometry that isn't in the geo group: "
+                f'{format_max_items(problem_meshes, "mesh(es)")} need added to the "{GEO_GROUP_NAME}" group.'
             )
             return False
         else:

--- a/pipeline/pipe/m/rig/builder/test/tests/hierarchy.py
+++ b/pipeline/pipe/m/rig/builder/test/tests/hierarchy.py
@@ -1,28 +1,64 @@
 from maya import cmds
 
 from .. import RigBuildTest
-from ..common import format_max_items
+from ..common import ROOT_NODE_NAME, format_max_items
 
 DEFAULT_NODES = {"persp", "top", "front", "side"}
+
+
+def _get_top_level_nodes() -> list[str]:
+    top_level_nodes = cmds.ls(assemblies=True)
+    non_default_top_level_nodes = [
+        node for node in top_level_nodes if node not in DEFAULT_NODES
+    ]
+    return non_default_top_level_nodes
 
 
 class TestSingleHierachy(RigBuildTest):
     """
     Checks that the scene consists of only a single rig hierarchy.
-    (No more than one root node).
+    (Exactly one root node).
     """
 
     def __init__(self):
         super().__init__("Single hierarchy")
 
     def run(self) -> bool:
-        top_level_nodes = cmds.ls(assemblies=True)
-        non_default_top_level_nodes = [
-            node for node in top_level_nodes if node not in DEFAULT_NODES
-        ]
-        if len(non_default_top_level_nodes) > 1:
+        top_level_nodes = _get_top_level_nodes()
+        if not top_level_nodes:
+            self.log_warn("Scene has no root node")
+            return False
+        if len(top_level_nodes) > 1:
             self.log_warn(
-                f"Scene has more than one root node: {format_max_items(non_default_top_level_nodes, 'node(s)')}"
+                f"Scene has more than one root node: {format_max_items(top_level_nodes, 'node(s)')}"
+            )
+            return False
+        self.log_success()
+        return True
+
+
+class TestRootNodeNaming(RigBuildTest):
+    """
+    Checks that the rig root node is named properly.
+    """
+
+    def __init__(self):
+        super().__init__("Root node naming")
+
+    def run(self) -> bool:
+        top_level_nodes = _get_top_level_nodes()
+        if not top_level_nodes:
+            self.log_warn("Scene has no root node")
+            return False
+        if len(top_level_nodes) > 1 and ROOT_NODE_NAME not in top_level_nodes:
+            self.log_warn(
+                f'Scene has more than one root node and none where named "{ROOT_NODE_NAME}"'
+            )
+            return False
+        root_node = top_level_nodes[0]
+        if root_node != ROOT_NODE_NAME:
+            self.log_warn(
+                f'Root node had incorrect naming: "{root_node}" instead of "{ROOT_NODE_NAME}"'
             )
             return False
         else:

--- a/pipeline/pipe/m/rig/builder/test/tests/visibility.py
+++ b/pipeline/pipe/m/rig/builder/test/tests/visibility.py
@@ -19,13 +19,15 @@ class TestHiddenRigNodes(RigBuildTest):
         super().__init__("No visible rig nodes")
 
     def run(self) -> bool:
-        rig_nodes: list[str] = []
+        rig_nodes: list[tuple[str, str]] = []
         for node_type in HIDDEN_NODE_TYPES:
             shapes = cmds.ls(type=node_type) or []
-            rig_nodes.extend(shapes)
-        rig_nodes_set: set[str] = set(rig_nodes)
+            rig_nodes.extend((shape, node_type) for shape in shapes)
+        rig_nodes_set: set[tuple[str, str]] = set(rig_nodes)
         problem_rig_nodes: list[str] = [
-            rig_node for rig_node in rig_nodes_set if is_visible(rig_node)
+            f"{rig_node[0]}: {rig_node[1]}"
+            for rig_node in rig_nodes_set
+            if is_visible(rig_node[0])
         ]
 
         if problem_rig_nodes:

--- a/pipeline/pipe/m/rig/builder/test/tests/visibility.py
+++ b/pipeline/pipe/m/rig/builder/test/tests/visibility.py
@@ -21,7 +21,7 @@ class TestHiddenRigNodes(RigBuildTest):
     def run(self) -> bool:
         rig_nodes: list[tuple[str, str]] = []
         for node_type in HIDDEN_NODE_TYPES:
-            shapes = cmds.ls(type=node_type) or []
+            shapes = cmds.ls(exactType=node_type) or []
             rig_nodes.extend((shape, node_type) for shape in shapes)
         rig_nodes_set: set[tuple[str, str]] = set(rig_nodes)
         problem_rig_nodes: list[str] = [

--- a/pipeline/pipe/m/rig/builder/test/tests/visibility.py
+++ b/pipeline/pipe/m/rig/builder/test/tests/visibility.py
@@ -1,0 +1,38 @@
+from maya import cmds
+
+from .. import RigBuildTest
+from ..common import (
+    format_max_items,
+    is_visible,
+)
+
+HIDDEN_NODE_TYPES = {"ikHandle", "locator", "clusterHandle", "follicle", "lattice"}
+
+
+class TestHiddenRigNodes(RigBuildTest):
+    """
+    Checks that the scene has no visible rig nodes (ikHandles, locators, etc.).
+    These nodes don't hide in the viewport when disabling NURBS curves with alt+1 which is annoying for animators.
+    """
+
+    def __init__(self):
+        super().__init__("No visible rig nodes")
+
+    def run(self) -> bool:
+        rig_nodes: list[str] = []
+        for node_type in HIDDEN_NODE_TYPES:
+            shapes = cmds.ls(type=node_type) or []
+            rig_nodes.extend(shapes)
+        rig_nodes_set: set[str] = set(rig_nodes)
+        problem_rig_nodes: list[str] = [
+            rig_node for rig_node in rig_nodes_set if is_visible(rig_node)
+        ]
+
+        if problem_rig_nodes:
+            self.log_warn(
+                f"Scene has visible rig nodes: {format_max_items(problem_rig_nodes, 'node(s)')}"
+            )
+            return False
+        else:
+            self.log_success()
+            return True

--- a/pipeline/pipe/m/rig/builder/ui/test_select.py
+++ b/pipeline/pipe/m/rig/builder/ui/test_select.py
@@ -171,7 +171,7 @@ class TestSelectList(QListView):
         else:
             self._set_border_color(None)
 
-    def _on_test_finished(self, test: RigBuildTest, passed: bool) -> None:
+    def on_test_finished(self, test: RigBuildTest, passed: bool) -> None:
         for item in self.test_items:
             if type(item.test) is type(test):
                 item.update_status(passed)
@@ -182,7 +182,7 @@ class TestSelectList(QListView):
                 break
 
     def _on_test_finished_local(self, test: RigBuildTest, passed: bool) -> None:
-        self._on_test_finished(test, passed)
+        self.on_test_finished(test, passed)
         if self._progress_manager is not None:
             self._progress_manager.update_progress_from_test_run(test, passed)
 

--- a/pipeline/pipe/m/rig/builder/ui/test_select.py
+++ b/pipeline/pipe/m/rig/builder/ui/test_select.py
@@ -8,6 +8,9 @@ from Qt.QtWidgets import QApplication, QHBoxLayout, QListView, QPushButton, QWid
 from ..progress import TestProgressManager
 from ..test import RIG_BUILD_TESTS, RigBuildTest, TestRunner
 
+PASSED_COLOR = QColor(0, 94, 75)
+FAILED_COLOR = QColor(130, 42, 50)
+
 
 class TestSelectListModel(QStandardItemModel):
     def __init__(self, parent: QtCore.QObject | None):
@@ -27,6 +30,7 @@ class TestItem(QStandardItem):
         super().__init__(test.name)
         self.test = test
         self.test_enabled: bool = True
+        self.test_passed: bool | None = None
         self.setEditable(False)
         self.setSelectable(False)
         self.setCheckable(True)
@@ -40,12 +44,14 @@ class TestItem(QStandardItem):
         self.update_status(result)
 
     def update_status(self, passed: bool):
+        self.test_passed = passed
         if passed:
-            self.setBackground(QBrush(QColor(0, 94, 75)))
+            self.setBackground(QBrush(PASSED_COLOR))
         else:
-            self.setBackground(QBrush(QColor(130, 42, 50)))
+            self.setBackground(QBrush(FAILED_COLOR))
 
     def clear_status(self):
+        self.test_passed = None
         self.setBackground(QBrush())
 
     def is_enabled(self) -> bool:
@@ -98,19 +104,6 @@ class TestSelectList(QListView):
         self.test_items: list[TestItem] = []
         self.populate_tests([test() for test in RIG_BUILD_TESTS])
 
-    def resizeEvent(self, e) -> None:
-        super().resizeEvent(e)
-        self._reposition_overlay()
-
-    def _reposition_overlay(self) -> None:
-        overlay = self._button_overlay
-        viewport = self.viewport()
-        overlay.adjustSize()
-        x = viewport.width() - overlay.width()
-        y = viewport.height() - overlay.height()
-        overlay.move(x, y)
-        overlay.raise_()
-
     def populate_tests(self, tests: Sequence[RigBuildTest]) -> None:
         for test in tests:
             self.add_item(test)
@@ -122,6 +115,7 @@ class TestSelectList(QListView):
         self.test_items.append(item)
 
     def clear_test_status(self) -> None:
+        self._set_border_color(None)
         for test_item in self.test_items:
             test_item.clear_status()
 
@@ -164,17 +158,31 @@ class TestSelectList(QListView):
         self._progress_manager.update_progress_finished()
         self._progress_manager = None
 
-    def on_test_finished(self, test: RigBuildTest, passed: bool) -> None:
+    def _update_overall_status(self) -> None:
+        enabled_items = [i for i in self.test_items if i.is_enabled()]
+
+        if not enabled_items:
+            self._set_border_color(None)
+
+        if all(test.test_passed is True for test in enabled_items):
+            self._set_border_color(PASSED_COLOR)
+        elif any(test.test_passed is False for test in enabled_items):
+            self._set_border_color(FAILED_COLOR)  # red
+        else:
+            self._set_border_color(None)
+
+    def _on_test_finished(self, test: RigBuildTest, passed: bool) -> None:
         for item in self.test_items:
             if type(item.test) is type(test):
                 item.update_status(passed)
                 if not passed:
                     self.scrollTo(item.index(), QListView.ScrollHint.EnsureVisible)
+                self._update_overall_status()
                 QApplication.processEvents()
                 break
 
     def _on_test_finished_local(self, test: RigBuildTest, passed: bool) -> None:
-        self.on_test_finished(test, passed)
+        self._on_test_finished(test, passed)
         if self._progress_manager is not None:
             self._progress_manager.update_progress_from_test_run(test, passed)
 
@@ -189,3 +197,27 @@ class TestSelectList(QListView):
     def connect_progress(self, progress_slot: Callable[[float], None]) -> None:
         """Stores the slot (e.g., progress_bar.update_progress) to connect later."""
         self._progress_slot = progress_slot  # type: ignore
+
+    def _set_border_color(self, color: QColor | None = None) -> None:
+        if color is not None:
+            self.setStyleSheet(f"""
+                QListView {{
+                    border: 2px solid rgba{color.getRgb()};
+                    border-radius: 3px;
+                }}
+            """)
+        else:
+            self.setStyleSheet("")
+
+    def resizeEvent(self, e) -> None:
+        super().resizeEvent(e)
+        self._reposition_overlay()
+
+    def _reposition_overlay(self) -> None:
+        overlay = self._button_overlay
+        viewport = self.viewport()
+        overlay.adjustSize()
+        x = viewport.width() - overlay.width()
+        y = viewport.height() - overlay.height()
+        overlay.move(x, y)
+        overlay.raise_()

--- a/pipeline/pipe/m/rig/builder/ui/window_ui.py
+++ b/pipeline/pipe/m/rig/builder/ui/window_ui.py
@@ -41,7 +41,7 @@ class RigBuilderWindowUI(MayaQWidgetDockableMixin, QWidget):
         # Build Section
         self.top_container = QWidget()
         self.main_splitter.addWidget(self.top_container)
-        self.main_splitter.setStretchFactor(0, 1)
+        self.main_splitter.setStretchFactor(0, 3)
 
         self.top_layout = QVBoxLayout(self.top_container)
         self.top_layout.setContentsMargins(0, 0, 0, 4)


### PR DESCRIPTION
Adds tests for our naming conventions that the anim export still depends on
namely:
- Rig root node is called "rig"
- Geo group is called "geo"

Also added tests to check for any rig nodes that aren't hidden properly (locators, clusters, ik handles, etc)
And test for checking that rig geo isn't selectable. 

Also added border to the test list depending on if all tests are passing for easier visibility when there are more tests than can fit on one page.

<img width="313" height="123" alt="image" src="https://github.com/user-attachments/assets/04c27a28-fdee-4368-a918-99dc12827419" />
<img width="313" height="123" alt="image" src="https://github.com/user-attachments/assets/7bfbc10d-9fbc-4c62-804e-504537a1f3d6" />
Yay all tests passed :)