### PR TITLE
Fix view transforms in Nuke

### DIFF
--- a/src/core/color/__init__.py
+++ b/src/core/color/__init__.py
@@ -24,10 +24,13 @@ def config_path() -> Path:
 
 
 def ocio_env_vars() -> dict[str, str]:
+    # Deliberately no OCIO_ACTIVE_VIEWS: a multi-value setting silently breaks
+    # Nuke 16.0v4's OCIODisplay view enumeration (the Viewer falls back to Raw
+    # only — Foundry bug 606354, fixed in 16.0v9).
     return {
         "OCIO": str(config_path()),
         "OCIO_ACTIVE_DISPLAYS": DISPLAY,
-        "OCIO_ACTIVE_VIEWS": ACTIVE_VIEWS,
+        # "OCIO_ACTIVE_VIEWS": ACTIVE_VIEWS,
         # Read by RenderMan to find `rman_color_config_<version>.json`.
         "RMAN_COLOR_CONFIG_DIR": str(config_dir()),
     }


### PR DESCRIPTION
This is part one of a two step color config correction. Note that this isnt athe best solution: the better solution is to upgrade Nuke to 16.0v9 or newer:

https://learn.foundry.com/hiero/16.1v1/content/release_notes/16.0/nuke_16.0v9_releasenotes.html
> *ID 541715* - Fixed Nuke not loading the saved view transform for some display devices - ACES 1.3
> *ID 585204* - The OCIO Display node's "view" and "display" knobs can reset when the OCIO config is reloaded
> *ID 606354* - Write/OCIODisplay nodes fail to load its ocioview knob if the view does not exist in the first display space's view options
> *ID 613287* - Read node colorspace in exported .nk scripts is now correct when it is set to a Transcode Images task

But this works, and I aint about to wait around for the lab machines to get a new image