### PR TITLE
Small refinements to the maya turnaround playblast

### DIFF
--- a/src/dcc/maya/playblast/turnaround/config.py
+++ b/src/dcc/maya/playblast/turnaround/config.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import Iterable
 
@@ -16,6 +17,33 @@ DEFAULT_HEIGHT = 1080
 DEFAULT_FRAMES_PER_PASS = 96
 DEFAULT_FOCAL_LENGTH = 50.0
 DEFAULT_CAMERA_PADDING = 1.25
+
+
+class Elevation(float, Enum):
+    """Camera tilt above level, in degrees, for a turnaround pass."""
+
+    LEVEL = 0.0
+    THREE_QUARTER = 30.0
+    TOP = 90.0
+
+    @property
+    def label(self) -> str:
+        return {
+            Elevation.LEVEL: "Level",
+            Elevation.THREE_QUARTER: "Three-Quarter",
+            Elevation.TOP: "Top",
+        }[self]
+
+
+@dataclass(frozen=True)
+class TurnaroundPass:
+    """One 360 deg orbit clip at a fixed elevation and shading mode."""
+
+    elevation: Elevation
+    wireframe_on_shaded: bool = False
+
+
+DEFAULT_PASSES = (TurnaroundPass(Elevation.THREE_QUARTER, False),)
 
 
 @dataclass(frozen=True)
@@ -44,16 +72,13 @@ class TurnaroundPlayblastConfig:
     asset_label: str
     output_paths: dict[FFmpegPreset, list[str | Path]]
     review_roots: tuple[str, ...]
+    passes: tuple[TurnaroundPass, ...] = DEFAULT_PASSES
     width: int = DEFAULT_WIDTH
     height: int = DEFAULT_HEIGHT
     frames_per_pass: int = DEFAULT_FRAMES_PER_PASS
     frame_rate: int = Playblaster.fps
     focal_length: float = DEFAULT_FOCAL_LENGTH
     camera_padding: float = DEFAULT_CAMERA_PADDING
-    use_default_material: bool = True
-    use_shadows: bool = True
-    use_anti_aliasing: bool = True
-    include_wireframe_pass: bool = True
 
 
 def resolve_turnaround_review_roots() -> TurnaroundReviewRoots:
@@ -174,7 +199,10 @@ __all__ = [
     "DEFAULT_FOCAL_LENGTH",
     "DEFAULT_FRAMES_PER_PASS",
     "DEFAULT_HEIGHT",
+    "DEFAULT_PASSES",
     "DEFAULT_WIDTH",
+    "Elevation",
+    "TurnaroundPass",
     "TurnaroundPlayblastConfig",
     "TurnaroundReviewRoots",
     "resolve_turnaround_review_roots",

--- a/src/dcc/maya/playblast/turnaround/config.py
+++ b/src/dcc/maya/playblast/turnaround/config.py
@@ -43,7 +43,10 @@ class TurnaroundPass:
     wireframe_on_shaded: bool = False
 
 
-DEFAULT_PASSES = (TurnaroundPass(Elevation.THREE_QUARTER, False),)
+DEFAULT_PASSES = (
+    TurnaroundPass(Elevation.THREE_QUARTER, False),
+    TurnaroundPass(Elevation.THREE_QUARTER, True),
+)
 
 
 @dataclass(frozen=True)

--- a/src/dcc/maya/playblast/turnaround/dialog.py
+++ b/src/dcc/maya/playblast/turnaround/dialog.py
@@ -281,6 +281,7 @@ class AssetTurnaroundDialog(ButtonPair, QtWidgets.QMainWindow):
                 passes_layout.addWidget(checkbox, row, column)
 
         self._pass_checkboxes[(Elevation.THREE_QUARTER, False)].setChecked(True)
+        self._pass_checkboxes[(Elevation.THREE_QUARTER, True)].setChecked(True)
         self._main_layout.addWidget(passes_group)
 
     def _selected_passes(self) -> tuple[TurnaroundPass, ...]:

--- a/src/dcc/maya/playblast/turnaround/dialog.py
+++ b/src/dcc/maya/playblast/turnaround/dialog.py
@@ -24,11 +24,13 @@ from dcc.maya.assetfile import read_asset_metadata
 from dcc.maya.playblast.shot.config import SaveLocation
 from dcc.maya.playblast.turnaround.config import (
     DEFAULT_FRAMES_PER_PASS,
+    Elevation,
+    TurnaroundPass,
     TurnaroundPlayblastConfig,
     resolve_turnaround_review_roots,
 )
 from dcc.maya.playblast.turnaround.playblaster import MTurnaroundPlayblaster
-from core.playblast import FFmpegPreset
+from core.playblast import FFmpegPreset, Playblaster
 from core.playblast.naming import next_versioned_basename
 from core.playblast.tempdir import resolve_playblast_tempdir
 from core.playblast.review import (
@@ -94,7 +96,7 @@ class AssetTurnaroundDialog(ButtonPair, QtWidgets.QMainWindow):
 
         self._build_header_section()
         self._build_targets_section()
-        self._build_viewport_options_section()
+        self._build_passes_section()
         self._build_buttons()
 
     def _build_header_section(self) -> None:
@@ -102,7 +104,7 @@ class AssetTurnaroundDialog(ButtonPair, QtWidgets.QMainWindow):
         title.setStyleSheet("font-size: 24px; font-weight: 700;")
         title.setAlignment(QtCore.Qt.AlignCenter)
 
-        subtitle = QLabel("Capture one shaded + wireframe turnaround review movie")
+        subtitle = QLabel("Capture an asset turnaround review movie")
         subtitle.setAlignment(QtCore.Qt.AlignCenter)
 
         self._main_layout.addWidget(title)
@@ -154,11 +156,9 @@ class AssetTurnaroundDialog(ButtonPair, QtWidgets.QMainWindow):
         )
         source_layout.addWidget(self._refresh_selection_button, 2, 2)
 
-        source_layout.addWidget(QLabel("Passes"), 3, 0)
+        source_layout.addWidget(QLabel("Summary"), 3, 0)
         self._passes_value = QLabel("-")
-        self._passes_value.setToolTip(
-            "Summary of the shaded and wireframe pass lengths."
-        )
+        self._passes_value.setToolTip("Number of selected passes and total runtime.")
         source_layout.addWidget(self._passes_value, 3, 1, 1, 2)
 
         source_layout.addWidget(QLabel("ShotGrid"), 4, 0)
@@ -263,51 +263,33 @@ class AssetTurnaroundDialog(ButtonPair, QtWidgets.QMainWindow):
         custom_path_layout.addWidget(browse_button)
         return custom_path_row
 
-    def _build_viewport_options_section(self) -> None:
-        options_group = QGroupBox("2. Viewport Options")
-        options_layout = QHBoxLayout(options_group)
+    def _build_passes_section(self) -> None:
+        passes_group = QGroupBox("2. Passes")
+        passes_layout = QGridLayout(passes_group)
 
-        self._use_default_material = self._build_option_checkbox(
-            "Use Default Material",
-            True,
-            "Use Maya's default material instead of scene shaders for a cleaner model review.",
-        )
-        options_layout.addWidget(self._use_default_material)
+        passes_layout.addWidget(QLabel("Elevation"), 0, 0)
+        passes_layout.addWidget(QLabel("Shaded"), 0, 1)
+        passes_layout.addWidget(QLabel("Wireframe"), 0, 2)
 
-        self._use_shadows = self._build_option_checkbox(
-            "Use Shadows",
-            True,
-            "Render Viewport 2.0 shadows in the shaded pass.",
-        )
-        options_layout.addWidget(self._use_shadows)
+        self._pass_checkboxes: dict[tuple[Elevation, bool], QCheckBox] = {}
+        for row, elevation in enumerate(Elevation, start=1):
+            passes_layout.addWidget(QLabel(elevation.label), row, 0)
+            for column, wireframe_on_shaded in enumerate((False, True), start=1):
+                checkbox = QCheckBox()
+                checkbox.toggled.connect(self._on_settings_changed)
+                self._pass_checkboxes[(elevation, wireframe_on_shaded)] = checkbox
+                passes_layout.addWidget(checkbox, row, column)
 
-        self._use_anti_aliasing = self._build_option_checkbox(
-            "Use Anti-aliasing",
-            True,
-            "Enable Viewport 2.0 multi-sample and SSAO settings.",
-        )
-        options_layout.addWidget(self._use_anti_aliasing)
+        self._pass_checkboxes[(Elevation.THREE_QUARTER, False)].setChecked(True)
+        self._main_layout.addWidget(passes_group)
 
-        self._include_wireframe_pass = self._build_option_checkbox(
-            "Include Wireframe Pass",
-            True,
-            "Append a second full turntable pass with wireframe-on-shaded enabled.",
-        )
-        options_layout.addWidget(self._include_wireframe_pass)
-
-        self._main_layout.addWidget(options_group)
-
-    def _build_option_checkbox(
-        self,
-        label: str,
-        checked: bool,
-        tooltip: str,
-    ) -> QCheckBox:
-        checkbox = QCheckBox(label)
-        checkbox.setChecked(checked)
-        checkbox.setToolTip(tooltip)
-        checkbox.toggled.connect(self._on_settings_changed)
-        return checkbox
+    def _selected_passes(self) -> tuple[TurnaroundPass, ...]:
+        selected: list[TurnaroundPass] = []
+        for elevation in Elevation:
+            for wireframe_on_shaded in (False, True):
+                if self._pass_checkboxes[(elevation, wireframe_on_shaded)].isChecked():
+                    selected.append(TurnaroundPass(elevation, wireframe_on_shaded))
+        return tuple(selected)
 
     def _build_buttons(self) -> None:
         self._init_buttons(has_cancel_button=True, ok_name="Create Turnaround")
@@ -418,10 +400,12 @@ class AssetTurnaroundDialog(ButtonPair, QtWidgets.QMainWindow):
         self._passes_value.setText(self._pass_summary_text())
 
     def _pass_summary_text(self) -> str:
-        shaded_summary = f"{DEFAULT_FRAMES_PER_PASS} shaded"
-        if self._include_wireframe_pass.isChecked():
-            return f"{shaded_summary} + {DEFAULT_FRAMES_PER_PASS} wireframe"
-        return shaded_summary
+        pass_count = len(self._selected_passes())
+        if not pass_count:
+            return "No passes selected"
+        seconds = pass_count * DEFAULT_FRAMES_PER_PASS / Playblaster.fps
+        noun = "pass" if pass_count == 1 else "passes"
+        return f"{pass_count} {noun} · ~{seconds:.0f}s"
 
     def _sync_custom_path_row_visibility(self) -> None:
         is_visible = self._is_custom_destination_selected()
@@ -463,6 +447,9 @@ class AssetTurnaroundDialog(ButtonPair, QtWidgets.QMainWindow):
                 "Select geometry for the turnaround, or make visible geometry "
                 "available in the scene."
             )
+
+        if not self._selected_passes():
+            return "Select at least one turnaround pass."
 
         if not self._selected_destination_locations():
             return "Select at least one save destination."
@@ -581,10 +568,7 @@ class AssetTurnaroundDialog(ButtonPair, QtWidgets.QMainWindow):
             asset_label=self._asset_display_name(),
             output_paths=self._paths_for_filename(output_name),
             review_roots=self._review_roots.roots,
-            use_default_material=self._use_default_material.isChecked(),
-            use_shadows=self._use_shadows.isChecked(),
-            use_anti_aliasing=self._use_anti_aliasing.isChecked(),
-            include_wireframe_pass=self._include_wireframe_pass.isChecked(),
+            passes=self._selected_passes(),
         )
 
     def _after_local_export(self, config: TurnaroundPlayblastConfig) -> list[str]:

--- a/src/dcc/maya/playblast/turnaround/framing.py
+++ b/src/dcc/maya/playblast/turnaround/framing.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import maya.api.OpenMaya as om
+import maya.cmds as mc
+
+Vec3 = tuple[float, float, float]
+
+# An asset may pin its own spin axis by adding a locator with this name.
+PIVOT_LOCATOR_NAME = "turnaround_pivot"
+
+_MIN_EXTENT = 0.001
+
+
+@dataclass(frozen=True)
+class SurfaceSamples:
+    """World-space surface of the review geometry, sampled once up front."""
+
+    points: tuple[Vec3, ...]
+    triangle_centroids: tuple[Vec3, ...]
+    triangle_areas: tuple[float, ...]
+
+
+@dataclass(frozen=True)
+class CylinderBound:
+    """Upright cylinder enclosing the surface, measured about the spin axis."""
+
+    radius: float
+    height: float
+    center_y: float
+
+
+def sample_review_surface(roots: tuple[str, ...]) -> SurfaceSamples:
+    """Read every review mesh's world-space points and per-triangle centroids."""
+
+    points: list[Vec3] = []
+    centroids: list[Vec3] = []
+    areas: list[float] = []
+
+    for mesh_path in _review_mesh_shapes(roots):
+        mesh = om.MFnMesh(_dag_path(mesh_path))
+        world_points = mesh.getPoints(om.MSpace.kWorld)
+        points.extend((p.x, p.y, p.z) for p in world_points)
+
+        _, triangle_vertices = mesh.getTriangles()
+        for i in range(0, len(triangle_vertices), 3):
+            a = world_points[triangle_vertices[i]]
+            b = world_points[triangle_vertices[i + 1]]
+            c = world_points[triangle_vertices[i + 2]]
+            centroids.append(
+                (
+                    (a.x + b.x + c.x) / 3.0,
+                    (a.y + b.y + c.y) / 3.0,
+                    (a.z + b.z + c.z) / 3.0,
+                )
+            )
+            areas.append(0.5 * ((b - a) ^ (c - a)).length())
+
+    if not points:
+        raise ValueError("No reviewable mesh geometry was found to frame.")
+
+    return SurfaceSamples(tuple(points), tuple(centroids), tuple(areas))
+
+
+def pivot_override() -> tuple[float, float] | None:
+    """Read the XZ spin axis from a `turnaround_pivot` locator, if one exists."""
+
+    if not mc.objExists(PIVOT_LOCATOR_NAME):
+        return None
+    # maya-stubs types the query form as `bool`; it returns a 3-float list.
+    x, _, z = mc.xform(  # type: ignore
+        PIVOT_LOCATOR_NAME, query=True, worldSpace=True, translation=True
+    )
+    return (float(x), float(z))
+
+
+def area_weighted_centroid(samples: SurfaceSamples) -> tuple[float, float]:
+    """The surface's XZ center of area — the default spin axis."""
+
+    total_area = sum(samples.triangle_areas)
+    if total_area <= 0.0:
+        return _mean_xz(samples.points)
+
+    x = sum(
+        c[0] * a for c, a in zip(samples.triangle_centroids, samples.triangle_areas)
+    )
+    z = sum(
+        c[2] * a for c, a in zip(samples.triangle_centroids, samples.triangle_areas)
+    )
+    return (x / total_area, z / total_area)
+
+
+def cylinder_bound(
+    samples: SurfaceSamples, pivot: tuple[float, float]
+) -> CylinderBound:
+    """Enclose the surface in an upright cylinder centered on the spin axis."""
+
+    pivot_x, pivot_z = pivot
+    radius = max(
+        (math.hypot(x - pivot_x, z - pivot_z) for x, _, z in samples.points),
+        default=_MIN_EXTENT,
+    )
+    min_y = min(y for _, y, _ in samples.points)
+    max_y = max(y for _, y, _ in samples.points)
+    return CylinderBound(
+        radius=max(radius, _MIN_EXTENT),
+        height=max(max_y - min_y, _MIN_EXTENT),
+        center_y=(min_y + max_y) * 0.5,
+    )
+
+
+def projected_extents(bound: CylinderBound, elevation: float) -> tuple[float, float]:
+    """The cylinder's on-screen width and height seen from a tilted camera.
+
+    `elevation` is the camera's angle above level, in radians.
+    """
+
+    width = 2.0 * bound.radius
+    height = bound.height * math.cos(elevation) + 2.0 * bound.radius * math.sin(
+        elevation
+    )
+    return (width, height)
+
+
+def fit_distance(
+    width: float,
+    height: float,
+    *,
+    vertical_fov: float,
+    aspect: float,
+    padding: float,
+) -> float:
+    """Distance at which a width x height rectangle just fills the frame."""
+
+    half_vertical = vertical_fov * 0.5
+    half_horizontal = math.atan(math.tan(half_vertical) * aspect)
+    fit_vertical = (height * 0.5) / math.tan(half_vertical)
+    fit_horizontal = (width * 0.5) / math.tan(half_horizontal)
+    return max(fit_vertical, fit_horizontal) * padding
+
+
+def _review_mesh_shapes(roots: tuple[str, ...]) -> tuple[str, ...]:
+    shapes_by_uuid: dict[str, str] = {}
+    for root in roots:
+        for mesh in mc.ls(root, dagObjects=True, long=True, type="mesh") or []:
+            if mc.getAttr(f"{mesh}.intermediateObject"):
+                continue
+            shapes_by_uuid[mc.ls(mesh, uuid=True)[0]] = str(mesh)
+    return tuple(shapes_by_uuid.values())
+
+
+def _dag_path(node: str) -> om.MDagPath:
+    selection = om.MSelectionList()
+    selection.add(node)
+    return selection.getDagPath(0)
+
+
+def _mean_xz(points: tuple[Vec3, ...]) -> tuple[float, float]:
+    count = len(points)
+    x = sum(p[0] for p in points) / count
+    z = sum(p[2] for p in points) / count
+    return (x, z)
+
+
+__all__ = [
+    "CylinderBound",
+    "PIVOT_LOCATOR_NAME",
+    "SurfaceSamples",
+    "area_weighted_centroid",
+    "cylinder_bound",
+    "fit_distance",
+    "pivot_override",
+    "projected_extents",
+    "sample_review_surface",
+]

--- a/src/dcc/maya/playblast/turnaround/framing.py
+++ b/src/dcc/maya/playblast/turnaround/framing.py
@@ -13,6 +13,9 @@ PIVOT_LOCATOR_NAME = "turnaround_pivot"
 
 _MIN_EXTENT = 0.001
 
+# Height bands used to measure how wide the asset sweeps at each level.
+_PROFILE_BANDS = 64
+
 
 @dataclass(frozen=True)
 class SurfaceSamples:
@@ -24,12 +27,17 @@ class SurfaceSamples:
 
 
 @dataclass(frozen=True)
-class CylinderBound:
-    """Upright cylinder enclosing the surface, measured about the spin axis."""
+class SweptProfile:
+    """How wide the asset sweeps at each height as it spins about the axis.
 
-    radius: float
-    height: float
+    `bands` holds `(height_offset_from_center, swept_radius)` pairs. Projecting
+    this profile frames rounded or tapered assets tighter than a uniform
+    cylinder would, which is where the wasted space at a tilted view comes from.
+    The asset is centered on `center_y`; the camera aims there.
+    """
+
     center_y: float
+    bands: tuple[tuple[float, float], ...]
 
 
 def sample_review_surface(roots: tuple[str, ...]) -> SurfaceSamples:
@@ -92,35 +100,45 @@ def area_weighted_centroid(samples: SurfaceSamples) -> tuple[float, float]:
     return (x / total_area, z / total_area)
 
 
-def cylinder_bound(
-    samples: SurfaceSamples, pivot: tuple[float, float]
-) -> CylinderBound:
-    """Enclose the surface in an upright cylinder centered on the spin axis."""
+def swept_profile(samples: SurfaceSamples, pivot: tuple[float, float]) -> SweptProfile:
+    """Measure the swept radius in each height band about the spin axis."""
 
     pivot_x, pivot_z = pivot
-    radius = max(
-        (math.hypot(x - pivot_x, z - pivot_z) for x, _, z in samples.points),
-        default=_MIN_EXTENT,
-    )
     min_y = min(y for _, y, _ in samples.points)
     max_y = max(y for _, y, _ in samples.points)
-    return CylinderBound(
-        radius=max(radius, _MIN_EXTENT),
-        height=max(max_y - min_y, _MIN_EXTENT),
-        center_y=(min_y + max_y) * 0.5,
+    center_y = (min_y + max_y) * 0.5
+    span = max(max_y - min_y, _MIN_EXTENT)
+
+    band_radius = [0.0] * _PROFILE_BANDS
+    for x, y, z in samples.points:
+        index = int((y - min_y) / span * (_PROFILE_BANDS - 1))
+        band_radius[index] = max(
+            band_radius[index], math.hypot(x - pivot_x, z - pivot_z)
+        )
+
+    band_height = span / _PROFILE_BANDS
+    bands = tuple(
+        (min_y + (index + 0.5) * band_height - center_y, radius)
+        for index, radius in enumerate(band_radius)
+        if radius > 0.0
     )
+    return SweptProfile(center_y=center_y, bands=bands or ((0.0, _MIN_EXTENT),))
 
 
-def projected_extents(bound: CylinderBound, elevation: float) -> tuple[float, float]:
-    """The cylinder's on-screen width and height seen from a tilted camera.
+def projected_frame(profile: SweptProfile, elevation: float) -> tuple[float, float]:
+    """On-screen width and height of the swept silhouette.
 
-    `elevation` is the camera's angle above level, in radians.
+    `elevation` is the camera's angle above level, in radians. Width is the swept
+    diameter; height is the silhouette's vertical extent about the spin center.
     """
 
-    width = 2.0 * bound.radius
-    height = bound.height * math.cos(elevation) + 2.0 * bound.radius * math.sin(
-        elevation
-    )
+    cos_e, sin_e = math.cos(elevation), math.sin(elevation)
+    max_radius = max(radius for _, radius in profile.bands)
+    top = max(y * cos_e + radius * sin_e for y, radius in profile.bands)
+    bottom = min(y * cos_e - radius * sin_e for y, radius in profile.bands)
+
+    width = 2.0 * max_radius
+    height = max(top - bottom, _MIN_EXTENT)
     return (width, height)
 
 
@@ -165,13 +183,13 @@ def _mean_xz(points: tuple[Vec3, ...]) -> tuple[float, float]:
 
 
 __all__ = [
-    "CylinderBound",
     "PIVOT_LOCATOR_NAME",
     "SurfaceSamples",
+    "SweptProfile",
     "area_weighted_centroid",
-    "cylinder_bound",
     "fit_distance",
     "pivot_override",
-    "projected_extents",
+    "projected_frame",
     "sample_review_surface",
+    "swept_profile",
 ]

--- a/src/dcc/maya/playblast/turnaround/playblaster.py
+++ b/src/dcc/maya/playblast/turnaround/playblaster.py
@@ -9,16 +9,18 @@ from pathlib import Path
 from typing import Iterable
 
 import maya.cmds as mc
-from mayacapture.capture import capture  # type: ignore[import-not-found]
-from Qt import QtWidgets
-
 from core.hud import (
     ARTIST,
     HudContent,
     apply_hud,
     labeled_line,
 )
+from core.playblast.encoding import build_image_input_chain, encode_movie
 from core.ui.progress import progress_scope
+from core.util.users import resolve_artist_display_name
+from mayacapture.capture import capture  # type: ignore[import-not-found]
+from Qt import QtWidgets
+
 from dcc.maya.playblast.turnaround.config import (
     Elevation,
     TurnaroundPass,
@@ -36,8 +38,6 @@ from dcc.maya.playblast.turnaround.framing import (
     swept_profile,
 )
 from dcc.maya.util.selection import maintain_selection
-from core.playblast.encoding import build_image_input_chain, encode_movie
-from core.util.users import resolve_artist_display_name
 
 # Turnaround-specific HUD labels. Cross-DCC labels (Artist, ...) live in
 # :mod:`core.hud`.
@@ -46,9 +46,8 @@ _LABEL_POINTS = "Points"
 
 log = logging.getLogger(__name__)
 
-# Flat near-black: dark enough to make a clay-shaded asset pop without crushing
-# its shadowed side, with no gradient to distract from form review.
-BACKGROUND = (0.12, 0.12, 0.13)
+# Flat charcoal
+BACKGROUND = (0.161, 0.161, 0.161)
 
 
 class MTurnaroundPlayblaster:

--- a/src/dcc/maya/playblast/turnaround/playblaster.py
+++ b/src/dcc/maya/playblast/turnaround/playblaster.py
@@ -27,13 +27,13 @@ from dcc.maya.playblast.turnaround.config import (
     _node_uuid,
 )
 from dcc.maya.playblast.turnaround.framing import (
-    CylinderBound,
+    SweptProfile,
     area_weighted_centroid,
-    cylinder_bound,
     fit_distance,
     pivot_override,
-    projected_extents,
+    projected_frame,
     sample_review_surface,
+    swept_profile,
 )
 from dcc.maya.util.selection import maintain_selection
 from core.playblast.encoding import build_image_input_chain, encode_movie
@@ -46,8 +46,9 @@ _LABEL_POINTS = "Points"
 
 log = logging.getLogger(__name__)
 
-BACKGROUND_TOP = (0.42, 0.44, 0.47)
-BACKGROUND_BOTTOM = (0.17, 0.17, 0.18)
+# Flat near-black: dark enough to make a clay-shaded asset pop without crushing
+# its shadowed side, with no gradient to distract from form review.
+BACKGROUND = (0.12, 0.12, 0.13)
 
 
 class MTurnaroundPlayblaster:
@@ -66,7 +67,7 @@ class MTurnaroundPlayblaster:
 
         samples = sample_review_surface(config.review_roots)
         pivot = pivot_override() or area_weighted_centroid(samples)
-        bound = cylinder_bound(samples, pivot)
+        profile = swept_profile(samples, pivot)
 
         steps = [_pass_label(index, p) for index, p in enumerate(config.passes)]
         steps += ["Assembling frames", "Encoding movies"]
@@ -101,7 +102,7 @@ class MTurnaroundPlayblaster:
                         _frame_camera_for_pass(
                             camera_transform,
                             camera_shape,
-                            bound=bound,
+                            profile=profile,
                             pivot=pivot,
                             elevation=turnaround_pass.elevation,
                             aspect=config.width / config.height,
@@ -140,9 +141,11 @@ class MTurnaroundPlayblaster:
             end_frame=config.frames_per_pass,
             format="image",
             compression="png",
-            # Keep this capture on-screen. `mayacapture` does not expose
-            # Maya's `offScreenViewportUpdate` flag, and the topology overlay
-            # needs a live model panel draw to be reliable.
+            # Keep this capture on-screen. Off-screen (`off_screen=True`) renders
+            # an empty frame here: Viewport 2.0's hidden buffer does not draw the
+            # isolated turnaround geometry on Linux, and it also drops the
+            # wireframe-on-shaded overlay. The shot and previs playblasters get
+            # away with off-screen because they render the whole scene unisolated.
             off_screen=False,
             show_ornaments=False,
             overwrite=True,
@@ -150,9 +153,8 @@ class MTurnaroundPlayblaster:
             viewer=False,
             isolate=list(review_roots),
             display_options={
-                "displayGradient": True,
-                "backgroundTop": BACKGROUND_TOP,
-                "backgroundBottom": BACKGROUND_BOTTOM,
+                "displayGradient": False,
+                "background": BACKGROUND,
             },
             viewport_options={
                 "displayAppearance": "smoothShaded",
@@ -358,14 +360,14 @@ def _frame_camera_for_pass(
     camera_transform: str,
     camera_shape: str,
     *,
-    bound: CylinderBound,
+    profile: SweptProfile,
     pivot: tuple[float, float],
     elevation: Elevation,
     aspect: float,
     padding: float,
 ) -> None:
     phi = math.radians(float(elevation))
-    width, height = projected_extents(bound, phi)
+    width, height = projected_frame(profile, phi)
     distance = fit_distance(
         width,
         height,
@@ -374,7 +376,7 @@ def _frame_camera_for_pass(
         padding=padding,
     )
 
-    aim = (pivot[0], bound.center_y, pivot[1])
+    aim = (pivot[0], profile.center_y, pivot[1])
     position = (
         aim[0],
         aim[1] + distance * math.sin(phi),
@@ -384,7 +386,7 @@ def _frame_camera_for_pass(
     # face the front of the asset toward the top of frame instead.
     world_up = (0.0, 0.0, -1.0) if elevation is Elevation.TOP else (0.0, 1.0, 0.0)
 
-    reach = max(bound.radius, bound.height * 0.5)
+    reach = max(width, height) * 0.5
     mc.setAttr(f"{camera_shape}.nearClipPlane", max(0.1, distance - 2.0 * reach))  # type: ignore
     mc.setAttr(f"{camera_shape}.farClipPlane", max(distance + 4.0 * reach, 1000.0))  # type: ignore
 

--- a/src/dcc/maya/playblast/turnaround/playblaster.py
+++ b/src/dcc/maya/playblast/turnaround/playblaster.py
@@ -20,9 +20,20 @@ from core.hud import (
 )
 from core.ui.progress import progress_scope
 from dcc.maya.playblast.turnaround.config import (
+    Elevation,
+    TurnaroundPass,
     TurnaroundPlayblastConfig,
     _first_parent,
     _node_uuid,
+)
+from dcc.maya.playblast.turnaround.framing import (
+    CylinderBound,
+    area_weighted_centroid,
+    cylinder_bound,
+    fit_distance,
+    pivot_override,
+    projected_extents,
+    sample_review_surface,
 )
 from dcc.maya.util.selection import maintain_selection
 from core.playblast.encoding import build_image_input_chain, encode_movie
@@ -35,13 +46,12 @@ _LABEL_POINTS = "Points"
 
 log = logging.getLogger(__name__)
 
-BACKGROUND_COLOR = (0.33, 0.33, 0.33)
 BACKGROUND_TOP = (0.42, 0.44, 0.47)
 BACKGROUND_BOTTOM = (0.17, 0.17, 0.18)
 
 
 class MTurnaroundPlayblaster:
-    """Capture a shaded and wireframe asset turnaround into one movie."""
+    """Capture a sequence of asset turnaround passes into one movie."""
 
     _config: TurnaroundPlayblastConfig
 
@@ -54,15 +64,15 @@ class MTurnaroundPlayblaster:
         if not config.review_roots:
             raise ValueError("No review roots were resolved for turnaround export.")
 
-        steps = ["Capturing shaded pass"]
-        if config.include_wireframe_pass:
-            steps.append("Capturing wireframe pass")
+        samples = sample_review_surface(config.review_roots)
+        pivot = pivot_override() or area_weighted_centroid(samples)
+        bound = cylinder_bound(samples, pivot)
+
+        steps = [_pass_label(index, p) for index, p in enumerate(config.passes)]
         steps += ["Assembling frames", "Encoding movies"]
 
         with tempfile.TemporaryDirectory(prefix="skd_turnaround_") as temp_dir:
             temp_root = Path(temp_dir)
-            shaded_base = temp_root / "turnaround_shaded"
-            wireframe_base = temp_root / "turnaround_wireframe"
             combined_base = temp_root / "turnaround_combined"
 
             with progress_scope(
@@ -75,45 +85,39 @@ class MTurnaroundPlayblaster:
                     _preserved_current_time(),
                     _staged_turntable_roots(
                         config.review_roots,
+                        pivot=pivot,
                         frames_per_pass=config.frames_per_pass,
                     ) as staged_roots,
                     _temporary_turnaround_camera(
-                        staged_roots,
                         focal_length=config.focal_length,
-                        camera_padding=config.camera_padding,
-                    ) as camera_shape,
+                    ) as (camera_transform, camera_shape),
                 ):
-                    progress.begin_step(
-                        "Capturing shaded pass",
-                        "Rendering frames \u2014 this may take a moment...",
-                    )
-                    self._capture_pass(
-                        output_base=shaded_base,
-                        camera_shape=camera_shape,
-                        review_roots=staged_roots,
-                        wireframe_on_shaded=False,
-                    )
-
-                    if config.include_wireframe_pass:
+                    pass_bases: list[Path] = []
+                    for index, turnaround_pass in enumerate(config.passes):
                         progress.begin_step(
-                            "Capturing wireframe pass",
-                            "Rendering frames \u2014 this may take a moment...",
+                            _pass_label(index, turnaround_pass),
+                            "Rendering frames — this may take a moment...",
                         )
+                        _frame_camera_for_pass(
+                            camera_transform,
+                            camera_shape,
+                            bound=bound,
+                            pivot=pivot,
+                            elevation=turnaround_pass.elevation,
+                            aspect=config.width / config.height,
+                            padding=config.camera_padding,
+                        )
+                        pass_base = temp_root / f"turnaround_pass_{index:02d}"
                         self._capture_pass(
-                            output_base=wireframe_base,
+                            output_base=pass_base,
                             camera_shape=camera_shape,
                             review_roots=staged_roots,
-                            wireframe_on_shaded=True,
+                            wireframe_on_shaded=turnaround_pass.wireframe_on_shaded,
                         )
+                        pass_bases.append(pass_base)
 
                 progress.begin_step("Assembling frames")
-                self._assemble_combined_sequence(
-                    shaded_base=shaded_base,
-                    wireframe_base=wireframe_base
-                    if config.include_wireframe_pass
-                    else None,
-                    combined_base=combined_base,
-                )
+                self._assemble_combined_sequence(pass_bases, combined_base)
 
                 progress.begin_step("Encoding movies", "Running FFmpeg...")
                 self._encode_output_movies(combined_base=combined_base)
@@ -127,28 +131,6 @@ class MTurnaroundPlayblaster:
         wireframe_on_shaded: bool,
     ) -> None:
         config = self._config
-
-        viewport_options: dict[str, str | bool] = {
-            # Shaded view's documented topology overlay is `wireframeOnShaded`.
-            "displayAppearance": "smoothShaded",
-            # HUD bakes during encode (apply_hud), so the viewport HUD is off.
-            "headsUpDisplay": False,
-            "wireframeOnShaded": wireframe_on_shaded,
-        }
-        if config.use_default_material:
-            viewport_options["useDefaultMaterial"] = True
-        if config.use_shadows:
-            viewport_options["shadows"] = True
-
-        viewport2_options: dict[str, bool] = {}
-        if config.use_anti_aliasing:
-            viewport2_options.update(
-                {
-                    "lineAAEnable": True,
-                    "multiSampleEnable": True,
-                }
-            )
-
         capture(
             camera=camera_shape,
             width=config.width,
@@ -169,39 +151,41 @@ class MTurnaroundPlayblaster:
             isolate=list(review_roots),
             display_options={
                 "displayGradient": True,
-                "background": BACKGROUND_COLOR,
                 "backgroundTop": BACKGROUND_TOP,
                 "backgroundBottom": BACKGROUND_BOTTOM,
             },
-            viewport_options=viewport_options,
-            viewport2_options=viewport2_options,
+            viewport_options={
+                "displayAppearance": "smoothShaded",
+                # Model review ignores scene shaders; materials are not authored
+                # in Maya, so there is nothing to look at but form.
+                "useDefaultMaterial": True,
+                "shadows": True,
+                # HUD bakes during encode (apply_hud), so the viewport HUD is off.
+                "headsUpDisplay": False,
+                "wireframeOnShaded": wireframe_on_shaded,
+            },
+            viewport2_options={
+                "multiSampleEnable": True,
+                "lineAAEnable": True,
+                "ssaoEnable": True,
+            },
         )
 
     def _assemble_combined_sequence(
         self,
-        *,
-        shaded_base: Path,
-        wireframe_base: Path | None,
+        pass_bases: list[Path],
         combined_base: Path,
     ) -> None:
-        self._copy_sequence(
-            source_base=shaded_base,
-            destination_base=combined_base,
-            source_start=1,
-            destination_start=1,
-            frame_count=self._config.frames_per_pass,
-        )
-
-        if wireframe_base is None:
-            return
-
-        self._copy_sequence(
-            source_base=wireframe_base,
-            destination_base=combined_base,
-            source_start=1,
-            destination_start=self._config.frames_per_pass + 1,
-            frame_count=self._config.frames_per_pass,
-        )
+        destination_frame = 1
+        for pass_base in pass_bases:
+            self._copy_sequence(
+                source_base=pass_base,
+                destination_base=combined_base,
+                source_start=1,
+                destination_start=destination_frame,
+                frame_count=self._config.frames_per_pass,
+            )
+            destination_frame += self._config.frames_per_pass
 
     @staticmethod
     def _copy_sequence(
@@ -271,6 +255,11 @@ class MTurnaroundPlayblaster:
         )
 
 
+def _pass_label(index: int, turnaround_pass: TurnaroundPass) -> str:
+    mode = "wireframe" if turnaround_pass.wireframe_on_shaded else "shaded"
+    return f"Pass {index + 1}: {turnaround_pass.elevation.label} {mode}"
+
+
 @contextmanager
 def _preserved_current_time():
     current_time = int(mc.currentTime(query=True))
@@ -284,6 +273,7 @@ def _preserved_current_time():
 def _staged_turntable_roots(
     review_roots: Iterable[str],
     *,
+    pivot: tuple[float, float],
     frames_per_pass: int,
 ):
     resolved_roots: list[str] = []
@@ -298,15 +288,18 @@ def _staged_turntable_roots(
 
     root_records: list[tuple[str, str | None]] = []
     for root in resolved_root_paths:
-        parent = _parent_path(root)
+        parent = _first_parent(root)
         parent_uuid = _node_uuid(parent) if parent else None
         root_records.append((_node_uuid(root), parent_uuid))
 
     turntable_group = str(
         mc.createNode("transform", name=_unique_name("assetTurnaroundTurntable_GRP"))
     )
-    center = _bounding_box_center(resolved_root_paths)
-    mc.xform(turntable_group, worldSpace=True, translation=center)
+    mc.xform(
+        turntable_group,
+        worldSpace=True,
+        translation=(pivot[0], 0.0, pivot[1]),
+    )
 
     try:
         for root_uuid, _ in root_records:
@@ -348,54 +341,83 @@ def _staged_turntable_roots(
 
 
 @contextmanager
-def _temporary_turnaround_camera(
-    review_roots: Iterable[str],
-    *,
-    focal_length: float,
-    camera_padding: float,
-):
-    bbox = _exact_bounding_box(review_roots)
-    center = _bounding_box_center_from_bbox(bbox)
-    size_x, size_y, size_z = _bounding_box_size_from_bbox(bbox)
-    radius = max(0.5 * math.sqrt(size_x**2 + size_y**2 + size_z**2), 1.0)
-    del size_y
-
+def _temporary_turnaround_camera(*, focal_length: float):
     camera_transform, camera_shape = mc.camera(name=_unique_name("assetTurnaround_cam"))  # type: ignore
-    aim_locator: str = mc.spaceLocator(name=_unique_name("assetTurnaroundAim_LOC"))[0]  # type: ignore
-    aim_constraint = None
-
     try:
         mc.setAttr(f"{camera_shape}.focalLength", focal_length)  # type: ignore
-        distance = _camera_distance_for_radius(
-            camera_shape,
-            radius=radius,
-            padding=camera_padding,
-        )
-        near_clip = max(0.1, distance - (radius * 2.0))
-        far_clip = max(distance + (radius * 4.0), 1000.0)
-        mc.setAttr(f"{camera_shape}.nearClipPlane", near_clip)  # type: ignore
-        mc.setAttr(f"{camera_shape}.farClipPlane", far_clip)  # type: ignore
-
-        camera_position = (center[0], center[1], center[2] - distance)
-        aim_position = center
-        mc.xform(camera_transform, worldSpace=True, translation=camera_position)
-        mc.xform(aim_locator, worldSpace=True, translation=aim_position)
-        aim_constraint = mc.aimConstraint(  # type: ignore
-            aim_locator,
-            camera_transform,
-            aimVector=(0, 0, -1),
-            upVector=(0, 1, 0),
-            worldUpType="vector",
-            worldUpVector=(0, 1, 0),
-        )[0]
-        yield str(camera_shape)
+        # Vertical film fit: the rendered height tracks the vertical aperture,
+        # so `fit_distance` can frame purely from the vertical field of view.
+        mc.setAttr(f"{camera_shape}.filmFit", 2)  # type: ignore
+        yield str(camera_transform), str(camera_shape)
     finally:
-        if aim_constraint and mc.objExists(aim_constraint):  # type: ignore
-            mc.delete(aim_constraint)  # type: ignore
-        if mc.objExists(aim_locator):
-            mc.delete(aim_locator)
         if mc.objExists(camera_transform):
             mc.delete(camera_transform)
+
+
+def _frame_camera_for_pass(
+    camera_transform: str,
+    camera_shape: str,
+    *,
+    bound: CylinderBound,
+    pivot: tuple[float, float],
+    elevation: Elevation,
+    aspect: float,
+    padding: float,
+) -> None:
+    phi = math.radians(float(elevation))
+    width, height = projected_extents(bound, phi)
+    distance = fit_distance(
+        width,
+        height,
+        vertical_fov=_vertical_fov(camera_shape),
+        aspect=aspect,
+        padding=padding,
+    )
+
+    aim = (pivot[0], bound.center_y, pivot[1])
+    position = (
+        aim[0],
+        aim[1] + distance * math.sin(phi),
+        aim[2] - distance * math.cos(phi),
+    )
+    # At the top, the camera looks straight down, so a Y up vector is degenerate;
+    # face the front of the asset toward the top of frame instead.
+    world_up = (0.0, 0.0, -1.0) if elevation is Elevation.TOP else (0.0, 1.0, 0.0)
+
+    reach = max(bound.radius, bound.height * 0.5)
+    mc.setAttr(f"{camera_shape}.nearClipPlane", max(0.1, distance - 2.0 * reach))  # type: ignore
+    mc.setAttr(f"{camera_shape}.farClipPlane", max(distance + 4.0 * reach, 1000.0))  # type: ignore
+
+    _aim_camera(camera_transform, position=position, aim=aim, world_up=world_up)
+
+
+def _aim_camera(
+    camera_transform: str,
+    *,
+    position: tuple[float, float, float],
+    aim: tuple[float, float, float],
+    world_up: tuple[float, float, float],
+) -> None:
+    mc.xform(camera_transform, worldSpace=True, translation=position)
+    aim_locator: str = mc.spaceLocator(name=_unique_name("assetTurnaroundAim_LOC"))[0]  # type: ignore
+    mc.xform(aim_locator, worldSpace=True, translation=aim)
+    constraint: str = mc.aimConstraint(  # type: ignore
+        aim_locator,
+        camera_transform,
+        aimVector=(0, 0, -1),
+        upVector=(0, 1, 0),
+        worldUpType="vector",
+        worldUpVector=world_up,
+    )[0]
+    # The constraint has done its job orienting the camera; drop it so the
+    # next pass can re-aim from scratch.
+    mc.delete(constraint, aim_locator)
+
+
+def _vertical_fov(camera_shape: str) -> float:
+    aperture_mm = float(mc.getAttr(f"{camera_shape}.verticalFilmAperture")) * 25.4
+    focal_length = float(mc.getAttr(f"{camera_shape}.focalLength"))
+    return 2.0 * math.atan(aperture_mm / (2.0 * focal_length))
 
 
 def _polygon_point_count(review_roots: tuple[str, ...]) -> int:
@@ -419,68 +441,6 @@ def _polygon_point_count(review_roots: tuple[str, ...]) -> int:
         except (RuntimeError, ValueError):
             log.warning("Could not evaluate point count for mesh '%s'.", mesh_path)
     return point_count
-
-
-def _exact_bounding_box(
-    nodes: Iterable[str],
-) -> tuple[float, float, float, float, float, float]:
-    resolved_nodes = list(nodes)
-    if not resolved_nodes:
-        raise ValueError("Bounding box requires at least one node.")
-
-    min_x, min_y, min_z, max_x, max_y, max_z = mc.exactWorldBoundingBox(resolved_nodes)  # type: ignore
-    return (
-        float(min_x),
-        float(min_y),
-        float(min_z),
-        float(max_x),
-        float(max_y),
-        float(max_z),
-    )
-
-
-def _bounding_box_center(nodes: Iterable[str]) -> tuple[float, float, float]:
-    return _bounding_box_center_from_bbox(_exact_bounding_box(nodes))
-
-
-def _bounding_box_center_from_bbox(
-    bbox: tuple[float, float, float, float, float, float],
-) -> tuple[float, float, float]:
-    min_x, min_y, min_z, max_x, max_y, max_z = bbox
-    return (
-        (min_x + max_x) * 0.5,
-        (min_y + max_y) * 0.5,
-        (min_z + max_z) * 0.5,
-    )
-
-
-def _bounding_box_size_from_bbox(
-    bbox: tuple[float, float, float, float, float, float],
-) -> tuple[float, float, float]:
-    min_x, min_y, min_z, max_x, max_y, max_z = bbox
-    return (
-        max(max_x - min_x, 0.001),
-        max(max_y - min_y, 0.001),
-        max(max_z - min_z, 0.001),
-    )
-
-
-def _camera_distance_for_radius(
-    camera_shape: str,
-    *,
-    radius: float,
-    padding: float,
-) -> float:
-    focal_length = float(mc.getAttr(f"{camera_shape}.focalLength"))
-    horizontal_aperture = (
-        float(mc.getAttr(f"{camera_shape}.horizontalFilmAperture")) * 25.4
-    )
-    vertical_aperture = float(mc.getAttr(f"{camera_shape}.verticalFilmAperture")) * 25.4
-
-    horizontal_fov = 2.0 * math.atan(horizontal_aperture / (2.0 * focal_length))
-    vertical_fov = 2.0 * math.atan(vertical_aperture / (2.0 * focal_length))
-    fit_fov = max(min(horizontal_fov, vertical_fov), 0.001)
-    return (radius * padding) / math.sin(fit_fov * 0.5)
 
 
 def _set_linear_turntable_animation(
@@ -509,10 +469,6 @@ def _current_node_path(node_uuid: str) -> str | None:
     if not matches:
         return None
     return str(matches[0])
-
-
-def _parent_path(node: str) -> str | None:
-    return _first_parent(node)
 
 
 def _unique_name(base_name: str) -> str:


### PR DESCRIPTION
- Added two new angles: 3/4 and top
- Made 3/4 the default
- Reworked the UI
- Changed the pivot calculation to be weighted
- Replaced the gradient background with a flat color
- Adjusted the framing calculation to waste less screen space

<img width="796" height="741" alt="image" src="https://github.com/user-attachments/assets/73217de2-f71e-4c06-9c35-1b0ded68fe70" />

https://github.com/user-attachments/assets/5919af41-4442-4e1f-b487-738f8886d031


