### PR TITLE
Maya Command Fixes

### DIFF
--- a/src/dcc/maya/site/pipeline_plugin.py
+++ b/src/dcc/maya/site/pipeline_plugin.py
@@ -2,15 +2,15 @@ from __future__ import annotations
 
 import logging
 
-from maya import cmds
-from maya.api.OpenMaya import MObject
 from dcc.maya.command import (
     add_named_command,
     get_decorated_commands,
     register_command_from_description,
 )
+from maya import cmds
+from maya.api.OpenMaya import MObject
 
-log = logging.getLogger("dcc.maya.plugin")
+log = logging.getLogger("dcc.maya.pipeline_plugin")
 
 PLUGIN_DISPLAY_NAME = "Sandwich Pipeline"
 COMMAND_PREFIX = "SKD_"

--- a/src/dcc/maya/site/userSetup.py
+++ b/src/dcc/maya/site/userSetup.py
@@ -7,7 +7,7 @@ import maya.cmds as mc
 
 def main():
     # Enable required plugins
-    plugins = ["mayaUsdPlugin", "plugin.py"]
+    plugins = ["mayaUsdPlugin", "pipeline_plugin.py"]
     pluginInfo: str = mc.pluginInfo(q=True, listPlugins=True)  # type: ignore
     for plugin in plugins:
         if plugin not in pluginInfo:

--- a/src/dcc/maya/util/__init__.py
+++ b/src/dcc/maya/util/__init__.py
@@ -1,3 +1,27 @@
 """Maya utility helpers (option vars, picker, scale ref, space switch, etc.)."""
 
 from __future__ import annotations
+
+from . import (
+    optionvar,
+    picker,
+    reload,
+    scale_reference,
+    selection,
+    space_switch,
+    studiolibrary,
+    time,
+    turnaround,
+)
+
+__all__ = [
+    "optionvar",
+    "picker",
+    "reload",
+    "scale_reference",
+    "selection",
+    "space_switch",
+    "studiolibrary",
+    "time",
+    "turnaround",
+]


### PR DESCRIPTION
This PR renames the plugin to be more readable in the maya plugin list. 
Also properly imports the utils such that command registry works again.

I think this just got missed somewhere along the refactor.