### PR TITLE
Progress bar

### DIFF
--- a/pipeline/pipe/glui/__init__.py
+++ b/pipeline/pipe/glui/__init__.py
@@ -1,8 +1,12 @@
+from .progress import ProgressDialog, ProgressScope, progress_scope
 from .save_version_dialog import PromoteVersionDialog, SaveVersionDialog
 from .version_browser import VersionBrowserWidget
 
 __all__ = [
+    "ProgressDialog",
+    "ProgressScope",
     "PromoteVersionDialog",
     "SaveVersionDialog",
     "VersionBrowserWidget",
+    "progress_scope",
 ]

--- a/pipeline/pipe/glui/progress.py
+++ b/pipeline/pipe/glui/progress.py
@@ -1,0 +1,232 @@
+"""Shared progress dialog and context manager for long-running pipeline operations.
+
+Provides a modal progress dialog that shows step-by-step progress to artists
+during synchronous workflows (publishes, playblasts, exports). The dialog
+displays a step counter, stage label, optional detail text, and a progress bar
+that supports both determinate and indeterminate modes.
+
+Synchronous workflows use the ``progress_scope`` context manager::
+
+    with progress_scope(
+        parent=window,
+        title="Publishing Asset",
+        steps=["Exporting USD", "Backing up scene"],
+    ) as progress:
+        progress.begin_step("Exporting USD")
+        export_usd()
+        progress.begin_step("Backing up scene")
+        run_backup()
+
+Async workflows (Substance Painter) create ``ProgressDialog`` directly and
+call ``set_progress`` / ``finish`` manually.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
+
+from Qt import QtCore, QtWidgets
+from Qt.QtWidgets import QDialog, QLabel, QProgressBar
+
+log = logging.getLogger(__name__)
+
+
+class ProgressDialog(QDialog):
+    """Non-closable modal dialog with step counter, stage label, detail text,
+    and a determinate/indeterminate progress bar.
+
+    The dialog blocks user close attempts while active. Call ``finish`` to
+    allow dismissal.
+    """
+
+    _allow_close: bool
+    _detail_label: QLabel
+    _progress_bar: QProgressBar
+    _stage_label: QLabel
+    _step_label: QLabel
+    _total_steps: int
+
+    def __init__(
+        self,
+        parent: QtWidgets.QWidget | None,
+        *,
+        title: str,
+        total_steps: int,
+    ) -> None:
+        super().__init__(parent)
+        self._allow_close = False
+        self._total_steps = total_steps
+
+        self.setWindowTitle(title)
+        self.setModal(True)
+        self.setMinimumWidth(420)
+        self.setWindowFlags(
+            (self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
+            | QtCore.Qt.WindowStaysOnTopHint
+        )
+        self.setWindowModality(QtCore.Qt.WindowModal)
+
+        layout = QtWidgets.QVBoxLayout(self)
+        layout.setContentsMargins(14, 14, 14, 14)
+        layout.setSpacing(8)
+
+        self._step_label = QLabel("")
+        self._step_label.setStyleSheet("font-size: 11px; color: #8a8a8a;")
+        layout.addWidget(self._step_label)
+
+        self._stage_label = QLabel("Preparing...")
+        self._stage_label.setStyleSheet("font-size: 13px; font-weight: bold;")
+        layout.addWidget(self._stage_label)
+
+        self._detail_label = QLabel("")
+        self._detail_label.setWordWrap(True)
+        layout.addWidget(self._detail_label)
+
+        self._progress_bar = QProgressBar()
+        self._progress_bar.setTextVisible(True)
+        self._progress_bar.setRange(0, 0)
+        layout.addWidget(self._progress_bar)
+
+    def event(self, event: QtCore.QEvent) -> bool:
+        if not self._allow_close and event.type() == QtCore.QEvent.Close:
+            event.ignore()
+            return True
+        return super().event(event)
+
+    def reject(self) -> None:
+        if self._allow_close:
+            super().reject()
+
+    def set_progress(
+        self,
+        *,
+        step: int,
+        stage: str,
+        detail: str = "",
+        current: int | None = None,
+        total: int | None = None,
+    ) -> None:
+        """Update all labels and the progress bar.
+
+        When *current* and *total* are both provided and *total* > 0, the bar
+        shows determinate progress (e.g. "3 / 12"). Otherwise the bar pulses
+        in indeterminate mode.
+        """
+        self._step_label.setText(f"Step {step} of {self._total_steps}")
+        self._stage_label.setText(stage)
+        self._detail_label.setText(detail)
+
+        if current is not None and total is not None and total > 0:
+            clamped_total = max(1, total)
+            clamped_current = max(0, min(current, clamped_total))
+            self._progress_bar.setRange(0, clamped_total)
+            self._progress_bar.setValue(clamped_current)
+            self._progress_bar.setFormat("%v / %m")
+        else:
+            self._progress_bar.setRange(0, 0)
+            self._progress_bar.setFormat("")
+
+        if not self.isVisible():
+            self.show()
+        self.raise_()
+        self.activateWindow()
+
+        QtWidgets.QApplication.processEvents()
+
+    def finish(self) -> None:
+        """Allow close and dismiss the dialog."""
+        if self._allow_close:
+            return
+        self._allow_close = True
+        self.close()
+
+
+class ProgressScope:
+    """Handle yielded by ``progress_scope`` for advancing through steps.
+
+    Each call to ``begin_step`` moves to the named step and resets the bar
+    to indeterminate mode. Use ``update_detail`` or ``update_substep`` for
+    finer-grained feedback within a step.
+    """
+
+    _dialog: ProgressDialog
+    _steps: Sequence[str]
+    _current_step: int
+
+    def __init__(self, dialog: ProgressDialog, steps: Sequence[str]) -> None:
+        self._dialog = dialog
+        self._steps = steps
+        self._current_step = 0
+
+    def begin_step(self, step_name: str, detail: str = "") -> None:
+        """Advance to the named step. Resets the bar to indeterminate."""
+        try:
+            index = list(self._steps).index(step_name) + 1
+        except ValueError:
+            raise ValueError(
+                f"Unknown step {step_name!r}. Declared steps: {list(self._steps)}"
+            ) from None
+        self._current_step = index
+        self._dialog.set_progress(step=index, stage=step_name, detail=detail)
+
+    def update_detail(self, detail: str) -> None:
+        """Update the detail text within the current step."""
+        if self._current_step == 0:
+            return
+        self._dialog.set_progress(
+            step=self._current_step,
+            stage=list(self._steps)[self._current_step - 1],
+            detail=detail,
+        )
+
+    def update_substep(self, current: int, total: int, detail: str = "") -> None:
+        """Show determinate sub-progress within the current step."""
+        if self._current_step == 0:
+            return
+        self._dialog.set_progress(
+            step=self._current_step,
+            stage=list(self._steps)[self._current_step - 1],
+            detail=detail,
+            current=current,
+            total=total,
+        )
+
+
+class _NoOpProgressScope:
+    """Stub scope for headless environments where no QApplication exists."""
+
+    def begin_step(self, step_name: str, detail: str = "") -> None:
+        pass
+
+    def update_detail(self, detail: str) -> None:
+        pass
+
+    def update_substep(self, current: int, total: int, detail: str = "") -> None:
+        pass
+
+
+@contextmanager
+def progress_scope(
+    *,
+    parent: QtWidgets.QWidget | None,
+    title: str,
+    steps: Sequence[str],
+) -> Iterator[ProgressScope | _NoOpProgressScope]:
+    """Show a progress dialog for the duration of a synchronous operation.
+
+    The dialog is guaranteed to close when the block exits, even on exception.
+    In headless environments (no ``QApplication``), yields a no-op scope.
+    """
+    app = QtWidgets.QApplication.instance()
+    if app is None:
+        yield _NoOpProgressScope()
+        return
+
+    dialog = ProgressDialog(parent, title=title, total_steps=len(steps))
+    scope = ProgressScope(dialog, steps)
+    try:
+        yield scope
+    finally:
+        dialog.finish()

--- a/pipeline/pipe/h/component_output_hda.py
+++ b/pipeline/pipe/h/component_output_hda.py
@@ -167,7 +167,11 @@ def publish(node: hou.Node) -> Mapping[str, Any]:
     _repair_broken_output_paths(node)
 
     options = _collect_publish_options(node)
-    result = publish_component(node.path(), options)
+    try:
+        parent = hou.qt.mainWindow()
+    except Exception:
+        parent = None
+    result = publish_component(node.path(), options, parent=parent)
     _write_status(node, title="Publish", payload=result)
     _apply_node_color(node, result)
     _show_ui_message(result, title="SKD Publish")

--- a/pipeline/pipe/h/publish.py
+++ b/pipeline/pipe/h/publish.py
@@ -226,7 +226,7 @@ def publish_component(
             if backup is None:
                 return _finalize_result(result)
 
-            progress.begin_step("Exporting component")
+            progress.begin_step("Exporting component", "This may take a moment...")
             export = _export_component(context=context, options=opts, result=result)
             if export is None:
                 return _finalize_result(result)

--- a/pipeline/pipe/h/publish.py
+++ b/pipeline/pipe/h/publish.py
@@ -22,8 +22,10 @@ from pathlib import Path
 from typing import Any, Mapping, NotRequired, TypedDict, cast
 
 import hou
+from Qt import QtWidgets
 
 from pipe.asset.version_adapter import asset_owner_from_metadata
+from pipe.glui.progress import progress_scope
 from pipe.versioning import stream_key_for
 from pipe.versioning.model import DCC_HOUDINI
 from pipe.versioning.store import (
@@ -191,8 +193,20 @@ class _PublishContext:
     export_path: Path
 
 
+_PUBLISH_STEPS = [
+    "Backing up project",
+    "Exporting component",
+    "Collecting thumbnail",
+    "Syncing gallery",
+    "Running hooks",
+]
+
+
 def publish_component(
-    node_path: str, options: PublishOptions | Mapping[str, Any] | None = None
+    node_path: str,
+    options: PublishOptions | Mapping[str, Any] | None = None,
+    *,
+    parent: QtWidgets.QWidget | None = None,
 ) -> PublishResult:
     """Publish a component output node with a reproducible backup snapshot."""
     opts = _coerce_options(options)
@@ -202,39 +216,49 @@ def publish_component(
         if context is None:
             return _finalize_result(result)
 
-        backup = _backup_snapshot(context=context, options=opts, result=result)
-        if backup is None:
-            return _finalize_result(result)
+        with progress_scope(
+            parent=parent,
+            title="Publishing Component",
+            steps=_PUBLISH_STEPS,
+        ) as progress:
+            progress.begin_step("Backing up project")
+            backup = _backup_snapshot(context=context, options=opts, result=result)
+            if backup is None:
+                return _finalize_result(result)
 
-        export = _export_component(context=context, options=opts, result=result)
-        if export is None:
-            return _finalize_result(result)
+            progress.begin_step("Exporting component")
+            export = _export_component(context=context, options=opts, result=result)
+            if export is None:
+                return _finalize_result(result)
 
-        thumbnail, thumbnail_bytes = _collect_thumbnail(
-            context=context, options=opts, result=result
-        )
-        result["thumbnail"] = thumbnail
+            progress.begin_step("Collecting thumbnail")
+            thumbnail, thumbnail_bytes = _collect_thumbnail(
+                context=context, options=opts, result=result
+            )
+            result["thumbnail"] = thumbnail
 
-        gallery = _sync_gallery(
-            context=context,
-            options=opts,
-            result=result,
-            thumbnail_bytes=thumbnail_bytes,
-            backup_version=backup["backup_version"],
-        )
-        result["gallery"] = gallery
+            progress.begin_step("Syncing gallery")
+            gallery = _sync_gallery(
+                context=context,
+                options=opts,
+                result=result,
+                thumbnail_bytes=thumbnail_bytes,
+                backup_version=backup["backup_version"],
+            )
+            result["gallery"] = gallery
 
-        hooks = _run_hooks(
-            context=context,
-            options=opts,
-            result=result,
-            backup=backup,
-            export=export,
-            gallery=gallery,
-        )
-        result["hooks"] = hooks
-        result["backup"] = backup
-        result["export"] = export
+            progress.begin_step("Running hooks")
+            hooks = _run_hooks(
+                context=context,
+                options=opts,
+                result=result,
+                backup=backup,
+                export=export,
+                gallery=gallery,
+            )
+            result["hooks"] = hooks
+            result["backup"] = backup
+            result["export"] = export
     except Exception as exc:
         _error(result, "UnhandledPublishException", str(exc))
     return _finalize_result(result)

--- a/pipeline/pipe/m/playblast/turnaround.py
+++ b/pipeline/pipe/m/playblast/turnaround.py
@@ -794,7 +794,7 @@ class AssetTurnaroundDialog(ButtonPair, QtWidgets.QMainWindow):
             return
 
         try:
-            self.playblaster.configure(config).playblast()
+            self.playblaster.configure(config).playblast(parent=self)
         except Exception as exc:
             log.exception("Turnaround export failed")
             MessageDialog(

--- a/pipeline/pipe/m/playblast/turnaround_playblaster.py
+++ b/pipeline/pipe/m/playblast/turnaround_playblaster.py
@@ -135,7 +135,10 @@ class TurnaroundPlayblaster:
                         aim_height_bias=config.aim_height_bias,
                     ) as camera_shape,
                 ):
-                    progress.begin_step("Capturing shaded pass", "Rendering frames...")
+                    progress.begin_step(
+                        "Capturing shaded pass",
+                        "Rendering frames \u2014 this may take a moment...",
+                    )
                     self._capture_pass(
                         output_base=shaded_base,
                         camera_shape=camera_shape,
@@ -145,7 +148,8 @@ class TurnaroundPlayblaster:
 
                     if config.include_wireframe_pass:
                         progress.begin_step(
-                            "Capturing wireframe pass", "Rendering frames..."
+                            "Capturing wireframe pass",
+                            "Rendering frames \u2014 this may take a moment...",
                         )
                         self._capture_pass(
                             output_base=wireframe_base,
@@ -273,6 +277,8 @@ class TurnaroundPlayblaster:
                 f"{destination_base.name}.{destination_frame:04d}.png"
             )
             shutil.copyfile(source_path, destination_path)
+            if offset % 10 == 0:
+                QtWidgets.QApplication.processEvents()
 
     def _encode_output_movies(self, *, combined_base: Path) -> None:
         image_pattern = str(combined_base) + ".%04d.png"
@@ -315,6 +321,7 @@ class TurnaroundPlayblaster:
                 output_path = Path(str(output_base) + f".{preset.ext}")
                 output_path.parent.mkdir(mode=0o770, parents=True, exist_ok=True)
                 shutil.copyfile(temp_movie_path, output_path)
+                QtWidgets.QApplication.processEvents()
 
 
 @contextmanager

--- a/pipeline/pipe/m/playblast/turnaround_playblaster.py
+++ b/pipeline/pipe/m/playblast/turnaround_playblaster.py
@@ -11,8 +11,10 @@ from typing import Iterable
 
 import ffmpeg  # type: ignore[import-untyped]
 import maya.cmds as mc
+from Qt import QtWidgets
 from mayacapture.capture import capture  # type: ignore[import-not-found]
 
+from pipe.glui.progress import progress_scope
 from pipe.m.util import maintain_selection
 from pipe.playblast_artist import resolve_artist_display_name
 from pipe.util import Playblaster
@@ -95,10 +97,15 @@ class TurnaroundPlayblaster:
         self._config = config
         return self
 
-    def playblast(self) -> None:
+    def playblast(self, *, parent: QtWidgets.QWidget | None = None) -> None:
         config = self._config
         if not config.review_roots:
             raise ValueError("No review roots were resolved for turnaround export.")
+
+        steps = ["Capturing shaded pass"]
+        if config.include_wireframe_pass:
+            steps.append("Capturing wireframe pass")
+        steps += ["Assembling frames", "Encoding movies"]
 
         with tempfile.TemporaryDirectory(prefix="skd_turnaround_") as temp_dir:
             temp_root = Path(temp_dir)
@@ -106,44 +113,58 @@ class TurnaroundPlayblaster:
             wireframe_base = temp_root / "turnaround_wireframe"
             combined_base = temp_root / "turnaround_combined"
 
-            with (
-                applied_hud(*_turnaround_huds(config.asset_label, config.review_roots)),
-                maintain_selection(),
-                _preserved_current_time(),
-                _staged_turntable_roots(
-                    config.review_roots,
-                    frames_per_pass=config.frames_per_pass,
-                ) as staged_roots,
-                _temporary_turnaround_camera(
-                    staged_roots,
-                    focal_length=config.focal_length,
-                    camera_padding=config.camera_padding,
-                    aim_height_bias=config.aim_height_bias,
-                ) as camera_shape,
-            ):
-                self._capture_pass(
-                    output_base=shaded_base,
-                    camera_shape=camera_shape,
-                    review_roots=staged_roots,
-                    wireframe_on_shaded=False,
-                )
-
-                if config.include_wireframe_pass:
+            with progress_scope(
+                parent=parent,
+                title="Turnaround Playblast",
+                steps=steps,
+            ) as progress:
+                with (
+                    applied_hud(
+                        *_turnaround_huds(config.asset_label, config.review_roots)
+                    ),
+                    maintain_selection(),
+                    _preserved_current_time(),
+                    _staged_turntable_roots(
+                        config.review_roots,
+                        frames_per_pass=config.frames_per_pass,
+                    ) as staged_roots,
+                    _temporary_turnaround_camera(
+                        staged_roots,
+                        focal_length=config.focal_length,
+                        camera_padding=config.camera_padding,
+                        aim_height_bias=config.aim_height_bias,
+                    ) as camera_shape,
+                ):
+                    progress.begin_step("Capturing shaded pass", "Rendering frames...")
                     self._capture_pass(
-                        output_base=wireframe_base,
+                        output_base=shaded_base,
                         camera_shape=camera_shape,
                         review_roots=staged_roots,
-                        wireframe_on_shaded=True,
+                        wireframe_on_shaded=False,
                     )
 
-            self._assemble_combined_sequence(
-                shaded_base=shaded_base,
-                wireframe_base=wireframe_base
-                if config.include_wireframe_pass
-                else None,
-                combined_base=combined_base,
-            )
-            self._encode_output_movies(combined_base=combined_base)
+                    if config.include_wireframe_pass:
+                        progress.begin_step(
+                            "Capturing wireframe pass", "Rendering frames..."
+                        )
+                        self._capture_pass(
+                            output_base=wireframe_base,
+                            camera_shape=camera_shape,
+                            review_roots=staged_roots,
+                            wireframe_on_shaded=True,
+                        )
+
+                progress.begin_step("Assembling frames")
+                self._assemble_combined_sequence(
+                    shaded_base=shaded_base,
+                    wireframe_base=wireframe_base
+                    if config.include_wireframe_pass
+                    else None,
+                    combined_base=combined_base,
+                )
+
+                progress.begin_step("Encoding movies", "Running FFmpeg...")
+                self._encode_output_movies(combined_base=combined_base)
 
     def _capture_pass(
         self,

--- a/pipeline/pipe/m/publish/asset.py
+++ b/pipeline/pipe/m/publish/asset.py
@@ -37,6 +37,7 @@ from pipe.glui.dialogs import (
     MessageDialog,
     MessageDialogCustomButtons,
 )
+from pipe.glui.progress import progress_scope
 from pipe.m.assetfile import (
     read_asset_metadata,
     resolve_asset_from_scene_path,
@@ -816,71 +817,85 @@ class AssetPublisher(Publisher):
                     **self._get_mayausd_kwargs(),
                 }
 
-                try:
-                    mc.mayaUSDExport(**kwargs)  # type: ignore[attr-defined]
-                except Exception as exc:
-                    print(traceback.format_exc())
-                    MessageDialog(
-                        self._window,
-                        "WARNING: Publish failed! Please check the console for more information",
-                        "Export Failed",
-                    ).exec_()
-                    self._emit_publish_error(
-                        publish_telemetry,
-                        error_code_name="export",
-                        error_message=str(exc),
-                        exception_type=type(exc).__name__,
-                        publish_path=publish_path,
-                    )
-                    return
+                publish_steps = ["Exporting USD"]
+                if ENABLE_HOUDINI_ASSET_BUILD:
+                    publish_steps.append("Building Houdini component")
+                publish_steps.append("Backing up asset")
 
-                if self._IS_WINDOWS:
+                with progress_scope(
+                    parent=self._window,
+                    title="Publishing Asset",
+                    steps=publish_steps,
+                ) as progress:
+                    progress.begin_step("Exporting USD")
                     try:
-                        shutil.move(temp_publish_path, self._publish_path)
+                        mc.mayaUSDExport(**kwargs)  # type: ignore[attr-defined]
+                    except Exception as exc:
+                        print(traceback.format_exc())
+                        MessageDialog(
+                            self._window,
+                            "WARNING: Publish failed! Please check the console for more information",
+                            "Export Failed",
+                        ).exec_()
+                        self._emit_publish_error(
+                            publish_telemetry,
+                            error_code_name="export",
+                            error_message=str(exc),
+                            exception_type=type(exc).__name__,
+                            publish_path=publish_path,
+                        )
+                        return
+
+                    if self._IS_WINDOWS:
+                        try:
+                            shutil.move(temp_publish_path, self._publish_path)
+                        except Exception as exc:
+                            self._emit_publish_error(
+                                publish_telemetry,
+                                error_code_name="windows_move",
+                                error_message=str(exc),
+                                exception_type=type(exc).__name__,
+                                publish_path=publish_path,
+                            )
+                            raise
+
+                    if ENABLE_HOUDINI_ASSET_BUILD:
+                        progress.begin_step("Building Houdini component")
+                    try:
+                        self._postpublish()
                     except Exception as exc:
                         self._emit_publish_error(
                             publish_telemetry,
-                            error_code_name="windows_move",
+                            error_code_name="copy",
                             error_message=str(exc),
                             exception_type=type(exc).__name__,
                             publish_path=publish_path,
                         )
                         raise
 
-                try:
-                    self._postpublish()
-                except Exception as exc:
-                    self._emit_publish_error(
-                        publish_telemetry,
-                        error_code_name="copy",
-                        error_message=str(exc),
-                        exception_type=type(exc).__name__,
-                        publish_path=publish_path,
-                    )
-                    raise
-
-                asset = None
-                if getattr(self, "_entity", None):
-                    asset = cast(Asset, self._entity)
-                if asset is None:
-                    asset = self._scene_asset or self._resolve_scene_asset()
-                try:
-                    if asset:
-                        self._run_backup(asset)
-                    else:
-                        self._backup_status = (
-                            "Backup skipped: asset could not be resolved."
+                    progress.begin_step("Backing up asset")
+                    asset = None
+                    if getattr(self, "_entity", None):
+                        asset = cast(Asset, self._entity)
+                    if asset is None:
+                        asset = self._scene_asset or self._resolve_scene_asset()
+                    try:
+                        if asset:
+                            self._run_backup(asset)
+                        else:
+                            self._backup_status = (
+                                "Backup skipped: asset could not be resolved."
+                            )
+                            log.warning("Backup skipped: asset could not be resolved.")
+                    except Exception as exc:
+                        self._emit_publish_error(
+                            publish_telemetry,
+                            error_code_name="copy",
+                            error_message=str(exc),
+                            exception_type=type(exc).__name__,
+                            publish_path=publish_path,
                         )
-                        log.warning("Backup skipped: asset could not be resolved.")
-                except Exception as exc:
-                    self._emit_publish_error(
-                        publish_telemetry,
-                        error_code_name="copy",
-                        error_message=str(exc),
-                        exception_type=type(exc).__name__,
-                        publish_path=publish_path,
-                    )
-                    raise
+                        raise
 
                 self._emit_publish_success(
                     publish_telemetry,

--- a/pipeline/pipe/m/publish/asset.py
+++ b/pipeline/pipe/m/publish/asset.py
@@ -823,7 +823,7 @@ class AssetPublisher(Publisher):
                     title="Publishing Asset",
                     steps=publish_steps,
                 ) as progress:
-                    progress.begin_step("Exporting USD")
+                    progress.begin_step("Exporting USD", "This may take a moment...")
                     try:
                         mc.mayaUSDExport(**kwargs)  # type: ignore[attr-defined]
                     except Exception as exc:
@@ -856,7 +856,10 @@ class AssetPublisher(Publisher):
                             raise
 
                     if ENABLE_HOUDINI_ASSET_BUILD:
-                        progress.begin_step("Building Houdini component")
+                        progress.begin_step(
+                            "Building Houdini component",
+                            "This may take a moment...",
+                        )
                     try:
                         self._postpublish()
                     except Exception as exc:

--- a/pipeline/pipe/m/publish/asset.py
+++ b/pipeline/pipe/m/publish/asset.py
@@ -7,10 +7,9 @@ import re
 import shutil
 import subprocess
 import time
-import traceback
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, Sequence, cast
+from typing import Any, Sequence, cast
 
 import maya.cmds as mc
 from env import Executables
@@ -48,9 +47,6 @@ from pipe.struct.db import Asset, SGEntity
 from pipe.versioning import BackupResult
 from pipe.versioning.store import backup_if_changed
 
-if TYPE_CHECKING:
-    pass
-
 from .publisher import Publisher
 
 try:
@@ -83,7 +79,7 @@ class HoudiniBuildError(RuntimeError):
 
 class _PublishAssetVariantControls:
     _geo_var_dropdown: QComboBox
-    _conn: Optional[DB]
+    _conn: DB | None
 
     def _init_variant_controls(self) -> None:
         geo_var_widget = QWidget(cast(QWidget, self))
@@ -192,10 +188,10 @@ class PublishAssetOptionsDialog(
 ):
     """Publish dialog for the current scene asset (read-only asset name)."""
 
-    _selected_asset_name: Optional[str]
+    _selected_asset_name: str | None
 
     def __init__(
-        self, parent: QWidget | None, items: Sequence[str], conn: Optional[DB]
+        self, parent: QWidget | None, items: Sequence[str], conn: DB | None
     ) -> None:
         super().__init__(
             parent,
@@ -259,7 +255,7 @@ class PublishAssetPickerDialog(
     """Fallback dialog that lets users choose the asset to publish."""
 
     def __init__(
-        self, parent: QWidget | None, items: Sequence[str], conn: Optional[DB]
+        self, parent: QWidget | None, items: Sequence[str], conn: DB | None
     ) -> None:
         super().__init__(
             parent,
@@ -691,7 +687,7 @@ class AssetPublisher(Publisher):
             return f"{message}\n\n" + "\n".join(details)
         return message
 
-    def publish(self):
+    def publish(self) -> None:
         publish_telemetry = self._new_publish_telemetry_state()
         publish_path: Path | None = None
         try:
@@ -831,7 +827,7 @@ class AssetPublisher(Publisher):
                     try:
                         mc.mayaUSDExport(**kwargs)  # type: ignore[attr-defined]
                     except Exception as exc:
-                        print(traceback.format_exc())
+                        log.exception("USD export failed")
                         MessageDialog(
                             self._window,
                             "WARNING: Publish failed! Please check the console for more information",

--- a/pipeline/pipe/sp/export.py
+++ b/pipeline/pipe/sp/export.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 import substance_painter as sp
+from Qt import QtWidgets
 
 if TYPE_CHECKING:
     import typing
@@ -465,6 +466,7 @@ class Exporter:
             event_planned_texture_count += outcome.event_planned_texture_count
             used_event_fallback = used_event_fallback or outcome.used_event_fallback
             all_exported_textures.update(outcome.exported_textures)
+            QtWidgets.QApplication.processEvents()
 
         export_payload["planned_texture_count"] = planned_texture_count
         export_payload["exported_texture_count"] = planned_export_count(

--- a/pipeline/pipe/sp/ui.py
+++ b/pipeline/pipe/sp/ui.py
@@ -79,12 +79,10 @@ class SubstanceExportWindow(QMainWindow, ButtonPair):
     _version_title_field: QtWidgets.QLineEdit
     _version_note_field: QtWidgets.QTextEdit
 
-    # _mat_var_enabled: QtWidgets.QCheckBox
-    # _metadataManager: pipe.sp.metadata.MetadataUpdater
     _tex_set_dict: dict[sp.textureset.TextureSet, "TexSetWidget"]
 
     def __init__(self, flags: QtCore.Qt.WindowFlags | None = None) -> None:
-        super(SubstanceExportWindow, self).__init__(get_main_qt_window())
+        super().__init__(get_main_qt_window())
 
         self._active_publish_context = None
         self._tex_set_dict = {}

--- a/pipeline/pipe/sp/ui.py
+++ b/pipeline/pipe/sp/ui.py
@@ -13,11 +13,9 @@ from Qt.QtCore import QRegExp
 from Qt.QtGui import QIcon, QPixmap, QRegExpValidator
 from Qt.QtWidgets import (
     QComboBox,
-    QDialog,
     QLabel,
     QLayout,
     QMainWindow,
-    QProgressBar,
 )
 
 if TYPE_CHECKING:
@@ -31,6 +29,7 @@ from pipe.asset.paths import paths_for_asset
 from pipe.asset.version_adapter import asset_owner_for, substance_project_stream
 from pipe.db import DB
 from pipe.glui.dialogs import ButtonPair, MessageDialog, MessageDialogCustomButtons
+from pipe.glui.progress import ProgressDialog
 from pipe.sp.export import Exporter, TexSetExportSettings
 from pipe.sp.houdini import HoudiniPublishError, run_asset_builder, summarize_result
 from pipe.sp.local import get_main_qt_window
@@ -65,101 +64,7 @@ class _PendingPublishRequest:
 @dataclass
 class _ActivePublishContext:
     request: _PendingPublishRequest
-    progress_dialog: "_PublishProgressDialog"
-
-
-class _PublishProgressDialog(QDialog):
-    _allow_close: bool
-    _detail_label: QLabel
-    _progress_bar: QProgressBar
-    _stage_label: QLabel
-    _stage_sequence: tuple[PublishStage, ...]
-    _step_label: QLabel
-
-    def __init__(
-        self,
-        parent: QtWidgets.QWidget | None,
-        *,
-        stage_sequence: typing.Sequence[PublishStage],
-    ) -> None:
-        super().__init__(parent)
-        self._allow_close = False
-        self._stage_sequence = tuple(stage_sequence)
-
-        self.setWindowTitle("Publishing Textures")
-        self.setModal(True)
-        self.setMinimumWidth(420)
-        self.setWindowFlags(
-            (self.windowFlags() & ~QtCore.Qt.WindowContextHelpButtonHint)
-            | QtCore.Qt.WindowStaysOnTopHint
-        )
-        self.setWindowModality(QtCore.Qt.WindowModal)
-
-        layout = QtWidgets.QVBoxLayout(self)
-        layout.setContentsMargins(14, 14, 14, 14)
-        layout.setSpacing(8)
-
-        self._step_label = QLabel("")
-        self._step_label.setStyleSheet("font-size: 11px; color: #8a8a8a;")
-        layout.addWidget(self._step_label)
-
-        self._stage_label = QLabel("Preparing publish")
-        self._stage_label.setStyleSheet("font-size: 13px; font-weight: bold;")
-        layout.addWidget(self._stage_label)
-
-        self._detail_label = QLabel("")
-        self._detail_label.setWordWrap(True)
-        layout.addWidget(self._detail_label)
-
-        self._progress_bar = QProgressBar()
-        self._progress_bar.setTextVisible(True)
-        self._progress_bar.setRange(0, 0)
-        layout.addWidget(self._progress_bar)
-
-    def event(self, event: QtCore.QEvent) -> bool:
-        if not self._allow_close and event.type() == QtCore.QEvent.Close:
-            event.ignore()
-            return True
-        return super().event(event)
-
-    def reject(self) -> None:
-        if self._allow_close:
-            super().reject()
-
-    def finish(self) -> None:
-        if self._allow_close:
-            return
-        self._allow_close = True
-        self.close()
-
-    def update_progress(self, update: PublishProgressUpdate) -> None:
-        step_index = self._step_index(update.stage)
-        self._step_label.setText(f"Step {step_index} of {len(self._stage_sequence)}")
-        self._stage_label.setText(update.stage.label)
-        self._detail_label.setText(update.message)
-
-        if update.is_determinate:
-            total = max(1, int(update.total or 0))
-            current = max(0, min(int(update.current or 0), total))
-            self._progress_bar.setRange(0, total)
-            self._progress_bar.setValue(current)
-            self._progress_bar.setFormat("%v / %m")
-        else:
-            self._progress_bar.setRange(0, 0)
-            self._progress_bar.setFormat("")
-
-        if not self.isVisible():
-            self.show()
-        self.raise_()
-        self.activateWindow()
-
-        QtWidgets.QApplication.processEvents()
-
-    def _step_index(self, stage: PublishStage) -> int:
-        try:
-            return self._stage_sequence.index(stage) + 1
-        except ValueError:
-            return len(self._stage_sequence)
+    progress_dialog: ProgressDialog
 
 
 class SubstanceExportWindow(QMainWindow, ButtonPair):
@@ -516,9 +421,10 @@ class SubstanceExportWindow(QMainWindow, ButtonPair):
         QTimer so Qt can paint the dialog before Substance Painter begins
         synchronous work.
         """
-        progress_dialog = _PublishProgressDialog(
+        progress_dialog = ProgressDialog(
             self,
-            stage_sequence=request.stage_sequence,
+            title="Publishing Textures",
+            total_steps=len(request.stage_sequence),
         )
         context = _ActivePublishContext(
             request=request,
@@ -532,7 +438,7 @@ class SubstanceExportWindow(QMainWindow, ButtonPair):
             if request.save_required
             else PublishStage.PREPARING_PUBLISH
         )
-        progress_dialog.update_progress(
+        self._send_publish_progress(
             PublishProgressUpdate(
                 stage=initial_stage,
                 message=(
@@ -565,7 +471,7 @@ class SubstanceExportWindow(QMainWindow, ButtonPair):
             if request.save_required
             else PublishStage.PREPARING_PUBLISH
         )
-        context.progress_dialog.update_progress(
+        self._send_publish_progress(
             PublishProgressUpdate(
                 stage=wait_stage,
                 message=(
@@ -605,7 +511,6 @@ class SubstanceExportWindow(QMainWindow, ButtonPair):
             return
 
         request = context.request
-        progress_dialog = context.progress_dialog
         exporter = Exporter(self._curr_asset)
 
         try:
@@ -626,7 +531,7 @@ class SubstanceExportWindow(QMainWindow, ButtonPair):
             log.info("Exporting!")
 
             if request.save_required:
-                progress_dialog.update_progress(
+                self._send_publish_progress(
                     PublishProgressUpdate(
                         stage=PublishStage.SAVING_PROJECT,
                         message="Saving the Substance Painter project before publish.",
@@ -653,7 +558,7 @@ class SubstanceExportWindow(QMainWindow, ButtonPair):
                     )
                     return
 
-            progress_dialog.update_progress(
+            self._send_publish_progress(
                 PublishProgressUpdate(
                     stage=PublishStage.PREPARING_PUBLISH,
                     message="Preparing the publish configuration and enabled texture sets.",
@@ -665,7 +570,7 @@ class SubstanceExportWindow(QMainWindow, ButtonPair):
                 request.mat_var,
                 request.geo_var,
                 request.material_layer,
-                progress_callback=progress_dialog.update_progress,
+                progress_callback=self._send_publish_progress,
             )
             if not export_success:
                 log.error(f"Texture export failed for {request.asset_label}")
@@ -687,7 +592,7 @@ class SubstanceExportWindow(QMainWindow, ButtonPair):
                 backup_status = "Backup skipped: project has no file path."
                 log.warning("Backup skipped: project has no file path.")
             else:
-                progress_dialog.update_progress(
+                self._send_publish_progress(
                     PublishProgressUpdate(
                         stage=PublishStage.BACKING_UP_PROJECT,
                         message="Saving a versioned backup of the Substance Painter project.",
@@ -749,7 +654,7 @@ class SubstanceExportWindow(QMainWindow, ButtonPair):
 
             houdini_status: str | None = None
             try:
-                progress_dialog.update_progress(
+                self._send_publish_progress(
                     PublishProgressUpdate(
                         stage=PublishStage.RUNNING_HOUDINI,
                         message="Running the Houdini asset publish step.",
@@ -792,6 +697,24 @@ class SubstanceExportWindow(QMainWindow, ButtonPair):
         self._active_publish_context = None
         context.progress_dialog.finish()
         self._set_publish_controls_enabled(True)
+
+    def _send_publish_progress(self, update: PublishProgressUpdate) -> None:
+        """Adapt a ``PublishProgressUpdate`` to the shared ``ProgressDialog``."""
+        ctx = self._active_publish_context
+        if ctx is None:
+            return
+        stage_sequence = ctx.request.stage_sequence
+        try:
+            step = list(stage_sequence).index(update.stage) + 1
+        except ValueError:
+            step = len(stage_sequence)
+        ctx.progress_dialog.set_progress(
+            step=step,
+            stage=update.stage.label,
+            detail=update.message,
+            current=update.current,
+            total=update.total,
+        )
 
     def _set_publish_controls_enabled(self, enabled: bool) -> None:
         self._central_widget.setEnabled(enabled)

--- a/pipeline/pipe/texconverter.py
+++ b/pipeline/pipe/texconverter.py
@@ -26,6 +26,21 @@ from pipe.util import silent_startupinfo
 log = logging.getLogger(__name__)
 
 
+def _process_qt_events() -> None:
+    """Flush pending Qt events so progress dialogs can repaint.
+
+    Safe to call when no QApplication exists (headless / batch mode).
+    """
+    try:
+        from Qt import QtWidgets
+
+        app = QtWidgets.QApplication.instance()
+        if app is not None:
+            app.processEvents()
+    except Exception:
+        pass
+
+
 def _nearest_pow2(n: int) -> int:
     return 1 << (n - 1).bit_length()
 
@@ -443,6 +458,8 @@ class TexConverter:
                         log.debug(stdout)
                     if p.stderr and (stderr := p.stderr.read().decode("utf-8")):
                         log.debug(stderr)
+
+                _process_qt_events()
 
                 if skip_check:
                     continue


### PR DESCRIPTION
pogress bar

Note that some DCC operations are atomic. So the progress bar freezes. This is avoidable, but only with the added complexity of either seperate processes, DCC native progress bars, or QThread or other wizardry that shall be explored at a later point when it matters.

For now, I like the simplicity. 

The better solution to freezing progress bars it to make them run faster, not smoother.

Will revisit if needs be